### PR TITLE
PushKit support

### DIFF
--- a/Riot.xcodeproj/project.pbxproj
+++ b/Riot.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		32D392191EB9B7AB009A2BAF /* DirectoryServerDetailTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 32D392171EB9B7AB009A2BAF /* DirectoryServerDetailTableViewCell.xib */; };
 		32FD0A3D1EB0CD9B0072B066 /* BugReportViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FD0A3B1EB0CD9B0072B066 /* BugReportViewController.m */; };
 		32FD0A3E1EB0CD9B0072B066 /* BugReportViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 32FD0A3C1EB0CD9B0072B066 /* BugReportViewController.xib */; };
+		926FA53F1F4C132000F826C2 /* MXSession+Riot.m in Sources */ = {isa = PBXBuildFile; fileRef = 926FA53E1F4C132000F826C2 /* MXSession+Riot.m */; };
 		E2EAC1A4FBD6FE5228584591 /* libPods-Riot.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D8737F782E108CFD6908691 /* libPods-Riot.a */; };
 		F0131DE51F2200D600CBF707 /* RiotSplitViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F0131DE41F2200D600CBF707 /* RiotSplitViewController.m */; };
 		F02C1A861E8EB04C0045A404 /* PeopleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F02C1A841E8EB04C0045A404 /* PeopleViewController.m */; };
@@ -545,6 +546,8 @@
 		32FD0A3B1EB0CD9B0072B066 /* BugReportViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugReportViewController.m; sourceTree = "<group>"; };
 		32FD0A3C1EB0CD9B0072B066 /* BugReportViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BugReportViewController.xib; sourceTree = "<group>"; };
 		7D8737F782E108CFD6908691 /* libPods-Riot.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Riot.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		926FA53D1F4C132000F826C2 /* MXSession+Riot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MXSession+Riot.h"; sourceTree = "<group>"; };
+		926FA53E1F4C132000F826C2 /* MXSession+Riot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MXSession+Riot.m"; sourceTree = "<group>"; };
 		F0131DE31F2200D600CBF707 /* RiotSplitViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RiotSplitViewController.h; sourceTree = "<group>"; };
 		F0131DE41F2200D600CBF707 /* RiotSplitViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RiotSplitViewController.m; sourceTree = "<group>"; };
 		F02C1A831E8EB04C0045A404 /* PeopleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PeopleViewController.h; sourceTree = "<group>"; };
@@ -1521,6 +1524,8 @@
 				F083BBEA1E7009EC00A9B29C /* UINavigationController+Riot.m */,
 				F083BBEB1E7009EC00A9B29C /* UIViewController+RiotSearch.h */,
 				F083BBEC1E7009EC00A9B29C /* UIViewController+RiotSearch.m */,
+				926FA53D1F4C132000F826C2 /* MXSession+Riot.h */,
+				926FA53E1F4C132000F826C2 /* MXSession+Riot.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -2668,6 +2673,7 @@
 				F083BDF81E7009ED00A9B29C /* RoomDataSource.m in Sources */,
 				F083BE371E7009ED00A9B29C /* RoomActivitiesView.m in Sources */,
 				F083BE131E7009ED00A9B29C /* HomeMessagesSearchViewController.m in Sources */,
+				926FA53F1F4C132000F826C2 /* MXSession+Riot.m in Sources */,
 				F083BE8C1E7009ED00A9B29C /* PreviewRoomTitleView.m in Sources */,
 				F083BE271E7009ED00A9B29C /* SettingsViewController.m in Sources */,
 				F083BE9A1E7009ED00A9B29C /* TableViewCellWithButton.m in Sources */,

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -1054,9 +1054,6 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             [[UIApplication sharedApplication] scheduleLocalNotification:eventNotification];
         }
         
-        // Update icon badge number
-        [UIApplication sharedApplication].applicationIconBadgeNumber = [session riot_missedDiscussionsCount];
-        
         dispatch_block_t completionBlock = [weakSelf createPushNotificationHandlingStateCleaningBlock];
         weakSelf.pushNotificationHandlingCompletionBlock = completionBlock;
         
