### PR TITLE
Prepare Dark Theme

### DIFF
--- a/Riot.xcodeproj/project.pbxproj
+++ b/Riot.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		32FD0A3D1EB0CD9B0072B066 /* BugReportViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FD0A3B1EB0CD9B0072B066 /* BugReportViewController.m */; };
 		32FD0A3E1EB0CD9B0072B066 /* BugReportViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 32FD0A3C1EB0CD9B0072B066 /* BugReportViewController.xib */; };
 		E2EAC1A4FBD6FE5228584591 /* libPods-Riot.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D8737F782E108CFD6908691 /* libPods-Riot.a */; };
+		F0131DE51F2200D600CBF707 /* RiotSplitViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F0131DE41F2200D600CBF707 /* RiotSplitViewController.m */; };
 		F02C1A861E8EB04C0045A404 /* PeopleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F02C1A841E8EB04C0045A404 /* PeopleViewController.m */; };
 		F05BD79E1E7AEBF800C69941 /* UnifiedSearchViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F05BD79D1E7AEBF800C69941 /* UnifiedSearchViewController.m */; };
 		F05BD7A11E7C0E4500C69941 /* MasterTabBarController.m in Sources */ = {isa = PBXBuildFile; fileRef = F05BD7A01E7C0E4500C69941 /* MasterTabBarController.m */; };
@@ -529,6 +530,8 @@
 		32FD0A3B1EB0CD9B0072B066 /* BugReportViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugReportViewController.m; sourceTree = "<group>"; };
 		32FD0A3C1EB0CD9B0072B066 /* BugReportViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BugReportViewController.xib; sourceTree = "<group>"; };
 		7D8737F782E108CFD6908691 /* libPods-Riot.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Riot.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F0131DE31F2200D600CBF707 /* RiotSplitViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RiotSplitViewController.h; sourceTree = "<group>"; };
+		F0131DE41F2200D600CBF707 /* RiotSplitViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RiotSplitViewController.m; sourceTree = "<group>"; };
 		F02C1A831E8EB04C0045A404 /* PeopleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PeopleViewController.h; sourceTree = "<group>"; };
 		F02C1A841E8EB04C0045A404 /* PeopleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PeopleViewController.m; sourceTree = "<group>"; };
 		F05BD79C1E7AEBF800C69941 /* UnifiedSearchViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UnifiedSearchViewController.h; sourceTree = "<group>"; };
@@ -1563,6 +1566,8 @@
 		F083BC191E7009EC00A9B29C /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
+				F0131DE31F2200D600CBF707 /* RiotSplitViewController.h */,
+				F0131DE41F2200D600CBF707 /* RiotSplitViewController.m */,
 				F0E059FE1E963103004B83FB /* FavouritesViewController.h */,
 				F0E059FF1E963103004B83FB /* FavouritesViewController.m */,
 				F0E05A001E963103004B83FB /* RoomsViewController.h */,
@@ -2529,6 +2534,7 @@
 				F083BE861E7009ED00A9B29C /* RoomTableViewCell.m in Sources */,
 				F083BDF51E7009ED00A9B29C /* main.m in Sources */,
 				F083BDEE1E7009ED00A9B29C /* MXRoom+Riot.m in Sources */,
+				F0131DE51F2200D600CBF707 /* RiotSplitViewController.m in Sources */,
 				F083BE331E7009ED00A9B29C /* DeviceView.m in Sources */,
 				32471CDC1F1373A100BDF50A /* RoomMembershipCollapsedWithPaginationTitleBubbleCell.m in Sources */,
 				F083BE2B1E7009ED00A9B29C /* AuthInputsView.m in Sources */,

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -2390,12 +2390,6 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             BOOL callIsEnded = (callViewController.mxCall.state == MXCallStateEnded);
             NSLog(@"Call view controller is dismissed (%d)", callIsEnded);
             
-            if (callIsEnded)
-            {
-                // Restore system status bar
-                [UIApplication sharedApplication].statusBarHidden = NO;
-            }
-            
             [callViewController dismissViewControllerAnimated:YES completion:^{
                 
                 if (!callIsEnded)
@@ -2530,31 +2524,11 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     {
         if (self.window.rootViewController.presentedViewController)
         {
-            [self.window.rootViewController.presentedViewController presentViewController:currentCallViewController animated:YES completion:^{
-                
-                // Hide system status bar
-                [UIApplication sharedApplication].statusBarHidden = YES;
-                
-                if (completion)
-                {
-                    completion ();
-                }
-                
-            }];
+            [self.window.rootViewController.presentedViewController presentViewController:currentCallViewController animated:YES completion:completion];
         }
         else
         {
-            [self.window.rootViewController presentViewController:currentCallViewController animated:YES completion:^{
-                
-                // Hide system status bar
-                [UIApplication sharedApplication].statusBarHidden = YES;
-                
-                if (completion)
-                {
-                    completion ();
-                }
-                
-            }];
+            [self.window.rootViewController presentViewController:currentCallViewController animated:YES completion:completion];
         }
     }
 }

--- a/Riot/Base.lproj/Main.storyboard
+++ b/Riot/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="H1p-Uh-vWS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="H1p-Uh-vWS">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -335,7 +335,7 @@
         <!--RecentsSplitVC-->
         <scene sceneID="Nki-YV-4Qg">
             <objects>
-                <splitViewController title="RecentsSplitVC" id="H1p-Uh-vWS" sceneMemberID="viewController">
+                <splitViewController title="RecentsSplitVC" id="H1p-Uh-vWS" customClass="RiotSplitViewController" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationItem key="navigationItem" id="EB5-8V-irH"/>
                     <connections>
@@ -428,7 +428,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logo.png" translatesAutoresizingMaskIntoConstraints="NO" id="6LG-qc-7jf">
-                                <rect key="frame" x="127" y="284" width="120" height="99"/>
+                                <rect key="frame" x="127" y="283" width="120" height="101"/>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -564,7 +564,7 @@
         </scene>
     </scenes>
     <resources>
-        <image name="logo.png" width="120" height="99"/>
+        <image name="logo.png" width="120" height="101"/>
         <image name="search_icon.png" width="22" height="22"/>
         <image name="settings_icon.png" width="24" height="24"/>
         <image name="tab_favourites.png" width="25" height="25"/>
@@ -577,10 +577,10 @@
         <image name="tab_rooms_selected.png" width="25" height="25"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="tk8-vF-K4T"/>
-        <segue reference="Tfl-tq-LQp"/>
+        <segue reference="fNQ-S3-DbZ"/>
         <segue reference="ziz-Xl-QVg"/>
         <segue reference="mFs-HA-7Oo"/>
-        <segue reference="fNQ-S3-DbZ"/>
+        <segue reference="0ws-cL-0tk"/>
+        <segue reference="Tfl-tq-LQp"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Riot/Info.plist
+++ b/Riot/Info.plist
@@ -89,7 +89,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 	<key>UserDefaults</key>
 	<string>${PRODUCT_NAME}-Defaults</string>
 </dict>

--- a/Riot/Utils/RiotDesignValues.h
+++ b/Riot/Utils/RiotDesignValues.h
@@ -18,6 +18,11 @@
 #import <MatrixKit/MatrixKit.h>
 
 /**
+ Posted when the user interface theme has been changed.
+ */
+extern NSString *const kRiotDesignValuesDidChangeThemeNotification;
+
+/**
  Convert a RGB hexadecimal value into a UIColor.
  */
 #define UIColorFromRGB(rgbValue) \
@@ -26,10 +31,16 @@
                      blue:((float)((rgbValue & 0x0000FF) >>  0))/255.0 \
                     alpha:1.0]
 
