### PR TITLE
MXKEventFormatter: Add singleEmojiTextFont property to special case t…

### DIFF
--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -90,6 +90,7 @@
         self.stateEventTextFont = [UIFont italicSystemFontOfSize:15];
         self.callNoticesTextFont = [UIFont italicSystemFontOfSize:15];
         self.encryptedMessagesTextFont = [UIFont italicSystemFontOfSize:15];
+        self.singleEmojiTextFont = [UIFont systemFontOfSize:48];
     }
     return self;
 }


### PR DESCRIPTION
…he display of message with a single emoji.

https://github.com/vector-im/riot-ios/issues/1157: optionally boost size of lone emoji like on riot-web

![](https://matrix.org/_matrix/media/v1/download/matrix.org/kkCmFbgWIXBAJPPTdUXzxZUf)