@@ -1087,6 +1084,9 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     
     return dispatch_block_create(0, ^{
         [session.notificationCenter removeListener:weakSelf.notificationListenerBlock];
+        
+        // Update icon badge number
+        [UIApplication sharedApplication].applicationIconBadgeNumber = [session riot_missedDiscussionsCount];
         
         id<MXBackgroundModeHandler> handler = [MXSDKOptions sharedInstance].backgroundModeHandler;
         

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -891,6 +891,9 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
 
 - (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
 {
+    if (notificationSettings.types == UIUserNotificationTypeNone)
+        return;
+    
     self.pushRegistry = [[PKPushRegistry alloc] initWithQueue:nil];
     self.pushRegistry.delegate = self;
     self.pushRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];
@@ -937,7 +940,6 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             NSLog(@"[AppDelegate] didReceiveLocalNotification : no linked session / account has been found.");
         }
     }
-
 }
 
 - (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(PKPushType)type

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -1057,6 +1057,22 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                 eventNotification.fireDate = [NSDate date];
                 eventNotification.alertBody = notificationBody;
                 eventNotification.userInfo = @{ @"room_id" : event.roomId };
+             
+                // Set sound name based on the value provided in action of MXPushRule
+                for (MXPushRuleAction *action in rule.actions)
+                {
+                    if (action.actionType == MXPushRuleActionTypeSetTweak)
+                    {
+                        if ([action.parameters[@"set_tweak"] isEqualToString:@"sound"])
+                        {
+                            NSString *soundName = action.parameters[@"value"];
+                            if ([soundName isEqualToString:@"default"])
+                                soundName = UILocalNotificationDefaultSoundName;
+                            
+                            eventNotification.soundName = soundName;
+                        }     
+                    }
+                }
                 
                 [[UIApplication sharedApplication] scheduleLocalNotification:eventNotification];
             }

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -43,6 +43,8 @@
 
 #import "CallViewController.h"
 
+#import "MXSession+Riot.h"
+
 //#define MX_CALL_STACK_OPENWEBRTC
 #ifdef MX_CALL_STACK_OPENWEBRTC
 #import <MatrixOpenWebRTCWrapper/MatrixOpenWebRTCWrapper.h>
@@ -1051,6 +1053,9 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             
             [[UIApplication sharedApplication] scheduleLocalNotification:eventNotification];
         }
+        
+        // Update icon badge number
+        [UIApplication sharedApplication].applicationIconBadgeNumber = [session riot_missedDiscussionsCount];
         
         dispatch_block_t completionBlock = [weakSelf createPushNotificationHandlingStateCleaningBlock];
         weakSelf.pushNotificationHandlingCompletionBlock = completionBlock;

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -1127,7 +1127,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             else if ([msgType isEqualToString:@"m.emote"])
                 notificationBody = [NSString stringWithFormat:NSLocalizedString(@"ACTION_FROM_USER_IN_ROOM", nil), roomDisplayName, eventSenderName, content];
             else if ([msgType isEqualToString:@"m.image"])
-                notificationBody = [NSString stringWithFormat:NSLocalizedString(@"IMAGE_FROM_USER_IN_ROOM", nil), eventSenderName, roomDisplayName];
+                notificationBody = [NSString stringWithFormat:NSLocalizedString(@"IMAGE_FROM_USER_IN_ROOM", nil), eventSenderName, content, roomDisplayName];
             else
                 // Unencrypted messages falls here
                 notificationBody = [NSString stringWithFormat:NSLocalizedString(@"MSG_FROM_USER_IN_ROOM", nil), eventSenderName, roomDisplayName];
@@ -1139,7 +1139,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             else if ([msgType isEqualToString:@"m.emote"])
                 notificationBody = [NSString stringWithFormat:NSLocalizedString(@"ACTION_FROM_USER", nil), eventSenderName, content];
             else if ([msgType isEqualToString:@"m.image"])
-                notificationBody = [NSString stringWithFormat:NSLocalizedString(@"IMAGE_FROM_USER", nil), eventSenderName];
+                notificationBody = [NSString stringWithFormat:NSLocalizedString(@"IMAGE_FROM_USER", nil), eventSenderName, content];
             else
                 // Unencrypted messages falls here
                 notificationBody = [NSString stringWithFormat:NSLocalizedString(@"MSG_FROM_USER", nil), eventSenderName];

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -318,6 +318,7 @@
 "settings_fail_to_update_profile" = "Fail to update profile";
 
 "settings_enable_push_notif" = "Notifications on this device";