+#pragma mark - Riot Theme Colors (depends on the selected theme light or dark).
+extern UIColor *kRiotPrimaryBgColor;
+extern UIColor *kRiotSecondaryBgColor;
+extern UIColor *kRiotPrimaryTextColor;
+extern UIColor *kRiotSecondaryTextColor; //subtitle, sending messages color.
+extern UIColor *kRiotTopicTextColor;
+
 #pragma mark - Riot Colors
 extern UIColor *kRiotColorGreen;
 extern UIColor *kRiotColorLightGreen;
-extern UIColor *kRiotColorLightGrey;
 extern UIColor *kRiotColorLightOrange;
 extern UIColor *kRiotColorSilver;
 extern UIColor *kRiotColorPinkRed;
@@ -37,24 +48,31 @@ extern UIColor *kRiotColorRed;
 extern UIColor *kRiotColorIndigo;
 extern UIColor *kRiotColorOrange;
 
+#pragma mark - Riot Background Colors
+extern UIColor *kRiotBgColorWhite;
+extern UIColor *kRiotBgColorBlack;
+
+extern UIColor *kRiotColorLightGrey;
+extern UIColor *kRiotColorLightBlack;
+
 #pragma mark - Riot Text Colors
 extern UIColor *kRiotTextColorBlack;
 extern UIColor *kRiotTextColorDarkGray;
 extern UIColor *kRiotTextColorGray;
-
-#pragma mark - Riot Navigation Bar Tint Color
-extern UIColor *kRiotNavBarTintColor;
+extern UIColor *kRiotTextColorWhite;
+extern UIColor *kRiotTextColorDarkWhite;
 
 #pragma mark - Riot Standard Room Member Power Level
 extern NSInteger const kRiotRoomModeratorLevel;
 extern NSInteger const kRiotRoomAdminLevel;
 
+#pragma mark - Riot 
+extern UIStatusBarStyle kRiotDesignStatusBarStyle;
+
+
 /**
  `RiotDesignValues` class manages the Riot design parameters
  */
 @interface RiotDesignValues : NSObject
-
-// to update the navigation bar buttons color
-// [[AppDelegate theDelegate] recentsNavigationController].navigationBar.tintColor = [UIColor greenColor];
 
 @end

--- a/Riot/Utils/RiotDesignValues.m
+++ b/Riot/Utils/RiotDesignValues.m
@@ -17,9 +17,16 @@
 
 #import "RiotDesignValues.h"
 
+NSString *const kRiotDesignValuesDidChangeThemeNotification = @"kRiotDesignValuesDidChangeThemeNotification";
+
+UIColor *kRiotPrimaryBgColor;
+UIColor *kRiotSecondaryBgColor;
+UIColor *kRiotPrimaryTextColor;
+UIColor *kRiotSecondaryTextColor;
+UIColor *kRiotTopicTextColor;
+
 UIColor *kRiotColorGreen;
 UIColor *kRiotColorLightGreen;
-UIColor *kRiotColorLightGrey;
 UIColor *kRiotColorLightOrange;
 UIColor *kRiotColorSilver;
 UIColor *kRiotColorPinkRed;
@@ -27,16 +34,36 @@ UIColor *kRiotColorRed;
 UIColor *kRiotColorIndigo;
 UIColor *kRiotColorOrange;
 
+UIColor *kRiotBgColorWhite;
+UIColor *kRiotBgColorBlack;
+
+UIColor *kRiotColorLightGrey;
+UIColor *kRiotColorLightBlack;
+
 UIColor *kRiotTextColorBlack;
 UIColor *kRiotTextColorDarkGray;
 UIColor *kRiotTextColorGray;
-
-UIColor *kRiotNavBarTintColor;
+UIColor *kRiotTextColorWhite;
+UIColor *kRiotTextColorDarkWhite;
 
 NSInteger const kRiotRoomModeratorLevel = 50;
 NSInteger const kRiotRoomAdminLevel = 100;
 
+UIStatusBarStyle kRiotDesignStatusBarStyle = UIStatusBarStyleDefault;
+
 @implementation RiotDesignValues
