### PR TITLE
Fix: Crash when scrolling in the public rooms from Unified Search

### DIFF
--- a/Riot/ViewController/DirectoryViewController.m
+++ b/Riot/ViewController/DirectoryViewController.m
@@ -230,19 +230,7 @@
 
             if (roomsAdded)
             {
-                // Notify the table view there are new items at its tail
-                NSMutableArray<NSIndexPath *> *indexPaths = [NSMutableArray arrayWithCapacity:roomsAdded];
-
-                NSUInteger numberOfRowsBefore = [self->dataSource tableView:self.tableView numberOfRowsInSection:0];
-                numberOfRowsBefore -= roomsAdded;
-
-                for (NSUInteger i = 0; i < roomsAdded; i++)
-                {
-                    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:(numberOfRowsBefore + i) inSection:0];
-                    [indexPaths addObject:indexPath];
-                }
-
-                [self.tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationAutomatic];
+                [self.tableView reloadData];
             }
             
             [self removeSpinnerFooterView];


### PR DESCRIPTION
#1355

Make pagination UI update of DirectoryViewController simpler.

The issue is that the same PublicRoomsDirectoryDataSource instance is shared between DirectoryViewController and RoomsViewController. We can have parallel paginations which makes hard to count the exact number of added cells.