+"settings_show_decrypted_content" = "Show decrypted content";
 "settings_global_settings_info" = "Global notification settings are available on your %@ web client";
 "settings_pin_rooms_with_missed_notif" = "Pin rooms with missed notifications";
 "settings_pin_rooms_with_unread" = "Pin rooms with unread messages";

--- a/Riot/Categories/MXSession+Riot.h
+++ b/Riot/Categories/MXSession+Riot.h
@@ -1,0 +1,28 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <MatrixSDK/MXSession.h>
+
+@interface MXSession (Riot)
+
+/**
+ The current number of rooms with missed notifications, including the invites.
+ */
+- (NSUInteger)riot_missedDiscussionsCount;
+
+@end

--- a/Riot/Categories/MXSession+Riot.m
+++ b/Riot/Categories/MXSession+Riot.m
@@ -1,0 +1,51 @@
+/*
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MXSession+Riot.h"
+
+#import "MXRoom+Riot.h"
+
+@implementation MXSession (Riot)
+
+- (NSUInteger)riot_missedDiscussionsCount
+{
+    NSUInteger missedDiscussionsCount = 0;
+    
+    // Sum all the rooms with missed notifications.
+    for (MXRoomSummary *roomSummary in self.roomsSummaries)
+    {
+        NSUInteger notificationCount = roomSummary.notificationCount;
+        
+        // Ignore the regular notification count if the room is in 'mentions only" mode at the Riot level.
+        if (roomSummary.room.isMentionsOnly)
+        {
+            // Only the highlighted missed messages must be considered here.
+            notificationCount = roomSummary.highlightCount;
+        }
+        
+        if (notificationCount)
+        {
+            missedDiscussionsCount++;
+        }
+    }
+    
+    // Add the invites count
+    missedDiscussionsCount += [self invitedRooms].count;
+    
+    return missedDiscussionsCount;
+}
+
+@end

--- a/Riot/ViewController/MasterTabBarController.m
+++ b/Riot/ViewController/MasterTabBarController.m
@@ -23,6 +23,7 @@
 #import "AppDelegate.h"
 
 #import "MXRoom+Riot.h"
+#import "MXSession+Riot.h"
 
 @interface MasterTabBarController ()
 {
@@ -424,26 +425,7 @@
     // Considering all the current sessions.
     for (MXSession *session in mxSessionArray)
     {
-        // Sum all the rooms with missed notifications.
-        for (MXRoomSummary *roomSummary in session.roomsSummaries)
-        {
-            NSUInteger notificationCount = roomSummary.notificationCount;
-            
-            // Ignore the regular notification count if the room is in 'mentions only" mode at the Riot level.
-            if (roomSummary.room.isMentionsOnly)
-            {
-                // Only the highlighted missed messages must be considered here.
-                notificationCount = roomSummary.highlightCount;
-            }
-            
-            if (notificationCount)
-            {
-                roomCount ++;
-            }
-        }
-        
-        // Add the invites count
-        roomCount += [session invitedRooms].count;
+        roomCount += [session riot_missedDiscussionsCount];
     }
     
     return roomCount;

--- a/Riot/ViewController/SettingsViewController.m
+++ b/Riot/ViewController/SettingsViewController.m
@@ -58,6 +58,7 @@ enum
 enum
 {
     NOTIFICATION_SETTINGS_ENABLE_PUSH_INDEX = 0,
+    NOTIFICATION_SETTINGS_SHOW_DECODED_CONTENT,
     NOTIFICATION_SETTINGS_GLOBAL_SETTINGS_INDEX,
     NOTIFICATION_SETTINGS_PIN_MISSED_NOTIFICATIONS_INDEX,
     NOTIFICATION_SETTINGS_PIN_UNREAD_INDEX,
@@ -1564,6 +1565,18 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
             
             cell = labelAndSwitchCell;
         }
+        else if (row == NOTIFICATION_SETTINGS_SHOW_DECODED_CONTENT)
+        {
+            MXKTableViewCellWithLabelAndSwitch* labelAndSwitchCell = [self getLabelAndSwitchCell:tableView forIndexPath:indexPath];
+            
+            labelAndSwitchCell.mxkLabel.text = NSLocalizedStringFromTable(@"settings_show_decrypted_content", @"Vector", nil);
+            labelAndSwitchCell.mxkSwitch.on = account.showDecryptedContentInNotifications;
+            labelAndSwitchCell.mxkSwitch.enabled = account.pushNotificationServiceIsActive;
+            [labelAndSwitchCell.mxkSwitch removeTarget:self action:nil forControlEvents:UIControlEventValueChanged];
+            [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleShowDecodedContent:) forControlEvents:UIControlEventValueChanged];
+            
+            cell = labelAndSwitchCell;
+        }
         else if (row == NOTIFICATION_SETTINGS_GLOBAL_SETTINGS_INDEX)
         {
             MXKTableViewCell *globalInfoCell = [self getDefaultTableViewCell:tableView];
@@ -2507,6 +2520,12 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
         // toggle the pushes
         [account setEnablePushNotifications:!account.pushNotificationServiceIsActive];
     }
+}
+
+- (void)toggleShowDecodedContent:(id)sender
+{
+    MXKAccount* account = [MXKAccountManager sharedManager].activeAccounts.firstObject;
+    account.showDecryptedContentInNotifications = !account.showDecryptedContentInNotifications;
 }
 
 - (void)toggleLocalContactsSync:(id)sender


### PR DESCRIPTION
To test PushKit notifications on your local machine change bundle id of the project to **im.vector.pushtest**. Perform changes in `initMatrixSession` to allow calling` [accountManager prepareSessionForActiveAccounts]` even in background mode. Also you will need a pem certificate which can be provided to you by me or Dave. To send pushes i use [Houston](https://github.com/nomad/houston).

Initially PushKit must be used only for VoIP notifications, but then it was decided to use it for all types of notifications in Riot. So the purpose of this is PR to provide this level of support.

The flow of registering for notifications didn't change a lot. There're new methods which replaced the old one. All of them belongs to `PKPushRegistryDelegate` protocol:

`pushRegistry:didUpdatePushCredentials:forType:`
`pushRegistry:didInvalidatePushTokenForType:`
`pushRegistry:didReceiveIncomingPushWithPayload:forType:`

To be able to handle PushKit notifications we create a `PushRegistry` instance, set AppDelegate as its delegate and hold for entire life of the app.

We subscribe for events from MXNotificationCenter instance of active MXSession when a new push is received. On arriving of each event an alert body string is created and then local notification is displayed.

Since we have a deal with network i add a delay for two cases:
1. There is a `pushNotificationHandlingTimeoutBlock` which is called when server sync takes a lot of time. 
2. `pushNotificationHandlingCompletionBlock` is called with delay after push event has been successfully processed. I added delay here to support handling of series incoming pushes. `Push1->Push1 has been handled->Schedule Push1 completion block->Push2->Cancel Push1 completion block->Wait for Push2 event...`

I set a random constants for these delays, so i'm glad to hear your proposals.

The list of possible cases we can meet:

1. Receive push -> start listening for push events from server sync response -> schedule timeout block -> cancel timeout block -> handle push event -> schedule completion block -> execute completion block -> end

2. Receive push -> start listening for push events from server sync response -> schedule timeout block -> execute timeout block -> end

3. Receive push -> start listening for push events from server sync response -> schedule timeout block -> cancel timeout block -> handle push event -> schedule completion block -> receive new push -> cancel completion block -> schedule timeout block -> wait for new push event from server

4. Receive push -> start listening for push events from server sync response -> schedule timeout block -> new push -> cancel timeout block -> schedule new timeout block -> cancel timeout block -> handle push event (from 1st push) -> schedule completion block -> | WAITING TIME | -> 

We have two ways to continue:
-> execute completion block (1st push event) -> end (2nd push event won't be handled) **PROBLEM**
-> cancel completion block  -> receive new push event (from 2nd push) -> schedule new completion block -> end

If we won't receive any events before completion block of first push event would be called we will lose second push event.

5. Receive push -> start listening for push events from server sync response -> schedule timeout block -> cancel timeout block -> handle push event (contains event for future push) -> schedule completion block -> receive push -> cancel completion block -> schedule timeout block -> execute timeout block -> end

Signed-off-by: Denis Morozov dmorozkn@gmail.com