+
++ (RiotDesignValues *)sharedInstance
+{
+    static RiotDesignValues *sharedOnceInstance;
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedOnceInstance = [[RiotDesignValues alloc] init];
+    });
+    
+    return sharedOnceInstance;
+}
 
 + (void)load
 {
@@ -46,22 +73,72 @@ NSInteger const kRiotRoomAdminLevel = 100;
 
     // Colors as defined by the design
     kRiotColorGreen = UIColorFromRGB(0x62CE9C);
-    kRiotColorLightGrey = [UIColor colorWithRed:(242.0 / 255.0) green:(242.0 / 255.0) blue:(242.0 / 255.0) alpha:1.0];
     kRiotColorSilver = UIColorFromRGB(0xC7C7CC);
     kRiotColorPinkRed = UIColorFromRGB(0xFF0064);
     kRiotColorRed = UIColorFromRGB(0xFF4444);
     kRiotColorIndigo = UIColorFromRGB(0xBD79CC);
     kRiotColorOrange = UIColorFromRGB(0xF8A15F);
-
-    kRiotTextColorBlack = [UIColor colorWithRed:(60.0 / 255.0) green:(60.0 / 255.0) blue:(60.0 / 255.0) alpha:1.0];
-    kRiotTextColorDarkGray = [UIColor colorWithRed:(74.0 / 255.0) green:(74.0 / 255.0) blue:(74.0 / 255.0) alpha:1.0];
-    kRiotTextColorGray = [UIColor colorWithRed:(157.0 / 255.0) green:(157.0 / 255.0) blue:(157.0 / 255.0) alpha:1.0];
     
-    kRiotNavBarTintColor = kRiotColorLightGrey;
+    kRiotBgColorWhite = [UIColor whiteColor];
+    kRiotBgColorBlack = UIColorFromRGB(0x2D2D2D);
+    
+    kRiotColorLightGrey = UIColorFromRGB(0xF2F2F2);
+    kRiotColorLightBlack = UIColorFromRGB(0x353535);
+
+    kRiotTextColorBlack = UIColorFromRGB(0x3C3C3C);
+    kRiotTextColorDarkGray = UIColorFromRGB(0x4A4A4A);
+    kRiotTextColorGray = UIColorFromRGB(0x9D9D9D);
+    kRiotTextColorWhite = UIColorFromRGB(0xDDDDDD);
+    kRiotTextColorDarkWhite = UIColorFromRGB(0xD9D9D9);
 
     // Colors copied from Vector web
     kRiotColorLightGreen = UIColorFromRGB(0x50e2c2);
     kRiotColorLightOrange = UIColorFromRGB(0xf4c371);
+    
+    // Observe user interface theme change.
+    [[NSUserDefaults standardUserDefaults] addObserver:[RiotDesignValues sharedInstance] forKeyPath:@"userInterfaceTheme" options:0 context:nil];
+    [[RiotDesignValues sharedInstance] userInterfaceThemeDidChange];
+}
+
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    if ([@"userInterfaceTheme" isEqualToString:keyPath])
+    {
+        [self userInterfaceThemeDidChange];
+    }
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    // Retrieve the current selected theme ("light" if none).
+    NSString *theme = [[NSUserDefaults standardUserDefaults] stringForKey:@"userInterfaceTheme"];
+    
+    // Currently only 2 themes is supported
+    if ([theme isEqualToString:@"dark"])
+    {
+        // Set dark theme colors
+        kRiotPrimaryBgColor = kRiotBgColorBlack;
+        kRiotSecondaryBgColor = kRiotColorLightBlack;
+        kRiotPrimaryTextColor = kRiotTextColorWhite;
+        kRiotSecondaryTextColor = kRiotTextColorGray;
+        kRiotTopicTextColor = kRiotTextColorDarkWhite;
+        
+        kRiotDesignStatusBarStyle = UIStatusBarStyleLightContent;
+    }
+    else
+    {
+        // Set light theme colors by default.
+        kRiotPrimaryBgColor = kRiotBgColorWhite;
+        kRiotSecondaryBgColor = kRiotColorLightGrey;
+        kRiotPrimaryTextColor = kRiotTextColorBlack;
+        kRiotSecondaryTextColor = kRiotTextColorGray;
+        kRiotTopicTextColor = kRiotTextColorDarkGray;
+        
+        kRiotDesignStatusBarStyle = UIStatusBarStyleDefault;
+    }
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:kRiotDesignValuesDidChangeThemeNotification object:nil];
 }
 
 @end

--- a/Riot/ViewController/AttachmentsViewController.m
+++ b/Riot/ViewController/AttachmentsViewController.m
@@ -19,6 +19,14 @@
 
 #import "AppDelegate.h"
 
+@interface AttachmentsViewController ()
+{
+    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
+}
+
+@end
+
 @implementation AttachmentsViewController
 
 #pragma mark -
@@ -27,8 +35,7 @@
 {
     [super finalizeInit];
     
-    // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
+    // Setup `MXKViewControllerHandling` properties.
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -39,6 +46,20 @@
     // Do any additional setup after loading the view, typically from a nib.
     
     self.attachmentsCollection.accessibilityIdentifier =@"AttachmentsVC";
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.view.backgroundColor = kRiotPrimaryBgColor;
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -51,6 +72,17 @@
     {
         [tracker set:kGAIScreenName value:@"AttachmentsViewer"];
         [tracker send:[[GAIDictionaryBuilder createScreenView] build]];
+    }
+}
+
+- (void)destroy
+{
+    [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
     }
 }
 

--- a/Riot/ViewController/AuthenticationViewController.h
+++ b/Riot/ViewController/AuthenticationViewController.h
@@ -19,6 +19,8 @@
 
 @interface AuthenticationViewController : MXKAuthenticationViewController <MXKAuthenticationViewControllerDelegate>
 
+@property (weak, nonatomic) IBOutlet UINavigationBar *navigationBar;
+
 @property (weak, nonatomic) IBOutlet UINavigationItem *mainNavigationItem;
 @property (weak, nonatomic) IBOutlet UIBarButtonItem *rightBarButtonItem;
 

--- a/Riot/ViewController/AuthenticationViewController.m
+++ b/Riot/ViewController/AuthenticationViewController.m
@@ -34,6 +34,11 @@
      The default country code used to initialize the mobile phone number input.
      */
     NSString *defaultCountryCode;
+    
+    /**
+     Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+     */
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 
 @end
@@ -59,7 +64,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
     
@@ -76,12 +80,8 @@
     self.rightBarButtonItem.title = NSLocalizedStringFromTable(@"auth_register", @"Vector", nil);
     
     self.defaultHomeServerUrl = [[NSUserDefaults standardUserDefaults] objectForKey:@"homeserverurl"];
-    self.homeServerTextField.textColor = kRiotTextColorBlack;
-    self.homeServerLabel.textColor = kRiotTextColorGray;
     
     self.defaultIdentityServerUrl = [[NSUserDefaults standardUserDefaults] objectForKey:@"identityserverurl"];
-    self.identityServerTextField.textColor = kRiotTextColorBlack;
-    self.identityServerLabel.textColor = kRiotTextColorGray;
     
     self.welcomeImageView.image = [UIImage imageNamed:@"logo"];
     
