### PR TITLE
List user hs directories

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -409,7 +409,7 @@
 
 // Directory
 "directory_title" = "Directory";
-"directory_server_picker_title" = "Choose an instance";
+"directory_server_picker_title" = "Select a directory";
 
 // Others
 "or" = "or";

--- a/Riot/Model/RoomList/PublicRoomsDirectoryDataSource.h
+++ b/Riot/Model/RoomList/PublicRoomsDirectoryDataSource.h
@@ -40,6 +40,12 @@
 @property (nonatomic) NSString *homeserver;
 
 /**
+ Flag to indicate to list all public rooms from all networks of `homeserver`.
+ NO will list only pure Matrix rooms.
+ */
+@property (nonatomic) BOOL includeAllNetworks;
+
+/**
  List public rooms from a third party protocol.
  Default is nil.
  */

--- a/Riot/Model/RoomList/PublicRoomsDirectoryDataSource.m
+++ b/Riot/Model/RoomList/PublicRoomsDirectoryDataSource.m
@@ -81,6 +81,12 @@ double const kPublicRoomsDirectoryDataExpiration = 10;
 
 - (void)setHomeserver:(NSString *)homeserver
 {
+    if ([homeserver isEqualToString:self.mxSession.matrixRestClient.credentials.homeServerName])
+    {
+        // The CS API does not like we pass the user's HS as parameter
+        homeserver = nil;
+    }
+    
     if (homeserver != _homeserver)
     {
         _homeserver = homeserver;
@@ -96,6 +102,7 @@ double const kPublicRoomsDirectoryDataExpiration = 10;
     if (thirdpartyProtocolInstance != _thirdpartyProtocolInstance)
     {
         _homeserver = nil;
+        _includeAllNetworks = NO;
         _thirdpartyProtocolInstance = thirdpartyProtocolInstance;
 
         // Reset data
@@ -186,18 +193,9 @@ double const kPublicRoomsDirectoryDataExpiration = 10;
 
     __weak typeof(self) weakSelf = self;
 
-
-    BOOL includeAllNetworks = NO;
-    if (!_homeserver && _thirdpartyProtocolInstance)
-    {
-        // TODO: property?
-        // Include all networks when listing public rooms from the user's HS
-        includeAllNetworks = YES;
-    }
-
     // Get the public rooms from the server
     MXHTTPOperation *newPublicRoomsRequest;
-    newPublicRoomsRequest = [self.mxSession.matrixRestClient publicRoomsOnServer:_homeserver limit:_paginationLimit since:nextBatch filter:_searchPattern thirdPartyInstanceId:_thirdpartyProtocolInstance.instanceId includeAllNetworks:includeAllNetworks success:^(MXPublicRoomsResponse *publicRoomsResponse) {
+    newPublicRoomsRequest = [self.mxSession.matrixRestClient publicRoomsOnServer:_homeserver limit:_paginationLimit since:nextBatch filter:_searchPattern thirdPartyInstanceId:_thirdpartyProtocolInstance.instanceId includeAllNetworks:_includeAllNetworks success:^(MXPublicRoomsResponse *publicRoomsResponse) {
 
         if (weakSelf)
         {

--- a/Riot/Model/RoomList/PublicRoomsDirectoryDataSource.m
+++ b/Riot/Model/RoomList/PublicRoomsDirectoryDataSource.m
@@ -73,7 +73,7 @@ double const kPublicRoomsDirectoryDataExpiration = 10;
     }
     else
     {
-        directoryServerDisplayname = self.mxSession.matrixRestClient.credentials.homeServer;
+        directoryServerDisplayname = self.mxSession.matrixRestClient.credentials.homeServerName;
     }
 
     return directoryServerDisplayname;
@@ -186,9 +186,18 @@ double const kPublicRoomsDirectoryDataExpiration = 10;
 
     __weak typeof(self) weakSelf = self;
 
+
+    BOOL includeAllNetworks = NO;
+    if (!_homeserver && _thirdpartyProtocolInstance)
+    {
+        // TODO: property?
+        // Include all networks when listing public rooms from the user's HS
+        includeAllNetworks = YES;
+    }
+
     // Get the public rooms from the server
     MXHTTPOperation *newPublicRoomsRequest;
-    newPublicRoomsRequest = [self.mxSession.matrixRestClient publicRoomsOnServer:_homeserver limit:_paginationLimit since:nextBatch filter:_searchPattern thirdPartyInstanceId:_thirdpartyProtocolInstance.instanceId includeAllNetworks:NO success:^(MXPublicRoomsResponse *publicRoomsResponse) {
+    newPublicRoomsRequest = [self.mxSession.matrixRestClient publicRoomsOnServer:_homeserver limit:_paginationLimit since:nextBatch filter:_searchPattern thirdPartyInstanceId:_thirdpartyProtocolInstance.instanceId includeAllNetworks:includeAllNetworks success:^(MXPublicRoomsResponse *publicRoomsResponse) {
 
         if (weakSelf)
         {

--- a/Riot/Model/RoomList/PublicRoomsDirectoryDataSource.m
+++ b/Riot/Model/RoomList/PublicRoomsDirectoryDataSource.m
@@ -86,14 +86,26 @@ double const kPublicRoomsDirectoryDataExpiration = 10;
         // The CS API does not like we pass the user's HS as parameter
         homeserver = nil;
     }
-    
+
+     _thirdpartyProtocolInstance = nil;
+
     if (homeserver != _homeserver)
     {
         _homeserver = homeserver;
-        _thirdpartyProtocolInstance = nil;
 
         // Reset data
-        [self startPagination];
+        [self resetPagination];
+    }
+}
+
+- (void)setIncludeAllNetworks:(BOOL)includeAllNetworks
+{
+    if (includeAllNetworks != _includeAllNetworks)
+    {
+        _includeAllNetworks = includeAllNetworks;
+        
+        // Reset data
+        [self resetPagination];
     }
 }
 
@@ -106,7 +118,7 @@ double const kPublicRoomsDirectoryDataExpiration = 10;
         _thirdpartyProtocolInstance = thirdpartyProtocolInstance;
 
         // Reset data
-        [self startPagination];
+        [self resetPagination];
     }
 }
 
@@ -117,7 +129,7 @@ double const kPublicRoomsDirectoryDataExpiration = 10;
         if (![searchPattern isEqualToString:_searchPattern])
         {
             _searchPattern = searchPattern;
-            [self startPagination];
+            [self resetPagination];
         }
     }
     else
@@ -127,7 +139,7 @@ double const kPublicRoomsDirectoryDataExpiration = 10;
         if (_searchPattern || rooms.count == 0)
         {
             _searchPattern = searchPattern;
-            [self startPagination];
+            [self resetPagination];
         }
     }
 }
@@ -163,7 +175,7 @@ double const kPublicRoomsDirectoryDataExpiration = 10;
     return room;
 }
 
-- (void)startPagination
+- (void)resetPagination
 {
     // Cancel the previous request
     if (publicRoomsRequest)
@@ -171,17 +183,12 @@ double const kPublicRoomsDirectoryDataExpiration = 10;
         [publicRoomsRequest cancel];
     }
 
-    [self setState:MXKDataSourceStatePreparing];
-
     // Reset all pagination vars
     [rooms removeAllObjects];
     nextBatch = nil;
     _roomsCount = 0;
     _moreThanRoomsCount = NO;
     _hasReachedPaginationEnd = NO;
-
-    // And do a single pagination
-    [self paginate:nil failure:nil];
 }
 
 - (MXHTTPOperation *)paginate:(void (^)(NSUInteger))complete failure:(void (^)(NSError *))failure
@@ -190,6 +197,8 @@ double const kPublicRoomsDirectoryDataExpiration = 10;
     {
         return nil;
     }
+
+    [self setState:MXKDataSourceStatePreparing];
 
     __weak typeof(self) weakSelf = self;
 

--- a/Riot/Model/RoomList/RecentsDataSource.m
+++ b/Riot/Model/RoomList/RecentsDataSource.m
@@ -100,12 +100,6 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
     _recentsDataSourceMode = recentsDataSourceMode;
     
     [self forceRefresh];
-
-    if (_recentsDataSourceMode == RecentsDataSourceModeRooms)
-    {
-        // Make _publicRoomsDirectoryDataSource start loading data
-        _publicRoomsDirectoryDataSource.searchPattern = nil;
-    }
 }
 
 - (UIView *)viewForStickyHeaderInSection:(NSInteger)section withFrame:(CGRect)frame
@@ -1017,6 +1011,7 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
         publicRoomsTriggerTimer = nil;
 
         _publicRoomsDirectoryDataSource.searchPattern = searchPattern;
+        [_publicRoomsDirectoryDataSource paginate:nil failure:nil];
     }
 }
 

