### PR TITLE
RoomVC: Make the activity indicator follow the keyboard

### DIFF
--- a/Riot/ViewController/RoomViewController.m
+++ b/Riot/ViewController/RoomViewController.m
@@ -930,6 +930,12 @@
             
         });
     }
+
+    // Make the activity indicator follow the keyboard
+    // At runtime, this creates a smooth animation
+    CGPoint activityIndicatorCenter = self.activityIndicator.center;
+    activityIndicatorCenter.y = self.view.center.y - keyboardHeight / 2;
+    self.activityIndicator.center = activityIndicatorCenter;
 }
 
 - (void)dismissTemporarySubViews


### PR DESCRIPTION
This avoids that the indicator view hides the text input.