@@ -129,6 +129,32 @@
     MXAuthenticationSession *authSession = [MXAuthenticationSession modelFromJSON:@{@"flows":@[@{@"stages":@[kMXLoginFlowTypePassword]}]}];
     [authInputsView setAuthSession:authSession withAuthType:MXKAuthenticationTypeLogin];
     self.authInputsView = authInputsView;
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.view.backgroundColor = kRiotSecondaryBgColor;
+    self.navigationBar.barTintColor = kRiotSecondaryBgColor;
+    self.authenticationScrollView.backgroundColor = kRiotPrimaryBgColor;
+    self.authFallbackContentView.backgroundColor = kRiotPrimaryBgColor;
+    
+    self.homeServerTextField.textColor = kRiotPrimaryTextColor;
+    self.homeServerLabel.textColor = kRiotTextColorGray;
+    
+    self.identityServerTextField.textColor = kRiotPrimaryTextColor;
+    self.identityServerLabel.textColor = kRiotTextColorGray;
+    
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
+    
+    [[UIApplication sharedApplication] setStatusBarStyle:kRiotDesignStatusBarStyle animated:NO];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -141,6 +167,17 @@
     {
         [tracker set:kGAIScreenName value:@"Authentication"];
         [tracker send:[[GAIDictionaryBuilder createScreenView] build]];
+    }
+}
+
+- (void)destroy
+{
+    [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
     }
 }
 

--- a/Riot/ViewController/AuthenticationViewController.xib
+++ b/Riot/ViewController/AuthenticationViewController.xib
@@ -34,6 +34,7 @@
                 <outlet property="identityServerSeparator" destination="t08-ua-0mJ" id="Sbf-ps-zeK"/>
                 <outlet property="identityServerTextField" destination="PZC-Hd-Q6a" id="vKg-sd-dzJ"/>
                 <outlet property="mainNavigationItem" destination="rj9-wP-8QS" id="yNN-Dg-4Yw"/>
+                <outlet property="navigationBar" destination="k7D-Gy-yBR" id="6Uc-3Q-3dO"/>
                 <outlet property="noFlowLabel" destination="54b-4O-ip9" id="f18-H1-cQm"/>
                 <outlet property="optionsContainer" destination="Gg0-TE-OGb" id="RWa-Pl-eaL"/>
                 <outlet property="retryButton" destination="wIH-Kd-r7q" id="42j-Ad-zVS"/>
@@ -51,7 +52,7 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="k7D-Gy-yBR">
+                <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k7D-Gy-yBR">
                     <rect key="frame" x="0.0" y="20" width="414" height="44"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="44" id="GiL-7R-Wm2"/>
@@ -84,7 +85,7 @@
                             <rect key="frame" x="0.0" y="0.0" width="375" height="485"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logo.png" translatesAutoresizingMaskIntoConstraints="NO" id="d8r-TX-pwX" userLabel="Welcome Image View">
-                                    <rect key="frame" x="127.66666666666666" y="25" width="120" height="101"/>
+                                    <rect key="frame" x="127.66666666666666" y="25" width="119.99999999999997" height="101"/>
                                     <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCWelcomeImageView"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="120" id="ZFx-Mn-Kzq"/>
@@ -121,7 +122,7 @@
                                             </connections>
                                         </button>
                                     </subviews>
-                                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCInputContainerView"/>
                                     <constraints>
                                         <constraint firstAttribute="centerX" secondItem="54b-4O-ip9" secondAttribute="centerX" id="0bV-x1-MhX"/>
@@ -254,7 +255,7 @@
                                                                     </constraints>
                                                                 </view>
                                                             </subviews>
-                                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                             <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCHsContainer"/>
                                                             <constraints>
                                                                 <constraint firstItem="G8l-AP-iRs" firstAttribute="leading" secondItem="1YY-gb-LG4" secondAttribute="leading" constant="18" id="0tL-7X-7HQ"/>
@@ -302,7 +303,7 @@
                                                                     </constraints>
                                                                 </view>
                                                             </subviews>
-                                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                             <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCISContainer"/>
                                                             <constraints>
                                                                 <constraint firstItem="PZC-Hd-Q6a" firstAttribute="leading" secondItem="kjJ-Tb-SIW" secondAttribute="leading" constant="18" id="Khv-I4-mWb"/>
@@ -318,7 +319,7 @@
                                                             </constraints>
                                                         </view>
                                                     </subviews>
-                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                     <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCCustomServersContainer"/>
                                                     <constraints>
                                                         <constraint firstItem="1YY-gb-LG4" firstAttribute="top" secondItem="uOi-KN-l9I" secondAttribute="top" id="6LT-5K-ftH"/>
@@ -331,7 +332,7 @@
                                                     </constraints>
                                                 </view>
                                             </subviews>
-                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                             <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCServerOptionsContainer"/>
                                             <constraints>
                                                 <constraint firstItem="6yx-o1-vbD" firstAttribute="top" secondItem="FIn-2w-e6H" secondAttribute="top" constant="5" id="0qc-IF-8LY"/>
@@ -344,7 +345,7 @@
                                             </constraints>
                                         </view>
                                     </subviews>
-                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCOptionsContainer"/>
                                     <constraints>
                                         <constraint firstItem="FIn-2w-e6H" firstAttribute="leading" secondItem="Gg0-TE-OGb" secondAttribute="leading" id="3G8-Tb-KaN"/>
@@ -362,7 +363,7 @@
                                     </constraints>
                                 </view>
                             </subviews>
-                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                             <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCScrollViewContentView"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="485" id="6v6-fz-e8o"/>

--- a/Riot/ViewController/CallViewController.m
+++ b/Riot/ViewController/CallViewController.m
@@ -30,10 +30,11 @@
     // Display a gradient view above the screen
     CAGradientLayer* gradientMaskLayer;
     
-    /**
-     Current alert (if any).
-     */
+    // Current alert (if any).
     UIAlertController *currentAlert;
+    
+    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 
 @end
