### PR TITLE
Prepare UX rework

### DIFF
--- a/Riot/ViewController/RecentsViewController.m
+++ b/Riot/ViewController/RecentsViewController.m
@@ -452,7 +452,7 @@
         [self.stickyHeadersTopContainer addSubview:sectionHeader];
         topContainerOffset = sectionHeader.frame.size.height;
         
-        for (NSUInteger index = 1; index < sectionsCount - 1; index++)
+        for (NSUInteger index = 1; index < sectionsCount; index++)
         {
             sectionHeader = [self tableView:self.recentsTableView viewForStickyHeaderInSection:index];
             sectionHeader.tag = index;
@@ -469,16 +469,6 @@
             sectionHeader.frame = frame;
             [self.stickyHeadersBottomContainer addSubview:sectionHeader];
             bottomContainerOffset += frame.size.height;
-        }
-        
-        if (sectionsCount > 1)
-        {
-            sectionHeader = [self tableView:self.recentsTableView viewForStickyHeaderInSection:sectionsCount - 1];
-            sectionHeader.tag = sectionsCount - 1;
-            frame = sectionHeader.frame;
-            frame.origin.y = bottomContainerOffset;
-            sectionHeader.frame = frame;
-            [self.stickyHeadersBottomContainer addSubview:sectionHeader];
         }
         
         [self refreshStickyHeadersContainersHeight];

--- a/Riot/ViewController/RecentsViewController.m
+++ b/Riot/ViewController/RecentsViewController.m
@@ -449,8 +449,16 @@
         frame = sectionHeader.frame;
         frame.origin.y = 0;
         sectionHeader.frame = frame;
+        sectionHeader.autoresizingMask = UIViewAutoresizingFlexibleWidth;
         [self.stickyHeadersTopContainer addSubview:sectionHeader];
         topContainerOffset = sectionHeader.frame.size.height;
+        
+        // Handle tap gesture
+        UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(onStickyHeaderTap:)];
+        [tap setNumberOfTouchesRequired:1];
+        [tap setNumberOfTapsRequired:1];
+        [tap setDelegate:self];
+        [sectionHeader addGestureRecognizer:tap];
         
         for (NSUInteger index = 1; index < sectionsCount; index++)
         {
@@ -459,20 +467,42 @@
             frame = sectionHeader.frame;
             frame.origin.y = topContainerOffset;
             sectionHeader.frame = frame;
+            sectionHeader.autoresizingMask = UIViewAutoresizingFlexibleWidth;
             [self.stickyHeadersTopContainer addSubview:sectionHeader];
             topContainerOffset += frame.size.height;
+            
+            // Handle tap gesture
+            tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(onStickyHeaderTap:)];
+            [tap setNumberOfTouchesRequired:1];
+            [tap setNumberOfTapsRequired:1];
+            [tap setDelegate:self];
+            [sectionHeader addGestureRecognizer:tap];
             
             sectionHeader = [self tableView:self.recentsTableView viewForStickyHeaderInSection:index];
             sectionHeader.tag = index;
             frame = sectionHeader.frame;
             frame.origin.y = bottomContainerOffset;
             sectionHeader.frame = frame;
+            sectionHeader.autoresizingMask = UIViewAutoresizingFlexibleWidth;
             [self.stickyHeadersBottomContainer addSubview:sectionHeader];
             bottomContainerOffset += frame.size.height;
+            
+            // Handle tap gesture
+            tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(onStickyHeaderTap:)];
+            [tap setNumberOfTouchesRequired:1];
+            [tap setNumberOfTapsRequired:1];
+            [tap setDelegate:self];
+            [sectionHeader addGestureRecognizer:tap];
         }
         
         [self refreshStickyHeadersContainersHeight];
     }
+}
+
+- (void)onStickyHeaderTap:(UIGestureRecognizer*)gestureRecognizer
+{
+    UIView *view = gestureRecognizer.view;
+    [self.recentsTableView scrollToRowAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:view.tag] atScrollPosition:UITableViewScrollPositionTop animated:YES];
 }
 
 - (void)refreshStickyHeadersContainersHeight

--- a/Riot/ViewController/RecentsViewController.m
+++ b/Riot/ViewController/RecentsViewController.m
@@ -611,8 +611,7 @@
         }
         
         // Handle here the case where no header is currently displayed.
-        // Consider this case only when the sticky headers have been reseted (the height of each container is then nil).
-        if (!firstDisplayedSectionHeader && self.stickyHeadersTopContainerHeightConstraint.constant == 0 && self.stickyHeadersBottomContainerHeightConstraint.constant == 0)
+        if (!firstDisplayedSectionHeader)
         {
             // No section header is displayed in the table, no more than one section is displayed.
             NSIndexPath *firstCellIndexPath = [self.recentsTableView indexPathForRowAtPoint:CGPointMake(0, self.recentsTableView.contentOffset.y)];


### PR DESCRIPTION
- Bug fix the last section header was missing in the sticky headers of the top.
- Handle tap gesture on the sticky headers
- Bug Fix: the first sticky header of the bottom container is sometimes cropped.
- Bug Fix: the sticky headers display failed on screen rotation.