### PR TITLE
Fix crash on decline button

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -2314,7 +2314,6 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             
             // Release properly
             [currentCallViewController destroy];
-            currentCallViewController = nil;
             
             if (completion)
             {


### PR DESCRIPTION
This scenario very often causes to crash: receive an incoming call and press decline on alert view.

Signed-off-by: Denis Morozov dmorozkn@gmail.com