@@ -45,7 +46,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -108,6 +108,20 @@
     [self.gradientMaskContainerView.layer addSublayer:gradientMaskLayer];
     
     [self updateLocalPreviewLayout];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.view.backgroundColor = kRiotPrimaryBgColor;
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 - (void)viewDidLayoutSubviews
@@ -153,6 +167,12 @@
 - (void)destroy
 {
     [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
     
     [gradientMaskLayer removeFromSuperlayer];
     gradientMaskLayer = nil;

--- a/Riot/ViewController/CallViewController.m
+++ b/Riot/ViewController/CallViewController.m
@@ -124,6 +124,12 @@
     self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
+- (BOOL)prefersStatusBarHidden
+{
+    // Hide the status bar on the call view controller.
+    return YES;
+}
+
 - (void)viewDidLayoutSubviews
 {
     [super viewDidLayoutSubviews];

--- a/Riot/ViewController/ContactDetailsViewController.m
+++ b/Riot/ViewController/ContactDetailsViewController.m
@@ -74,6 +74,11 @@
      Current alert (if any).
      */
     UIAlertController *currentAlert;
+    
+    /**
+     Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+     */
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 @end
 
@@ -100,7 +105,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -202,6 +206,19 @@
         NSNumber *orientation = (NSNumber*)(notif.userInfo[UIApplicationStatusBarOrientationUserInfoKey]);
         self.bottomImageView.hidden = (orientation.integerValue == UIInterfaceOrientationLandscapeLeft || orientation.integerValue == UIInterfaceOrientationLandscapeRight);
     }];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -270,6 +287,12 @@
 - (void)destroy
 {
     [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
     
     if (roomCreationRequest)
     {

--- a/Riot/ViewController/ContactDetailsViewController.m
+++ b/Riot/ViewController/ContactDetailsViewController.m
@@ -79,6 +79,11 @@
      Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
      */
     id kRiotDesignValuesDidChangeThemeNotificationObserver;
+    
+    /**
+     The current visibility of the status bar in this view controller.
+     */
+    BOOL isStatusBarHidden;
 }
 @end
 
@@ -107,6 +112,9 @@
     // Setup `MXKViewControllerHandling` properties
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
+    
+    // Keep visible the status bar by default.
+    isStatusBarHidden = NO;
 }
 
 - (void)viewDidLoad
@@ -219,6 +227,12 @@
 - (void)userInterfaceThemeDidChange
 {
     self.defaultBarTintColor = kRiotSecondaryBgColor;
+}
+
+- (BOOL)prefersStatusBarHidden
+{
+    // Return the current status bar visibility.
+    return isStatusBarHidden;
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -1096,6 +1110,10 @@
             [avatarFullScreenView removeFromSuperview];
 
             avatarFullScreenView = nil;
+            
+            isStatusBarHidden = NO;
+            // Trigger status bar update
+            [self setNeedsStatusBarAppearanceUpdate];
         }];
 
         NSString *avatarURL = nil;
@@ -1113,6 +1131,10 @@
                              previewImage:contactAvatar.image];
 
         [avatarFullScreenView showFullScreen];
+        isStatusBarHidden = YES;
+        
+        // Trigger status bar update
+        [self setNeedsStatusBarAppearanceUpdate];
     }
 }
 

--- a/Riot/ViewController/ContactsTableViewController.m
+++ b/Riot/ViewController/ContactsTableViewController.m
@@ -29,8 +29,15 @@
 
 @interface ContactsTableViewController ()
 {
-    // Observe kAppDelegateDidTapStatusBarNotification to handle tap on clock status bar.
+    /**
+     Observe kAppDelegateDidTapStatusBarNotification to handle tap on clock status bar.
+     */
     id kAppDelegateDidTapStatusBarNotificationObserver;
+    
+    /**
+     Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+     */
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 
 @end
@@ -58,7 +65,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
     
@@ -85,6 +91,19 @@
     
     // Hide line separators of empty cells
     self.contactsTableView.tableFooterView = [[UIView alloc] init];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 - (void)didReceiveMemoryWarning
@@ -96,6 +115,12 @@
 - (void)destroy
 {
     [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Riot/ViewController/CountryPickerViewController.m
+++ b/Riot/ViewController/CountryPickerViewController.m
@@ -45,6 +45,19 @@
 
     // Hide line separators of empty cells
     self.tableView.tableFooterView = [[UIView alloc] init];
+
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -58,19 +71,6 @@
         [tracker set:kGAIScreenName value:@"CountryPicker"];
         [tracker send:[[GAIDictionaryBuilder createScreenView] build]];
     }
-    
-    // Observe user interface theme change.
-    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
-        
-        [self userInterfaceThemeDidChange];
-        
-    }];
-    [self userInterfaceThemeDidChange];
-}
-
-- (void)userInterfaceThemeDidChange
-{
-    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 - (void)destroy

--- a/Riot/ViewController/CountryPickerViewController.m
+++ b/Riot/ViewController/CountryPickerViewController.m
@@ -18,6 +18,16 @@
 
 #import "AppDelegate.h"
 
+@interface CountryPickerViewController ()
+{
+    /**
+     Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+     */
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
+}
+
+@end
+
 @implementation CountryPickerViewController
 
 - (void)finalizeInit
@@ -25,7 +35,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -48,6 +57,30 @@
     {
         [tracker set:kGAIScreenName value:@"CountryPicker"];
         [tracker send:[[GAIDictionaryBuilder createScreenView] build]];
+    }
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
+}
+
+- (void)destroy
+{
+    [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
     }
 }
 

--- a/Riot/ViewController/DirectoryServerPickerViewController.m
+++ b/Riot/ViewController/DirectoryServerPickerViewController.m
@@ -34,6 +34,9 @@
 
     // Current request in progress.
     MXHTTPOperation *mxCurrentOperation;
+    
+    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 @end
 