--- a/Riot/Model/RoomList/UnifiedSearchRecentsDataSource.m
+++ b/Riot/Model/RoomList/UnifiedSearchRecentsDataSource.m
@@ -53,7 +53,7 @@
     [super setPublicRoomsDirectoryDataSource:publicRoomsDirectoryDataSource];
     
     // Start by looking for all public rooms
-    self.publicRoomsDirectoryDataSource.searchPattern = nil;
+    [self.publicRoomsDirectoryDataSource paginate:nil failure:nil];
 }
 
 - (void)setHideRecents:(BOOL)hideRecents

--- a/Riot/Riot-Defaults.plist
+++ b/Riot/Riot-Defaults.plist
@@ -42,5 +42,10 @@
 	<integer>15066368</integer>
 	<key>presenceColorForOfflineUser</key>
 	<integer>15020851</integer>
+	<key>roomDirectoryServers</key>
+	<dict>
+		<key>matrix.org</key>
+		<string></string>
+	</dict>
 </dict>
 </plist>

--- a/Riot/ViewController/DirectoryServerPickerViewController.h
+++ b/Riot/ViewController/DirectoryServerPickerViewController.h
@@ -24,12 +24,12 @@
  Display data managed by the passed `MXKDirectoryServersDataSource`.
 
  @param dataSource the data source serving the data.
