### PR TITLE
Fix App crashes on [AvatarGenerator imageFromText:withBackgroundColor:]

### DIFF
--- a/Riot/Model/Room/RoomBubbleCellData.m
+++ b/Riot/Model/Room/RoomBubbleCellData.m
@@ -33,9 +33,6 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
     
     if (self)
     {
-        // Use the vector style placeholder
-        self.senderAvatarPlaceholder = [AvatarGenerator generateAvatarForMatrixItem:self.senderId withDisplayName:self.senderDisplayName];
-        
         // Increase maximum number of components
         self.maxComponentCount = 20;
         

--- a/Riot/Model/Room/RoomDataSource.m
+++ b/Riot/Model/Room/RoomDataSource.m
@@ -106,6 +106,15 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    // Do cell data customization that needs to be done before [MXKRoomBubbleTableViewCell render]
+    RoomBubbleCellData *roomBubbleCellData = [self cellDataAtIndex:indexPath.row];
+
+    // Use the Riot style placeholder
+    if (!roomBubbleCellData.senderAvatarPlaceholder)
+    {
+        roomBubbleCellData.senderAvatarPlaceholder = [AvatarGenerator generateAvatarForMatrixItem:roomBubbleCellData.senderId withDisplayName:roomBubbleCellData.senderDisplayName];
+    }
+
     UITableViewCell *cell = [super tableView:tableView cellForRowAtIndexPath:indexPath];
     
     // Finalize cell view customization here


### PR DESCRIPTION
https://github.com/vector-im/riot-ios/issues/657

Do not call [AvatarGenerator imageFromText:withBackgroundColor:] outside main thread.