### PR TITLE
MediaPicker xib layout fix

### DIFF
--- a/Riot/ViewController/MediaPickerViewController.xib
+++ b/Riot/ViewController/MediaPickerViewController.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -15,7 +15,6 @@
                 <outlet property="cameraActivityIndicator" destination="dxP-iB-dWk" id="HBu-hw-Cx9"/>
                 <outlet property="cameraCaptureButton" destination="uRG-b0-CjY" id="3Qc-PU-LUY"/>
                 <outlet property="cameraCaptureButtonWidthConstraint" destination="gmN-48-HHd" id="NQ1-3b-Oz7"/>
-                <outlet property="cameraPreviewContainerAspectRatio" destination="QDd-Tq-4zL" id="qNb-5w-GnM"/>
                 <outlet property="cameraPreviewContainerView" destination="w7z-f3-kdT" id="iqZ-I1-ZcW"/>
                 <outlet property="cameraSwitchButton" destination="PXk-ZD-TYS" id="i6p-yB-8HG"/>
                 <outlet property="cameraVideoCaptureProgressView" destination="aXP-Vh-zUp" id="yvj-G0-8oa"/>
@@ -33,22 +32,22 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZfS-wG-RjJ">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cE0-0g-Su5" userLabel="Capture View">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="550"/>
+                            <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                             <subviews>
                                 <view contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="w7z-f3-kdT" userLabel="Preview Container View">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="550"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                                     <color key="backgroundColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <accessibility key="accessibilityConfiguration" identifier="MediaPickerVCPreviewContainerView"/>
                                 </view>
                                 <button opaque="NO" alpha="0.40000000000000002" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PXk-ZD-TYS" userLabel="Camera Switch Button">
-                                    <rect key="frame" x="317" y="24" width="46" height="46"/>
+                                    <rect key="frame" x="710" y="24" width="46" height="46"/>
                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <accessibility key="accessibilityConfiguration" identifier="MediaPickerVCCameraSwitchButton"/>
                                     <constraints>
@@ -63,7 +62,7 @@
                                     </connections>
                                 </button>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="camera_switch.png" translatesAutoresizingMaskIntoConstraints="NO" id="etc-h5-0u2">
-                                    <rect key="frame" x="324" y="35" width="32" height="24"/>
+                                    <rect key="frame" x="717" y="35" width="32" height="24"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="32" id="Mci-PP-bNY"/>
                                         <constraint firstAttribute="height" constant="24" id="cqi-nf-MLe"/>
@@ -92,10 +91,10 @@
                                     </constraints>
                                 </imageView>
                                 <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="dxP-iB-dWk" userLabel="Camera Activity Indicator">
-                                    <rect key="frame" x="177.5" y="265" width="20" height="20"/>
+                                    <rect key="frame" x="374.5" y="502" width="20" height="20"/>
                                 </activityIndicatorView>
                                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aXP-Vh-zUp" customClass="MXKPieChartView">
-                                    <rect key="frame" x="141.5" y="432.5" width="92" height="92"/>
+                                    <rect key="frame" x="338.5" y="906.5" width="92" height="92"/>
                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                     <accessibility key="accessibilityConfiguration" identifier="MediaPickerVCCameraVideoCaptureProgressView"/>
                                     <constraints>
@@ -104,7 +103,7 @@
                                     </constraints>
                                 </view>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uRG-b0-CjY" userLabel="Capture Button">
-                                    <rect key="frame" x="146" y="437" width="83" height="83"/>
+                                    <rect key="frame" x="343" y="911" width="83" height="83"/>
                                     <accessibility key="accessibilityConfiguration" identifier="MediaPickerVCCaptureButton"/>
                                     <constraints>
                                         <constraint firstAttribute="width" secondItem="uRG-b0-CjY" secondAttribute="height" multiplier="1:1" id="1aP-D4-EI5"/>
@@ -128,7 +127,6 @@
                                 <constraint firstItem="VA2-Cu-dX6" firstAttribute="centerY" secondItem="sO8-Ds-mXZ" secondAttribute="centerY" id="Fze-aW-Jg3"/>
                                 <constraint firstItem="aXP-Vh-zUp" firstAttribute="centerX" secondItem="uRG-b0-CjY" secondAttribute="centerX" id="IWo-s2-YaV"/>
                                 <constraint firstAttribute="bottom" secondItem="w7z-f3-kdT" secondAttribute="bottom" id="Odc-BN-d37"/>
-                                <constraint firstAttribute="width" secondItem="cE0-0g-Su5" secondAttribute="height" multiplier="15:22" id="QDd-Tq-4zL"/>
                                 <constraint firstItem="VA2-Cu-dX6" firstAttribute="centerX" secondItem="sO8-Ds-mXZ" secondAttribute="centerX" id="Xmg-sf-k4n"/>
                                 <constraint firstItem="etc-h5-0u2" firstAttribute="centerY" secondItem="PXk-ZD-TYS" secondAttribute="centerY" id="cW6-ue-5Vb"/>
                                 <constraint firstItem="w7z-f3-kdT" firstAttribute="leading" secondItem="cE0-0g-Su5" secondAttribute="leading" id="eH4-0j-WXi"/>
@@ -143,10 +141,10 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jzs-FL-Rqd" userLabel="Collection Container View">
-                            <rect key="frame" x="0.0" y="550" width="375" height="450"/>
+                            <rect key="frame" x="0.0" y="1024" width="768" height="450"/>
                             <subviews>
                                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="Cnz-mP-gE5">
-                                    <rect key="frame" x="0.0" y="2" width="375" height="448"/>
+                                    <rect key="frame" x="0.0" y="2" width="768" height="448"/>
                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="2" minimumInteritemSpacing="2" id="wY5-ZF-Ge2">
                                         <size key="itemSize" width="148" height="148"/>
@@ -173,10 +171,10 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QeN-lu-6hK" userLabel="Library View">
-                            <rect key="frame" x="0.0" y="1000" width="375" height="74"/>
+                            <rect key="frame" x="0.0" y="1474" width="768" height="74"/>
                             <subviews>
                                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="74" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="mCG-GH-ADc" userLabel="Albums Table View">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="74"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="74"/>
                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="MediaPickerVCAlbumsTableView"/>
@@ -225,6 +223,7 @@
                 <constraint firstAttribute="bottom" secondItem="ZfS-wG-RjJ" secondAttribute="bottom" id="Sre-5e-ocp"/>
                 <constraint firstAttribute="trailing" secondItem="ZfS-wG-RjJ" secondAttribute="trailing" id="UrC-gh-xoR"/>
                 <constraint firstItem="ZfS-wG-RjJ" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="bUn-mA-Mv2"/>
+                <constraint firstItem="cE0-0g-Su5" firstAttribute="height" secondItem="iN0-l3-epB" secondAttribute="height" id="oln-H8-TBb"/>
             </constraints>
         </view>
     </objects>


### PR DESCRIPTION
Currently, the CaptureView in the MediaPickerController has a fixed aspect ratio. This results in not being able to see the CaptureButton without scrolling on iPads. In this pull request, I am trying to fix this issue by removing the CaptureView's aspect ratio constrain and adding CaptureView's height equals MainScrollView's parent view height constrain. 

I have not tested this on real device since I cannot build this app on my machine (profiling issue). Please help me test it if anyone could. Thanks!

BTW, awesome app! 😊