### PR TITLE
Load the local contacts on first account creation,

### DIFF
--- a/Vector/AppDelegate.m
+++ b/Vector/AppDelegate.m
@@ -486,38 +486,8 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
         [account resume];
     }
     
-    // Check whether the application is allowed to access the local contacts.
-    if (ABAddressBookGetAuthorizationStatus() == kABAuthorizationStatusAuthorized)
-    {
-        // Check the user permission for syncing local contacts. This permission was handled independently on previous application version.
-        if (![MXKAppSettings standardAppSettings].syncLocalContacts)
-        {
-            // Check whether it was not requested yet.
-            if (![MXKAppSettings standardAppSettings].syncLocalContactsPermissionRequested)
-            {
-                [MXKAppSettings standardAppSettings].syncLocalContactsPermissionRequested = YES;
-                
-                UIViewController *viewController = self.window.rootViewController.presentedViewController;
-                if (!viewController)
-                {
-                    viewController = self.window.rootViewController;
-                }
-                
-                [MXKContactManager requestUserConfirmationForLocalContactsSyncInViewController:viewController completionHandler:^(BOOL granted) {
-                    
-                    if (granted)
-                    {
-                        // Allow local contacts sync in order to discover matrix users.
-                        [MXKAppSettings standardAppSettings].syncLocalContacts = YES;
-                    }
-                    
-                }];
-            }
-        }
-
-        // Refresh the local contacts list by reloading it
-        [[MXKContactManager sharedManager] loadLocalContacts];
-    }
+    // Refresh local contact from the contact book.
+    [self refreshLocalContacts];
     
     _isAppForeground = YES;
 }
@@ -1467,6 +1437,16 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             // Observe inApp notifications toggle change
             [account addObserver:self forKeyPath:@"enableInAppNotifications" options:0 context:nil];
         }
+        
+        // Load the local contacts on first account creation.
+        if ([MXKAccountManager sharedManager].accounts.count == 1)
+        {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                
+                [self refreshLocalContacts];
+                
+            });
+        }
     }];
     
     // Add observer to handle removed accounts
@@ -1631,8 +1611,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     // Return to authentication screen
     [_homeViewController showAuthenticationScreen];
     
-    // Reset App settings
-    [[MXKAppSettings standardAppSettings] reset];
+    // Note: Keep App settings
     
     // Reset the contact manager
     [[MXKContactManager sharedManager] reset];
@@ -1993,6 +1972,44 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
         }
         
     }];
+}
+
+#pragma mark - Contacts handling
+
+- (void)refreshLocalContacts
+{
+    // Check whether the application is allowed to access the local contacts.
+    if (ABAddressBookGetAuthorizationStatus() == kABAuthorizationStatusAuthorized)
+    {
+        // Check the user permission for syncing local contacts. This permission was handled independently on previous application version.
+        if (![MXKAppSettings standardAppSettings].syncLocalContacts)
+        {
+            // Check whether it was not requested yet.
+            if (![MXKAppSettings standardAppSettings].syncLocalContactsPermissionRequested)
+            {
+                [MXKAppSettings standardAppSettings].syncLocalContactsPermissionRequested = YES;
+                
+                UIViewController *viewController = self.window.rootViewController.presentedViewController;
+                if (!viewController)
+                {
+                    viewController = self.window.rootViewController;
+                }
+                
+                [MXKContactManager requestUserConfirmationForLocalContactsSyncInViewController:viewController completionHandler:^(BOOL granted) {
+                    
+                    if (granted)
+                    {
+                        // Allow local contacts sync in order to discover matrix users.
+                        [MXKAppSettings standardAppSettings].syncLocalContacts = YES;
+                    }
+                    
+                }];
+            }
+        }
+        
+        // Refresh the local contacts list by reloading it
+        [[MXKContactManager sharedManager] loadLocalContacts];
+    }
 }
 
 #pragma mark - MXKCallViewControllerDelegate


### PR DESCRIPTION
if the contact book access is authorized.

Keep the app settings in case of logout (We don't want to reset the current `syncLocalContacts` flag on logout).