### PR TITLE
Initialise the read marker if it does not exist yet.

### DIFF
--- a/Riot/ViewController/RoomViewController.m
+++ b/Riot/ViewController/RoomViewController.m
@@ -3545,6 +3545,13 @@
     else
     {
         self.jumpToLastUnreadBannerContainer.hidden = YES;
+        
+        // Initialize the read marker if it does not exist yet
+        if (!self.roomDataSource.room.accountData.readMarkerEventId)
+        {
+            // Move the read marker to the current read receipt position by default.
+            [self.roomDataSource.room forgetReadMarker];
+        }
     }
 }
 


### PR DESCRIPTION
Set it to the current read receipt position by default