@@ -44,7 +47,6 @@
     [super finalizeInit];
 
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -54,6 +56,12 @@
     dataSource.delegate = nil;
     dataSource = nil;
     onCompleteBlock = nil;
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
 
     if (kAppDelegateDidTapStatusBarNotificationObserver)
     {
@@ -99,6 +107,19 @@
 
     // Hide line separators of empty cells
     self.tableView.tableFooterView = [[UIView alloc] init];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Riot/ViewController/DirectoryViewController.m
+++ b/Riot/ViewController/DirectoryViewController.m
@@ -30,6 +30,9 @@
 
     // The animated view displayed at the table view bottom when paginating
     UIView* footerSpinnerView;
+    
+    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 
 @end
@@ -41,7 +44,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -56,6 +58,30 @@
 
     // Hide line separators of empty cells
     self.tableView.tableFooterView = [[UIView alloc] init];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
+}
+
+- (void)destroy
+{
+    [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Riot/ViewController/HomeFilesSearchViewController.m
+++ b/Riot/ViewController/HomeFilesSearchViewController.m
@@ -26,6 +26,16 @@
 
 #import "EventFormatter.h"
 
+@interface HomeFilesSearchViewController()
+{
+    /**
+     Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+     */
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
+}
+
+@end
+
 @implementation HomeFilesSearchViewController
 
 - (void)finalizeInit
@@ -33,7 +43,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -49,6 +58,30 @@
 
     // Hide line separators of empty cells
     self.searchTableView.tableFooterView = [[UIView alloc] init];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
+}
+
+- (void)destroy
+{
+    [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Riot/ViewController/HomeMessagesSearchViewController.m
+++ b/Riot/ViewController/HomeMessagesSearchViewController.m
@@ -30,6 +30,16 @@
 
 #import "EventFormatter.h"
 
+@interface HomeMessagesSearchViewController ()
+{
+    /**
+     Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+     */
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
+}
+
+@end
+
 @implementation HomeMessagesSearchViewController
 
 - (void)finalizeInit
@@ -37,7 +47,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -56,6 +65,30 @@
 
     // Hide line separators of empty cells
     self.searchTableView.tableFooterView = [[UIView alloc] init];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
+}
+
+- (void)destroy
+{
+    [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Riot/ViewController/LanguagePickerViewController.m
+++ b/Riot/ViewController/LanguagePickerViewController.m
@@ -18,6 +18,16 @@
 
 #import "AppDelegate.h"
 
+@interface LanguagePickerViewController ()
+{
+    /**
+     Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+     */
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
+}
+
+@end
+
 @implementation LanguagePickerViewController
 
 - (void)finalizeInit
@@ -25,7 +35,6 @@
     [super finalizeInit];
 
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -36,6 +45,30 @@
 
     // Hide line separators of empty cells
     self.tableView.tableFooterView = [[UIView alloc] init];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
+}
+
+- (void)destroy
+{
+    [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Riot/ViewController/MediaAlbumContentViewController.m
+++ b/Riot/ViewController/MediaAlbumContentViewController.m
@@ -114,6 +114,19 @@
     self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
+- (BOOL)prefersStatusBarHidden
+{
+    // Return the preferred value of the delegate if it is a view controller itself.
+    // This is required to handle correctly the full screen mode when a media is selected.
+    if ([self.delegate isKindOfClass:UIViewController.class])
+    {
+        return [(UIViewController*)self.delegate prefersStatusBarHidden];
+    }
+    
+    // Keep visible the status bar by default.
+    return NO;
+}
+
 - (void)destroy
 {
     [super destroy];

--- a/Riot/ViewController/MediaAlbumContentViewController.m
+++ b/Riot/ViewController/MediaAlbumContentViewController.m
@@ -37,6 +37,11 @@
      The currently selected media. Nil when the multiselection is not active.
      */
     NSMutableArray <PHAsset*> *selectedAssets;
+    
+    /**
+     Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+     */
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 
 @end
@@ -64,7 +69,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -95,11 +99,30 @@
     {
         self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedStringFromTable(@"media_picker_select", @"Vector", nil) style:UIBarButtonItemStylePlain target:self action:@selector(onSelect:)];
     }
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
 }
 
-- (void)dealloc
+- (void)userInterfaceThemeDidChange
 {
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
+}
+
+- (void)destroy
+{
+    [super destroy];
     
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
 }
 
 - (void)didReceiveMemoryWarning
@@ -187,13 +210,6 @@
     self.navigationItem.title = _assetsCollection.localizedTitle;
     
     [self.assetsCollectionView reloadData];
-}
-
-#pragma mark - Override MXKViewController
-
-- (void)destroy
-{
-    [super destroy];
 }
 
 #pragma mark - UICollectionViewDataSource

--- a/Riot/ViewController/MediaPickerViewController.m
+++ b/Riot/ViewController/MediaPickerViewController.m
@@ -83,6 +83,11 @@ static void *RecordingContext = &RecordingContext;
      Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
      */
     id kRiotDesignValuesDidChangeThemeNotificationObserver;
+    
+    /**
+     The current visibility of the status bar in this view controller.
+     */
+    BOOL isStatusBarHidden;
 }
 
 @property (nonatomic) UIBackgroundTaskIdentifier backgroundRecordingID;
@@ -117,6 +122,9 @@ static void *RecordingContext = &RecordingContext;
     
     cameraQueue = dispatch_queue_create("media.picker.vc.camera", NULL);
     canToggleCamera = YES;
+    
+    // Keep visible the status bar by default.
+    isStatusBarHidden = NO;
 }
 
 - (void)viewDidLoad
@@ -171,6 +179,12 @@ static void *RecordingContext = &RecordingContext;
 - (void)userInterfaceThemeDidChange
 {
     self.defaultBarTintColor = kRiotSecondaryBgColor;
+}
+
+- (BOOL)prefersStatusBarHidden
+{
+    // Return the current status bar visibility.
+    return isStatusBarHidden;
 }
 
 - (void)viewDidLayoutSubviews
@@ -759,6 +773,11 @@ static void *RecordingContext = &RecordingContext;
     
     validationView.image = selectedImage;
     [validationView showFullScreen];
+    
+    // Hide the status bar
+    isStatusBarHidden = YES;
+    // Trigger status bar update
+    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 - (void)validateSelectedVideo:(NSURL*)selectedVideoURL responseHandler:(void (^)(BOOL isValidated))handler
@@ -805,6 +824,11 @@ static void *RecordingContext = &RecordingContext;
     }
 
     [validationView showFullScreen];
+    
+    // Hide the status bar
+    isStatusBarHidden = YES;
+    // Trigger status bar update
+    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 - (void)dismissImageValidationView
@@ -825,6 +849,10 @@ static void *RecordingContext = &RecordingContext;
         [validationView dismissSelection];
         [validationView removeFromSuperview];
         validationView = nil;
+        
+        // Restore the status bar
+        isStatusBarHidden = NO;
+        [self setNeedsStatusBarAppearanceUpdate];
     }
 }
 

--- a/Riot/ViewController/MediaPickerViewController.m
+++ b/Riot/ViewController/MediaPickerViewController.m
@@ -78,7 +78,11 @@ static void *RecordingContext = &RecordingContext;
     
     NSTimer *updateVideoRecordingTimer;
     NSDate *videoRecordStartDate;