- @param onComplete a block called when the picker disappears. It provides either the selected
-                   protocol instance or a new homeserver URL.
+ @param onComplete a block called when the picker disappears. It provides data about
+                   the selected protocol instance or homeserver.
                    Both nil means the user cancelled the picker.
  */
 - (void)displayWithDataSource:(MXKDirectoryServersDataSource*)dataSource
-                   onComplete:(void (^)(MXThirdPartyProtocolInstance *thirdpartyProtocolInstance, NSString *homeserver))onComplete;
+                   onComplete:(void (^)(id<MXKDirectoryServerCellDataStoring> cellData))onComplete;
 
 @end
 

--- a/Riot/ViewController/DirectoryServerPickerViewController.m
+++ b/Riot/ViewController/DirectoryServerPickerViewController.m
@@ -26,7 +26,7 @@
     // Observe kAppDelegateDidTapStatusBarNotification to handle tap on clock status bar.
     id kAppDelegateDidTapStatusBarNotificationObserver;
 
-    void (^onCompleteBlock)(MXThirdPartyProtocolInstance *thirdpartyProtocolInstance, NSString *homeserver);
+    void (^onCompleteBlock)(id<MXKDirectoryServerCellDataStoring> cellData);
 }
 @end
 
@@ -110,7 +110,7 @@
 }
 
 - (void)displayWithDataSource:(MXKDirectoryServersDataSource*)theDataSource
