### PR TITLE
Improve the people invite screens

### DIFF
--- a/Vector/Assets/en.lproj/Vector.strings
+++ b/Vector/Assets/en.lproj/Vector.strings
@@ -123,8 +123,8 @@
 "directory_search_fail" = "Failed to fetch data";
 
 // Contacts
-"contacts_address_book_section" = "LOCAL CONTACTS";
-"contacts_matrix_users_section" = "KNOWN CONTACTS";
+"contacts_address_book_section" = "LOCAL CONTACTS (%tu)";
+"contacts_matrix_users_section" = "KNOWN CONTACTS (%tu)";
 "contacts_address_book_matrix_users_toggle" = "Matrix users only";
 
 // Chat participants

--- a/Vector/ViewController/ContactsTableViewController.m
+++ b/Vector/ViewController/ContactsTableViewController.m
@@ -681,13 +681,12 @@
         
         if (section == filteredLocalContactsSection)
         {
-            headerLabel.text = [NSString stringWithFormat:@"%@ (%tu)", NSLocalizedStringFromTable(@"contacts_address_book_section", @"Vector", nil), filteredLocalContacts.count];
-            
+            headerLabel.text = [NSString stringWithFormat:NSLocalizedStringFromTable(@"contacts_address_book_section", @"Vector", nil), filteredLocalContacts.count];
             sectionBitwise = CONTACTS_TABLEVC_LOCALCONTACTS_BITWISE;
         }
         else //if (section == filteredMatrixContactsSection)
         {
-            headerLabel.text = [NSString stringWithFormat:@"%@ (%tu)", NSLocalizedStringFromTable(@"contacts_matrix_users_section", @"Vector", nil), filteredMatrixContacts.count];
+            headerLabel.text = [NSString stringWithFormat:NSLocalizedStringFromTable(@"contacts_matrix_users_section", @"Vector", nil), filteredMatrixContacts.count];
             sectionBitwise = CONTACTS_TABLEVC_KNOWNCONTACTS_BITWISE;
         }
         

--- a/Vector/ViewController/ContactsTableViewController.m
+++ b/Vector/ViewController/ContactsTableViewController.m
@@ -505,10 +505,8 @@
     {
         searchInputSection = count++;
         
-        if (filteredLocalContacts.count)
-        {
-            filteredLocalContactsSection = count++;
-        }
+        // Keep visible the Local contacts header even if no local contacts is displayed in order to keep visible the check box "Matrix user only".
+        filteredLocalContactsSection = count++;
         
         if (filteredMatrixContacts.count)
         {
@@ -523,10 +521,8 @@
             filteredLocalContacts = [self unfilteredLocalContactsArray];
         }
         
-        if (filteredLocalContacts.count)
-        {
-            filteredLocalContactsSection = count++;
-        }
+        // Keep visible the Local contacts header even if no local contacts is displayed in order to keep visible the check box "Matrix user only".
+        filteredLocalContactsSection = count++;
     }
     
     // Enable the section shrinking only when all the contacts sections are displayed.
@@ -685,12 +681,13 @@
         
         if (section == filteredLocalContactsSection)
         {
-            headerLabel.text = NSLocalizedStringFromTable(@"contacts_address_book_section", @"Vector", nil);
+            headerLabel.text = [NSString stringWithFormat:@"%@ (%tu)", NSLocalizedStringFromTable(@"contacts_address_book_section", @"Vector", nil), filteredLocalContacts.count];
+            
             sectionBitwise = CONTACTS_TABLEVC_LOCALCONTACTS_BITWISE;
         }
         else //if (section == filteredMatrixContactsSection)
         {
-            headerLabel.text = NSLocalizedStringFromTable(@"contacts_matrix_users_section", @"Vector", nil);
+            headerLabel.text = [NSString stringWithFormat:@"%@ (%tu)", NSLocalizedStringFromTable(@"contacts_matrix_users_section", @"Vector", nil), filteredMatrixContacts.count];
             sectionBitwise = CONTACTS_TABLEVC_KNOWNCONTACTS_BITWISE;
         }
         


### PR DESCRIPTION
#904

- Keep visible the Local contacts header even if no local contacts is displayed in order to keep visible the check box "Matrix user only".