### PR TITLE
Fix: Room directory: stuck after the 20 first items

### DIFF
--- a/Riot/ViewController/RoomsViewController.m
+++ b/Riot/ViewController/RoomsViewController.m
@@ -268,9 +268,9 @@
 
 - (void)triggerDirectoryPagination
 {
-    if (recentsDataSource.publicRoomsDirectoryDataSource.hasReachedPaginationEnd || footerSpinnerView)
+    if (!recentsDataSource || recentsDataSource.publicRoomsDirectoryDataSource.hasReachedPaginationEnd || footerSpinnerView)
     {
-        // We got all public rooms or we are already paginating
+        // We are not yet ready or we got all public rooms or we are already paginating
         // Do nothing
         return;
     }


### PR DESCRIPTION
#1329 

I do not know what causes the regression but this fix avoids to show the footer spinner if the data source is not yet ready (=nil), which is a good sanity check anyway.

As the spinner view is used as a flag to indicate that a pagination is in progress, the pagination code fell in dead lock and did no more paginations.

This case happens because ```[RoomViewController triggerDirectoryPagination]``` is called with a nil datasource when the screen appears.


