### PR TITLE
Contact permission

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -160,6 +160,8 @@
 "contacts_address_book_section" = "LOCAL CONTACTS";
 "contacts_address_book_matrix_users_toggle" = "Matrix users only";
 "contacts_address_book_no_contact" = "No local contacts";
+"contacts_address_book_permission_required" = "Permission required to access local contacts";
+"contacts_address_book_permission_denied" = "You didn't allow Riot to access your local contacts";
 "contacts_matrix_users_section" = "KNOWN CONTACTS";
 
 // Chat participants

--- a/Riot/Model/Contact/ContactsDataSource.m
+++ b/Riot/Model/Contact/ContactsDataSource.m
@@ -81,15 +81,8 @@
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onContactManagerDidUpdate:) name:kMXKContactManagerDidUpdateLocalContactsNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onContactManagerDidUpdate:) name:kMXKContactManagerDidUpdateLocalContactMatrixIDsNotification object:nil];
         
-        // Check whether the access to the local contacts has not been already asked.
-        if (ABAddressBookGetAuthorizationStatus() == kABAuthorizationStatusNotDetermined)
-        {
-            // Allow by default the local contacts sync in order to discover matrix users.
-            // This setting change will trigger the loading of the local contacts, which will automatically
-            // ask user permission to access their local contacts.
-            [MXKAppSettings standardAppSettings].syncLocalContacts = YES;
-        }
-        else
+        // Refresh the matrix identifiers for all the local contacts.
+        if (ABAddressBookGetAuthorizationStatus() != kABAuthorizationStatusNotDetermined)
         {
             // Refresh the matrix identifiers for all the local contacts.
             [[MXKContactManager sharedManager] updateMatrixIDsForAllLocalContacts];

--- a/Riot/Model/Contact/ContactsDataSource.m
+++ b/Riot/Model/Contact/ContactsDataSource.m
@@ -529,7 +529,29 @@
         }
         else if (indexPath.section == filteredLocalContactsSection)
         {
-            tableViewCell.textLabel.text = NSLocalizedStringFromTable(@"contacts_address_book_no_contact", @"Vector", nil);
+            tableViewCell.textLabel.numberOfLines = 0;
+
+            // Indicate to the user why there is no contacts
+            switch (ABAddressBookGetAuthorizationStatus())
+            {
+                case kABAuthorizationStatusAuthorized:
+                    // Because there is no contacts on the device
+                    tableViewCell.textLabel.text = NSLocalizedStringFromTable(@"contacts_address_book_no_contact", @"Vector", nil);
+                    break;
+
+                case kABAuthorizationStatusNotDetermined:
+                    // Because the user have not granted the permission yet
+                    // (The permission request popup is displayed at the same time)
+                    tableViewCell.textLabel.text = NSLocalizedStringFromTable(@"contacts_address_book_permission_required", @"Vector", nil);
+                    break;
+
+                default:
+                {
+                    // Because the user didn't allow the app to access local contacts
+                    tableViewCell.textLabel.text = NSLocalizedStringFromTable(@"contacts_address_book_permission_denied", @"Vector", nil);
+                    break;
+                }
+            }
         }
         return tableViewCell;
     }

--- a/Riot/ViewController/ContactsTableViewController.m
+++ b/Riot/ViewController/ContactsTableViewController.m
@@ -109,7 +109,16 @@
         [tracker set:kGAIScreenName value:_screenName];
         [tracker send:[[GAIDictionaryBuilder createScreenView] build]];
     }
-    
+
+    // Check whether the access to the local contacts has not been already asked.
+    if (ABAddressBookGetAuthorizationStatus() == kABAuthorizationStatusNotDetermined)
+    {
+        // Allow by default the local contacts sync in order to discover matrix users.
+        // This setting change will trigger the loading of the local contacts, which will automatically
+        // ask user permission to access their local contacts.
+        [MXKAppSettings standardAppSettings].syncLocalContacts = YES;
+    }
+
     // Observe kAppDelegateDidTapStatusBarNotification.
     kAppDelegateDidTapStatusBarNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kAppDelegateDidTapStatusBarNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
         

--- a/Riot/ViewController/PeopleViewController.m
+++ b/Riot/ViewController/PeopleViewController.m
@@ -100,7 +100,16 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    
+
+    // Check whether the access to the local contacts has not been already asked.
+    if (ABAddressBookGetAuthorizationStatus() == kABAuthorizationStatusNotDetermined)
+    {
+        // Allow by default the local contacts sync in order to discover matrix users.
+        // This setting change will trigger the loading of the local contacts, which will automatically
+        // ask user permission to access their local contacts.
+        [MXKAppSettings standardAppSettings].syncLocalContacts = YES;
+    }
+
     [AppDelegate theDelegate].masterTabBarController.navigationItem.title = NSLocalizedStringFromTable(@"title_people", @"Vector", nil);
     [AppDelegate theDelegate].masterTabBarController.navigationController.navigationBar.tintColor = kRiotColorOrange;
     [AppDelegate theDelegate].masterTabBarController.tabBar.tintColor = kRiotColorOrange;


### PR DESCRIPTION
- Make the permission popup display again (it appears when the user goes into the people tab)
- Display "You didn't allow Riot to access your local contacts" instead of "No local contacts" when the user has denied the phonebook access permission

![](https://matrix.org/_matrix/media/v1/download/matrix.org/aBAwUoKirqpnSjjrWXlDfUFd)