### PR TITLE
BF: Unknown devices modal from calling page is different that room page one

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -226,6 +226,8 @@
 "unknown_devices_alert_title" = "Room contains unknown devices";
 "unknown_devices_alert" = "This room contains unknown devices which have not been verified.\nThis means there is no guarantee that the devices belong to the users they claim to.\nWe recommend you go through the verification process for each device before continuing, but you can resend the message without verifying if you prefer.";
 "unknown_devices_send_anyway" = "Send Anyway";
+"unknown_devices_call_anyway" = "Call Anyway";
+"unknown_devices_answer_anyway" = "Answer Anyway";
 "unknown_devices_verify" = "Verify...";
 "unknown_devices_title" = "Unknown devices";
 

--- a/Riot/Base.lproj/Main.storyboard
+++ b/Riot/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="H1p-Uh-vWS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="H1p-Uh-vWS">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -116,7 +116,7 @@
         <!--Users Devices View Controller-->
         <scene sceneID="fKQ-Tq-qUc">
             <objects>
-                <viewController id="z83-KC-trJ" customClass="UsersDevicesViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="UsersDevicesViewControllerStoryboardId" id="z83-KC-trJ" customClass="UsersDevicesViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="KBN-JV-gSS"/>
                         <viewControllerLayoutGuide type="bottom" id="lAN-yJ-zNI"/>
@@ -355,7 +355,7 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="agy-3r-khl"/>
-        <segue reference="tcD-xb-ae8"/>
+        <segue reference="f5u-Y1-7nt"/>
         <segue reference="cUw-vU-gJq"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Riot/ViewController/RoomViewController.m
+++ b/Riot/ViewController/RoomViewController.m
@@ -2285,7 +2285,7 @@
         if (unknownDevices)
         {
             UsersDevicesViewController *usersDevicesViewController = (UsersDevicesViewController *)segue.destinationViewController.childViewControllers.firstObject;
-            [usersDevicesViewController displayUsersDevices:unknownDevices andMatrixSession:self.roomDataSource.mxSession];
+            [usersDevicesViewController displayUsersDevices:unknownDevices andMatrixSession:self.roomDataSource.mxSession onComplete:nil];
 
             unknownDevices = nil;
         }

--- a/Riot/ViewController/UsersDevicesViewController.h
+++ b/Riot/ViewController/UsersDevicesViewController.h
@@ -25,8 +25,13 @@
  Display a map of users/devices.
 
  @param usersDevices the map to display.
+ @param mxSession the Matrix session.
+ @param onComplete a block called when the user quits the screen
+                   doneButtonPressed is:
+                       - YES if the user clicked the Done button, meaning he acknowledges all unknown devices.
+                       - NO if the user clicked the Cancel button, meaning he prefers to cancel the current request.
  */
-- (void)displayUsersDevices:(MXUsersDevicesMap<MXDeviceInfo*>*)usersDevices andMatrixSession:(MXSession*)mxSession;
+- (void)displayUsersDevices:(MXUsersDevicesMap<MXDeviceInfo*>*)usersDevices andMatrixSession:(MXSession*)mxSession onComplete:(void (^)(BOOL doneButtonPressed))onComplete;
 
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 

--- a/Riot/ViewController/UsersDevicesViewController.m
+++ b/Riot/ViewController/UsersDevicesViewController.m
@@ -26,16 +26,19 @@
 {
     MXUsersDevicesMap<MXDeviceInfo*> *usersDevices;
     MXSession *mxSession;
+
+    void (^onCompleteBlock)(BOOL doneButtonPressed);
 }
 
 @end
 
 @implementation UsersDevicesViewController
 
-- (void)displayUsersDevices:(MXUsersDevicesMap<MXDeviceInfo*>*)theUsersDevices andMatrixSession:(MXSession*)matrixSession;
+- (void)displayUsersDevices:(MXUsersDevicesMap<MXDeviceInfo*>*)theUsersDevices andMatrixSession:(MXSession*)matrixSession onComplete:(void (^)(BOOL doneButtonPressed))onComplete
 {
     usersDevices = theUsersDevices;
     mxSession = matrixSession;
+    onCompleteBlock = onComplete;
 }
 
 - (void)finalizeInit
@@ -228,12 +231,22 @@
 
         [self stopActivityIndicator];
         [self dismissViewControllerAnimated:YES completion:nil];
+
+        if (onCompleteBlock)
+        {
+            onCompleteBlock(YES);
+        }
     }];
 }
 
 - (IBAction)onCancel:(id)sender
 {
     [self dismissViewControllerAnimated:YES completion:nil];
+
+    if (onCompleteBlock)
+    {
+        onCompleteBlock(NO);
+    }
 }
 
 #pragma mark - Private methods


### PR DESCRIPTION
#1058 

Placing and answering a call when there are unknown devices in the room have now the same UX as sending a message in the same condition.
The same alert and the same view are displayed.
In the alert, rather than "Send anyway", we use the strings "Call anyway" and "Answer anyway".

![](https://matrix.org/_matrix/media/v1/download/matrix.org/dVBuUoCQjnsdLhxAIJObpLmc)