-
+    
+    /**
+     Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+     */
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 
 @property (nonatomic) UIBackgroundTaskIdentifier backgroundRecordingID;
@@ -108,7 +112,6 @@ static void *RecordingContext = &RecordingContext;
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
     
@@ -155,6 +158,19 @@ static void *RecordingContext = &RecordingContext;
         [self reloadUserLibraryAlbums];
         
     }];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 - (void)viewDidLayoutSubviews
@@ -852,6 +868,12 @@ static void *RecordingContext = &RecordingContext;
 - (void)destroy
 {
     [self stopAVCapture];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
     
     if (UIApplicationWillEnterForegroundNotificationObserver)
     {

--- a/Riot/ViewController/RecentsViewController.m
+++ b/Riot/ViewController/RecentsViewController.m
@@ -60,6 +60,9 @@
     // The fake search bar displayed at the top of the recents table. We switch on the actual search bar (self.recentsSearchBar)
     // when the user selects it.
     UISearchBar *tableSearchBar;
+    
+    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 
 @end
@@ -87,7 +90,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
     
@@ -143,6 +145,19 @@
     
     self.recentsSearchBar.autocapitalizationType = UITextAutocapitalizationTypeNone;
     self.recentsSearchBar.placeholder = NSLocalizedStringFromTable(@"search_default_placeholder", @"Vector", nil);
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 - (void)destroy
@@ -167,6 +182,12 @@
     {
         [[NSNotificationCenter defaultCenter] removeObserver:UIApplicationDidEnterBackgroundNotificationObserver];
         UIApplicationDidEnterBackgroundNotificationObserver = nil;
+    }
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
     }
 }
 

--- a/Riot/ViewController/RiotSplitViewController.h
+++ b/Riot/ViewController/RiotSplitViewController.h
@@ -1,0 +1,26 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+/**
+ RiotSplitViewController extends UISplitViewController to handle status bar display.
+ */
+
+@interface RiotSplitViewController : UISplitViewController
+
+@end
+

--- a/Riot/ViewController/RiotSplitViewController.m
+++ b/Riot/ViewController/RiotSplitViewController.m
@@ -1,0 +1,65 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "RiotSplitViewController.h"
+
+@implementation RiotSplitViewController
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    if (self.collapsed)
+    {
+        // Look for the view controller displayed at the top.
+        UIViewController *topViewController = self.viewControllers.firstObject;
+        
+        while ([topViewController isKindOfClass:[UINavigationController class]])
+        {
+            topViewController = ((UINavigationController*)topViewController).topViewController;
+        }
+        
+        if (topViewController)
+        {
+            return [topViewController preferredStatusBarStyle];
+        }
+    }
+    
+    // Keep the default UISplitViewController style.
+    return [super preferredStatusBarStyle];
+}
+
+- (BOOL)prefersStatusBarHidden
+{
+    if (self.collapsed)
+    {
+        // Look for the view controller displayed at the top.
+        UIViewController *topViewController = self.viewControllers.firstObject;
+        
+        while ([topViewController isKindOfClass:[UINavigationController class]])
+        {
+            topViewController = ((UINavigationController*)topViewController).topViewController;
+        }
+        
+        if (topViewController)
+        {
+            return [topViewController prefersStatusBarHidden];
+        }
+    }
+    
+    // Keep the default UISplitViewController mode.
+    return [super prefersStatusBarHidden];
+}
+
+@end

--- a/Riot/ViewController/RoomFilesSearchViewController.m
+++ b/Riot/ViewController/RoomFilesSearchViewController.m
@@ -30,6 +30,9 @@
 {
     // Observe kAppDelegateDidTapStatusBarNotification to handle tap on clock status bar.
     id kAppDelegateDidTapStatusBarNotificationObserver;
+    
+    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 
 @end
@@ -41,7 +44,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -57,6 +59,30 @@
     [self.searchTableView registerClass:FilesSearchTableViewCell.class forCellReuseIdentifier:FilesSearchTableViewCell.defaultReuseIdentifier];
     
     self.searchTableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
+}
+
+- (void)destroy
+{
+    [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Riot/ViewController/RoomFilesViewController.m
+++ b/Riot/ViewController/RoomFilesViewController.m
@@ -23,6 +23,16 @@
 
 #import "AttachmentsViewController.h"
 
+@interface RoomFilesViewController ()
+{
+    /**
+     Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+     */
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
+}
+
+@end
+
 @implementation RoomFilesViewController
 
 #pragma mark -
@@ -56,7 +66,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -88,6 +97,30 @@
     [UIView setAnimationsEnabled:NO];
     [self roomInputToolbarView:self.inputToolbarView heightDidChanged:0 completion:nil];
     [UIView setAnimationsEnabled:YES];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
+}
+
+- (void)destroy
+{
+    [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
 }
 
 // This method is called when the viewcontroller is added or removed from a container view controller.

--- a/Riot/ViewController/RoomMemberDetailsViewController.m
+++ b/Riot/ViewController/RoomMemberDetailsViewController.m
@@ -66,6 +66,11 @@
      Observe UIApplicationWillChangeStatusBarOrientationNotification to hide/show bubbles bg.
      */
     id UIApplicationWillChangeStatusBarOrientationNotificationObserver;
+    
+    /**
+     Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+     */
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 @end
 
@@ -92,7 +97,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
     
@@ -187,6 +191,19 @@
         NSNumber *orientation = (NSNumber*)(notif.userInfo[UIApplicationStatusBarOrientationUserInfoKey]);
         self.bottomImageView.hidden = (orientation.integerValue == UIInterfaceOrientationLandscapeLeft || orientation.integerValue == UIInterfaceOrientationLandscapeRight);
     }];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -247,6 +264,12 @@
     {
         [[NSNotificationCenter defaultCenter] removeObserver:UIApplicationWillChangeStatusBarOrientationNotificationObserver];
         UIApplicationWillChangeStatusBarOrientationNotificationObserver = nil;
+    }
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
     }
     
     [memberTitleView removeFromSuperview];