-                   onComplete:(void (^)(MXThirdPartyProtocolInstance *thirdpartyProtocolInstance, NSString *homeserver))onComplete;
+                   onComplete:(void (^)(id<MXKDirectoryServerCellDataStoring> cellData))onComplete;
 {
     dataSource = theDataSource;
     onCompleteBlock = onComplete;
@@ -165,15 +165,7 @@
 
     if (onCompleteBlock)
     {
-        if (cellData.thirdPartyProtocolInstance)
-        {
-            onCompleteBlock(cellData.thirdPartyProtocolInstance, nil);
-        }
-// TODO: Manage adding of homeserver URL
-//        else if (cellData.homeserverUrl)
-//        {
-//            onCompleteBlock(nil, cellData.homeserverUrl);
-//        }
+        onCompleteBlock(cellData);
     }
 
     [self withdrawViewControllerAnimated:YES completion:nil];
@@ -185,7 +177,7 @@
 {
     if (onCompleteBlock)
     {
-        onCompleteBlock(nil, nil);
+        onCompleteBlock(nil);
     }
 
     [self withdrawViewControllerAnimated:YES completion:nil];

--- a/Riot/ViewController/RoomsViewController.m
+++ b/Riot/ViewController/RoomsViewController.m
@@ -126,6 +126,10 @@
         MXKDirectoryServersDataSource *directoryServersDataSource = [[MXKDirectoryServersDataSource alloc] initWithMatrixSession:recentsDataSource.publicRoomsDirectoryDataSource.mxSession];
         [directoryServersDataSource finalizeInitialization];
 
+        // Add directory servers from the app settings plist
+        NSArray<NSString*> *roomDirectoryServers = [[NSUserDefaults standardUserDefaults] objectForKey:@"roomDirectoryServers"];
+        directoryServersDataSource.roomDirectoryServers = roomDirectoryServers;
+
         [directoryServerPickerViewController displayWithDataSource:directoryServersDataSource onComplete:^(id<MXKDirectoryServerCellDataStoring> cellData) {
             if (cellData)
             {

--- a/Riot/ViewController/RoomsViewController.m
+++ b/Riot/ViewController/RoomsViewController.m
@@ -61,10 +61,19 @@
     
     if ([self.dataSource isKindOfClass:RecentsDataSource.class])
     {
+        BOOL isFirstTime = !recentsDataSource;
+
         // Take the lead on the shared data source.
         recentsDataSource = (RecentsDataSource*)self.dataSource;
         recentsDataSource.areSectionsShrinkable = NO;
         [recentsDataSource setDelegate:self andRecentsDataSourceMode:RecentsDataSourceModeRooms];
+
+        if (isFirstTime)
+        {
+            // The first time the screen is displayed, make publicRoomsDirectoryDataSource
+            // start loading data
+            [recentsDataSource.publicRoomsDirectoryDataSource paginate:nil failure:nil];
+        }
     }
 }
 
@@ -130,6 +139,19 @@
                     recentsDataSource.publicRoomsDirectoryDataSource.includeAllNetworks = cellData.includeAllNetworks;
                     recentsDataSource.publicRoomsDirectoryDataSource.homeserver = cellData.homeserver;
                 }
+
+                // Refresh data
+                [self addSpinnerFooterView];
+
+                [recentsDataSource.publicRoomsDirectoryDataSource paginate:^(NSUInteger roomsAdded) {
+
+                    // The table view is automatically filled
+                    [self removeSpinnerFooterView];
+                    
+                } failure:^(NSError *error) {
+                    
+                    [self removeSpinnerFooterView];
+                }];
             }
         }];
 

--- a/Riot/ViewController/RoomsViewController.m
+++ b/Riot/ViewController/RoomsViewController.m
@@ -147,9 +147,12 @@
 
                     // The table view is automatically filled
                     [self removeSpinnerFooterView];
-                    
+
+                    // Make the directory section appear full-page
+                    [self.recentsTableView scrollToRowAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:recentsDataSource.directorySection] atScrollPosition:UITableViewScrollPositionTop animated:YES];
+
                 } failure:^(NSError *error) {
-                    
+
                     [self removeSpinnerFooterView];
                 }];
             }

