### PR TITLE
Warn unknown devices: Add a send anyway button.

### DIFF
--- a/Vector/Assets/en.lproj/Vector.strings
+++ b/Vector/Assets/en.lproj/Vector.strings
@@ -209,6 +209,7 @@
 // Unknown devices
 "unknown_devices_alert_title" = "Room contains unknown devices";
 "unknown_devices_alert" = "This room contains unknown devices which have not been verified.\nThis means there is no guarantee that the devices belong to the users they claim to.\nWe recommend you go through the verification process for each device before continuing, but you can resend the message without verifying if you prefer.";
+"unknown_devices_send_anyway" = "Send Anyway";
 "unknown_devices_verify" = "Verify...";
 "unknown_devices_title" = "Unknown devices";
 

--- a/Vector/ViewController/UsersDevicesViewController.m
+++ b/Vector/ViewController/UsersDevicesViewController.m
@@ -55,7 +55,9 @@
     self.title = NSLocalizedStringFromTable(@"unknown_devices_title", @"Vector", nil);
     self.accessibilityLabel=@"UsersDevicesVCTitleStaticText";
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(onDone:)];
-self.navigationItem.rightBarButtonItem.accessibilityIdentifier=@"UsersDevicesVCDoneButton";
+    self.navigationItem.rightBarButtonItem.accessibilityIdentifier=@"UsersDevicesVCDoneButton";
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(onCancel:)];
+    self.navigationItem.leftBarButtonItem.accessibilityIdentifier=@"UsersDevicesVCCancelButton";
     self.tableView.delegate = self;
     self.tableView.accessibilityIdentifier=@"UsersDevicesVCDTableView";
     self.tableView.dataSource = self;
@@ -227,6 +229,11 @@ self.navigationItem.rightBarButtonItem.accessibilityIdentifier=@"UsersDevicesVCD
         [self stopActivityIndicator];
         [self dismissViewControllerAnimated:YES completion:nil];
     }];
+}
+
+- (IBAction)onCancel:(id)sender
+{
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark - Private methods


### PR DESCRIPTION
As 2 buttons works better than 3 in MXKAlert, "Send Anyway" replaces the previous "Cancel" button. 
The end user can still "Cancel" the action but on the UsersDevicesViewController screen when he presses "Verify...".