--- a/Riot/ViewController/RoomMessagesSearchViewController.m
+++ b/Riot/ViewController/RoomMessagesSearchViewController.m
@@ -32,6 +32,9 @@
 {
     // Observe kAppDelegateDidTapStatusBarNotification to handle tap on clock status bar.
     id kAppDelegateDidTapStatusBarNotificationObserver;
+    
+    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 
 @end
@@ -43,7 +46,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -58,6 +60,30 @@
     // Reuse cells from the RoomViewController to display results
     [self.searchTableView registerClass:RoomIncomingTextMsgBubbleCell.class forCellReuseIdentifier:RoomIncomingTextMsgBubbleCell.defaultReuseIdentifier];
     [self.searchTableView registerClass:RoomIncomingAttachmentBubbleCell.class forCellReuseIdentifier:RoomIncomingAttachmentBubbleCell.defaultReuseIdentifier];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
+}
+
+- (void)destroy
+{
+    [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Riot/ViewController/RoomParticipantsViewController.m
+++ b/Riot/ViewController/RoomParticipantsViewController.m
@@ -59,6 +59,9 @@
     NSLayoutConstraint *addParticipantButtonImageViewBottomConstraint;
     
     UIAlertController *currentAlert;
+    
+    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 
 @end
@@ -86,7 +89,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -145,6 +147,19 @@
     
     // Add room creation button programmatically
     [self addAddParticipantButton];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 // This method is called when the viewcontroller is added or removed from a container view controller.
@@ -157,6 +172,12 @@
 
 - (void)destroy
 {
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
+    
     if (leaveRoomNotificationObserver)
     {
         [[NSNotificationCenter defaultCenter] removeObserver:leaveRoomNotificationObserver];

--- a/Riot/ViewController/RoomSettingsViewController.m
+++ b/Riot/ViewController/RoomSettingsViewController.m
@@ -147,6 +147,9 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
     
     // A copy of the banned members
     NSArray<MXRoomMember*> *bannedMembers;
+    
+    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 @end
 
@@ -159,7 +162,6 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
     _selectedRoomSettingsField = RoomSettingsViewControllerFieldNone;
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -232,6 +234,19 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
     self.tableView.estimatedRowHeight = 44;
     
     [self setNavBarButtons];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -332,6 +347,12 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
     {
         [actualDirectoryVisibilityRequest cancel];
         actualDirectoryVisibilityRequest = nil;
+    }
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
     }
     
     if (appDelegateDidTapStatusBarNotificationObserver)

--- a/Riot/ViewController/RoomViewController.m
+++ b/Riot/ViewController/RoomViewController.m
@@ -174,6 +174,9 @@
     
     // The search bar buttom item back up.
     UIBarButtonItem *searchBarButtonItem;
+    
+    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 
 @end
@@ -234,7 +237,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
     
@@ -402,6 +404,19 @@
     {
         [self refreshRoomInputToolbar];
     }
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 - (void)didReceiveMemoryWarning
@@ -1020,6 +1035,11 @@
     
     [self removeTypingNotificationsListener];
     
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
     if (kAppDelegateDidTapStatusBarNotificationObserver)
     {
         [[NSNotificationCenter defaultCenter] removeObserver:kAppDelegateDidTapStatusBarNotificationObserver];

--- a/Riot/ViewController/SegmentedViewController.m
+++ b/Riot/ViewController/SegmentedViewController.m
@@ -42,6 +42,9 @@
     // the selected marker view
     UIView* selectedMarkerView;
     NSLayoutConstraint *leftMarkerViewConstraint;
+    
+    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 
 @end
@@ -95,6 +98,12 @@
         selectedMarkerView = nil;
     }
     
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
+    
     [super destroy];
 }
 
@@ -119,7 +128,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -151,6 +159,19 @@
     [NSLayoutConstraint activateConstraints:@[self.selectionContainerTopConstraint]];
     
     [self createSegmentedViews];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Riot/ViewController/SettingsViewController.m
+++ b/Riot/ViewController/SettingsViewController.m
@@ -73,8 +73,9 @@ enum
 enum
 {
     USER_INTERFACE_LANGUAGE_INDEX = 0,
-    USER_INTERFACE_THEME_INDEX,
-    USER_INTERFACE_COUNT
+//    USER_INTERFACE_THEME_INDEX,
+    USER_INTERFACE_COUNT,
+    USER_INTERFACE_THEME_INDEX
 };
 
 enum
@@ -301,7 +302,12 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
         [self refreshSettings];
     }
     
-    [[UIApplication sharedApplication] setStatusBarStyle:kRiotDesignStatusBarStyle animated:NO];
+    [self setNeedsStatusBarAppearanceUpdate];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return kRiotDesignStatusBarStyle;
 }
 
 - (void)didReceiveMemoryWarning

--- a/Riot/ViewController/UsersDevicesViewController.m
+++ b/Riot/ViewController/UsersDevicesViewController.m
@@ -25,6 +25,9 @@
     MXSession *mxSession;
 
     void (^onCompleteBlock)(BOOL doneButtonPressed);
+    
+    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+    id kRiotDesignValuesDidChangeThemeNotificationObserver;
 }
 
 @end
@@ -43,7 +46,6 @@
     [super finalizeInit];
     
     // Setup `MXKViewControllerHandling` properties
-    self.defaultBarTintColor = kRiotNavBarTintColor;
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
 }
@@ -67,6 +69,30 @@
 
     // Hide line separators of empty cells
     self.tableView.tableFooterView = [[UIView alloc] init];
+    
+    // Observe user interface theme change.
+    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        [self userInterfaceThemeDidChange];
+        
+    }];
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
+    self.defaultBarTintColor = kRiotSecondaryBgColor;
+}
+
+- (void)destroy
+{
+    [super destroy];
+    
+    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
+        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Riot/Views/TableViewCell/TableViewCellWithCollectionView.m
+++ b/Riot/Views/TableViewCell/TableViewCellWithCollectionView.m
@@ -15,6 +15,7 @@
  */
 
 #import "TableViewCellWithCollectionView.h"
+#import "RiotDesignValues.h"
 
 @implementation TableViewCellWithCollectionView
 
@@ -23,6 +24,8 @@
     [super awakeFromNib];
     
     self.editionViewHeightConstraint.constant = 0;
+    
+    self.editionView.backgroundColor = kRiotSecondaryBgColor;
 }
 
 - (void)prepareForReuse


### PR DESCRIPTION
Remove the [UIApplication statusBarHidden] use (deprecated since iOS 9).
Use the default UIViewController-based status bar system.

Hide the user interface theme option in Settings.

https://github.com/vector-im/riot-meta/issues/22