--- a/Riot/ViewController/RoomsViewController.m
+++ b/Riot/ViewController/RoomsViewController.m
@@ -117,22 +117,19 @@
         MXKDirectoryServersDataSource *directoryServersDataSource = [[MXKDirectoryServersDataSource alloc] initWithMatrixSession:recentsDataSource.publicRoomsDirectoryDataSource.mxSession];
         [directoryServersDataSource finalizeInitialization];
 
-        [directoryServerPickerViewController displayWithDataSource:directoryServersDataSource onComplete:^(MXThirdPartyProtocolInstance *thirdpartyProtocolInstance, NSString *homeserver) {
-
-            // Use the selected directory server
-            if (thirdpartyProtocolInstance)
+        [directoryServerPickerViewController displayWithDataSource:directoryServersDataSource onComplete:^(id<MXKDirectoryServerCellDataStoring> cellData) {
+            if (cellData)
             {
-                recentsDataSource.publicRoomsDirectoryDataSource.thirdpartyProtocolInstance = thirdpartyProtocolInstance;
-            }
-            else if (homeserver)
-            {
-                recentsDataSource.publicRoomsDirectoryDataSource.homeserver = homeserver;
-            }
-            else
-            {
-                // Reset any previously selected directory server
-                recentsDataSource.publicRoomsDirectoryDataSource.homeserver = nil;
-                recentsDataSource.publicRoomsDirectoryDataSource.thirdpartyProtocolInstance = nil;
+                // Use the selected directory server
+                if (cellData.thirdPartyProtocolInstance)
+                {
+                    recentsDataSource.publicRoomsDirectoryDataSource.thirdpartyProtocolInstance = cellData.thirdPartyProtocolInstance;
+                }
+                else if (cellData.homeserver)
+                {
+                    recentsDataSource.publicRoomsDirectoryDataSource.includeAllNetworks = cellData.includeAllNetworks;
+                    recentsDataSource.publicRoomsDirectoryDataSource.homeserver = cellData.homeserver;
+                }
             }
         }];
 

--- a/Riot/Views/Directory/DirectoryServerTableViewCell.m
+++ b/Riot/Views/Directory/DirectoryServerTableViewCell.m
@@ -35,22 +35,27 @@
     [super layoutSubviews];
     
     // Round image view
-    [self.iconImageView.layer setCornerRadius:self.iconImageView.frame.size.width / 2];
     self.iconImageView.clipsToBounds = YES;
     self.iconImageView.backgroundColor = [UIColor clearColor];
 }
 
 - (void)render:(id<MXKDirectoryServerCellDataStoring>)cellData
 {
-    if (cellData.iconUrl)
+    self.iconImageView.hidden = NO;
+
+    if (cellData.icon)
     {
-        [self.iconImageView setImageURL:cellData.iconUrl withType:nil andImageOrientation:UIImageOrientationUp previewImage:[UIImage imageNamed:@"placeholder"]];
+        self.iconImageView.image = cellData.icon;
+    }
+    else  if (cellData.thirdPartyProtocolInstance.icon)
+    {
+        [self.iconImageView setImageURL:cellData.thirdPartyProtocolInstance.icon withType:nil andImageOrientation:UIImageOrientationUp previewImage:[UIImage imageNamed:@"placeholder"]];
     }
     else
     {
-        self.iconImageView.image = [UIImage imageNamed:@"placeholder"];
+        self.iconImageView.hidden = YES;
     }
-    
+
     self.descLabel.text = cellData.desc;
 }
 


### PR DESCRIPTION
and add a roomDirectoryServers option to Riot-Defaults.plist to add custom homeservers.

Currently only matrix.org is added. That means if a user is from a random HS, he will always be able to list public rooms from the matrix.org HS.

Other changes:
- Fix a bug that paginated public rooms every time we switch to the rooms tab.
- After new directory selection, focus on the directory section.