### PR TITLE
Bug Fix - default room avatar for an empty room should not be your own face

### DIFF
--- a/Riot/Categories/MXRoom+Vector.h
+++ b/Riot/Categories/MXRoom+Vector.h
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2017 Vector Creations Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -22,9 +23,9 @@
 @interface MXRoom (Vector)
 
 /**
- The vector displayname of the room
+ The Riot displayname of the room
  */
-@property(nonatomic, readonly) NSString* vectorDisplayname;
+@property(nonatomic, readonly) NSString* riotDisplayname;
 
 /**
  Tell whether all the notifications are disabled for the room.

--- a/Riot/Model/Room/RoomPreviewData.m
+++ b/Riot/Model/Room/RoomPreviewData.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2016 OpenMarket Ltd
+ Copyright 2017 Vector Creations Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -80,7 +81,7 @@
         _roomDataSource = [[RoomDataSource alloc] initWithPeekingRoom:peekingRoom andInitialEventId:_eventId];
         [_roomDataSource finalizeInitialization];
 
-        _roomName = peekingRoom.vectorDisplayname;
+        _roomName = peekingRoom.riotDisplayname;
         _roomAvatarUrl = peekingRoom.state.avatar;
         
         _roomTopic = [MXTools stripNewlineCharacters:peekingRoom.state.topic];;

--- a/Riot/Model/RoomList/RecentCellData.m
+++ b/Riot/Model/RoomList/RecentCellData.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2017 Vector Creations Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -26,7 +27,7 @@
 - (void)update
 {
     [super update];
-    roomDisplayname = self.roomDataSource.room.vectorDisplayname;
+    roomDisplayname = self.roomDataSource.room.riotDisplayname;
     if (!roomDisplayname.length)
     {
         roomDisplayname = NSLocalizedStringFromTable(@"room_displayname_no_title", @"Vector", nil);

--- a/Riot/Model/RoomList/RecentsDataSource.m
+++ b/Riot/Model/RoomList/RecentsDataSource.m
@@ -876,7 +876,7 @@
         
         NSString* tagOrder = [room.mxSession tagOrderToBeAtIndex:newPath.row from:oldPos withTag:dstRoomTag];
         
-        NSLog(@"[RecentsDataSource] Update the room %@ [%@] tag from %@ to %@ with tag order %@", room.state.roomId, room.vectorDisplayname, oldRoomTag, dstRoomTag, tagOrder);
+        NSLog(@"[RecentsDataSource] Update the room %@ [%@] tag from %@ to %@ with tag order %@", room.state.roomId, room.riotDisplayname, oldRoomTag, dstRoomTag, tagOrder);
         
         [room replaceTag:oldRoomTag
                    byTag:dstRoomTag

--- a/Riot/Model/Search/FilesSearchCellData.m
+++ b/Riot/Model/Search/FilesSearchCellData.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2016 OpenMarket Ltd
+ Copyright 2017 Vector Creations Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -74,7 +75,7 @@
         MXRoom *room = [searchDataSource.mxSession roomWithRoomId:roomId];
         if (room)
         {
-            roomDisplayName = room.vectorDisplayname;
+            roomDisplayName = room.riotDisplayname;
             if (!roomDisplayName.length)
             {
                 roomDisplayName = NSLocalizedStringFromTable(@"room_displayname_no_title", @"Vector", nil);

--- a/Riot/ViewController/CallViewController.m
+++ b/Riot/ViewController/CallViewController.m
@@ -187,7 +187,7 @@
     }
     else if (self.mxCall.room)
     {
-        return [AvatarGenerator generateAvatarForMatrixItem:self.mxCall.room.roomId withDisplayName:self.mxCall.room.vectorDisplayname size:self.callerImageViewWidthConstraint.constant andFontSize:fontSize];
+        return [AvatarGenerator generateAvatarForMatrixItem:self.mxCall.room.roomId withDisplayName:self.mxCall.room.riotDisplayname size:self.callerImageViewWidthConstraint.constant andFontSize:fontSize];
     }
     
     return [UIImage imageNamed:@"placeholder"];
@@ -216,7 +216,7 @@
     }
     else if (self.mxCall.isConferenceCall)
     {
-        peerDisplayName = self.mxCall.room.vectorDisplayname;
+        peerDisplayName = self.mxCall.room.riotDisplayname;
         peerAvatarURL = self.mxCall.room.state.avatar;
     }
     

--- a/Riot/Views/RoomList/RoomTableViewCell.m
+++ b/Riot/Views/RoomList/RoomTableViewCell.m
@@ -45,7 +45,7 @@
     [room setRoomAvatarImageIn:self.avatarImageView];
     self.avatarImageView.backgroundColor = [UIColor clearColor];
     
-    self.titleLabel.text = room.vectorDisplayname;
+    self.titleLabel.text = room.riotDisplayname;
 }
 
 + (CGFloat)cellHeight

--- a/Riot/Views/RoomTitle/ExpandedRoomTitleView.m
+++ b/Riot/Views/RoomTitle/ExpandedRoomTitleView.m
@@ -44,7 +44,7 @@
     
     if (self.mxRoom)
     {
-        self.displayNameTextField.text = self.mxRoom.vectorDisplayname;
+        self.displayNameTextField.text = self.mxRoom.riotDisplayname;
         if (!self.displayNameTextField.text.length)
         {
             self.displayNameTextField.text = NSLocalizedStringFromTable(@"room_displayname_no_title", @"Vector", nil);

--- a/Riot/Views/RoomTitle/PreviewRoomTitleView.m
+++ b/Riot/Views/RoomTitle/PreviewRoomTitleView.m
@@ -134,7 +134,7 @@
     else if (self.mxRoom)
     {
         // The user is here invited to join a room (This invitation has been received from server sync)
-        self.displayNameTextField.text = self.mxRoom.vectorDisplayname;
+        self.displayNameTextField.text = self.mxRoom.riotDisplayname;
         if (!self.displayNameTextField.text.length)
         {
             self.displayNameTextField.text = NSLocalizedStringFromTable(@"room_displayname_no_title", @"Vector", nil);

--- a/Riot/Views/RoomTitle/RoomTitleView.m
+++ b/Riot/Views/RoomTitle/RoomTitleView.m
@@ -117,7 +117,7 @@
     }
     else if (self.mxRoom)
     {
-        self.displayNameTextField.text = self.mxRoom.vectorDisplayname;
+        self.displayNameTextField.text = self.mxRoom.riotDisplayname;
         if (!self.displayNameTextField.text.length)
         {
             self.displayNameTextField.text = NSLocalizedStringFromTable(@"room_displayname_no_title", @"Vector", nil);

--- a/Riot/Views/RoomTitle/SimpleRoomTitleView.m
+++ b/Riot/Views/RoomTitle/SimpleRoomTitleView.m
@@ -74,7 +74,7 @@
     
     if (self.mxRoom)
     {
-        self.displayNameTextField.text = self.mxRoom.vectorDisplayname;
+        self.displayNameTextField.text = self.mxRoom.riotDisplayname;
         if (!self.displayNameTextField.text.length)
         {
             self.displayNameTextField.text = NSLocalizedStringFromTable(@"room_displayname_no_title", @"Vector", nil);

--- a/Riot/Views/Search/MessagesSearchResultAttachmentBubbleCell.m
+++ b/Riot/Views/Search/MessagesSearchResultAttachmentBubbleCell.m
@@ -43,7 +43,7 @@
         MXRoom* room = [bubbleData.mxSession roomWithRoomId:bubbleData.roomId];
         if (room)
         {
-            self.roomNameLabel.text = room.vectorDisplayname;
+            self.roomNameLabel.text = room.riotDisplayname;
             if (!self.roomNameLabel.text.length)
             {
                 self.roomNameLabel.text = NSLocalizedStringFromTable(@"room_displayname_no_title", @"Vector", nil);

--- a/Riot/Views/Search/MessagesSearchResultTextMsgBubbleCell.m
+++ b/Riot/Views/Search/MessagesSearchResultTextMsgBubbleCell.m
@@ -43,7 +43,7 @@
         MXRoom* room = [bubbleData.mxSession roomWithRoomId:bubbleData.roomId];
         if (room)
         {
-            self.roomNameLabel.text = room.vectorDisplayname;
+            self.roomNameLabel.text = room.riotDisplayname;
         }
         else
         {


### PR DESCRIPTION
#1044

Improvements:
- If the room has only two members, use the avatar of the second member even if this member is invited.
- The plain solid circle (without initial) is used only for an "empty room" without display name (We name "empty room" a room in which the current user is the only active member).