### PR TITLE
Fix issue #1480

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -2469,6 +2469,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             
             // Release properly
             [currentCallViewController destroy];
+            currentCallViewController = nil;
             
             if (completion)
             {


### PR DESCRIPTION
See #1480 

It can also fix:
> sometimes you would accept a call and the green phone icon next to the input textbox will change to a red "hang up" icon, but no "call screen" or "green call header bar at the top" would come up. You'd be looking at the chat and be able to talk (and hang up from that red "hang up" icon), but you won't be able to bring up that "call screen".

Signed-off-by: Denis Morozov dmorozkn@gmail.com