### PR TITLE
Fix dangling in the memory CallViewController

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -2262,8 +2262,6 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             
             // Release properly
             [currentCallViewController destroy];
-            currentCallViewController.mxCall.delegate = nil;
-            currentCallViewController.delegate = nil;
             currentCallViewController = nil;
             
             if (completion)
@@ -2312,8 +2310,6 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                 
                 // Release properly
                 [currentCallViewController destroy];
-                currentCallViewController.mxCall.delegate = nil;
-                currentCallViewController.delegate = nil;
                 currentCallViewController = nil;
             }
         }

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -2261,6 +2261,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             _incomingCallNotification = nil;
             
             // Release properly
+            [currentCallViewController destroy];
             currentCallViewController.mxCall.delegate = nil;
             currentCallViewController.delegate = nil;
             currentCallViewController = nil;
@@ -2310,6 +2311,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                 [self removeCallStatusBar];
                 
                 // Release properly
+                [currentCallViewController destroy];
                 currentCallViewController.mxCall.delegate = nil;
                 currentCallViewController.delegate = nil;
                 currentCallViewController = nil;


### PR DESCRIPTION
`CallViewController` is dangling in the memory even if it was dismissed. The reason of this are `updateStatusTimer`, `roomDidFlushDataNotificationObserver`, `audioSessionRouteChangeNotificationObserver` and `roomListener` which prevent it from being dismissed if they weren't reset as part of dismissing process.  To handle this situation we just need to call `destroy` method in appropriate place in the `AppDelegate`.