### PR TITLE
Improvements in notification registration flow

### DIFF
--- a/Riot/AppDelegate.h
+++ b/Riot/AppDelegate.h
@@ -116,6 +116,13 @@ extern NSString *const kAppDelegateNetworkStatusDidChangeNotification;
 
 - (void)registerUserNotificationSettings;
 
+/**
+ Perform registration for remote notifications.
+ 
+ @param completion the block to be executed when registration finished.
+ */
+- (void)registerForRemoteNotificationsWithCompletion:(void (^)(NSError *))completion;
+
 #pragma mark - Matrix Room handling
 
 - (void)showRoom:(NSString*)roomId andEventId:(NSString*)eventId withMatrixSession:(MXSession*)mxSession;


### PR DESCRIPTION
There is a problem:
Imagine that you disabled notifications for Riot on a system level, then when you'll try enable them on the settings screen and you'll see an alert which advices you to go to the system settings and enable them there. After you did that you return to the Riot and will try to enable them again but you will see the same alert.

Also if user has disabled notification between launches we don't delete stored push token, so server will send pushes, but we can't process them, since we don't have access to notifications.

It will be better to merge this with PushKit in the future.

Signed-off-by: Denis Morozov dmorozkn@gmail.com