### PR TITLE
Return key on hardware keyboards now sends messages

### DIFF
--- a/Riot.xcodeproj/project.pbxproj
+++ b/Riot.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		32FD0A3D1EB0CD9B0072B066 /* BugReportViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 32FD0A3B1EB0CD9B0072B066 /* BugReportViewController.m */; };
 		32FD0A3E1EB0CD9B0072B066 /* BugReportViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 32FD0A3C1EB0CD9B0072B066 /* BugReportViewController.xib */; };
 		92324BE31F4F66D3009DE194 /* IncomingCallView.m in Sources */ = {isa = PBXBuildFile; fileRef = 92324BE21F4F66D3009DE194 /* IncomingCallView.m */; };
+		83711A7C1F6F8E7D008F0D4D /* KeyboardGrowingTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 83711A7B1F6F8E7D008F0D4D /* KeyboardGrowingTextView.m */; };
 		92324BE61F4F6A60009DE194 /* CircleButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 92324BE51F4F6A60009DE194 /* CircleButton.m */; };
 		A27ECCE3FC4971745D2CB78D /* libPods-RiotShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7246451C668D6782166E22EC /* libPods-RiotShareExtension.a */; };
 		F0131DE51F2200D600CBF707 /* RiotSplitViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F0131DE41F2200D600CBF707 /* RiotSplitViewController.m */; };
@@ -658,6 +659,7 @@
 		32FD0A3C1EB0CD9B0072B066 /* BugReportViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BugReportViewController.xib; sourceTree = "<group>"; };
 		7246451C668D6782166E22EC /* libPods-RiotShareExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RiotShareExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		765F5104DB3EC39713DEB3A4 /* Pods-RiotShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RiotShareExtension.release.xcconfig"; path = "Pods/Target Support Files/Pods-RiotShareExtension/Pods-RiotShareExtension.release.xcconfig"; sourceTree = "<group>"; };
+		83711A7B1F6F8E7D008F0D4D /* KeyboardGrowingTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeyboardGrowingTextView.m; sourceTree = "<group>"; };
 		839BB91240D350D5607D55BA /* Pods-Riot.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Riot.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Riot/Pods-Riot.debug.xcconfig"; sourceTree = "<group>"; };
 		92324BE11F4F66D3009DE194 /* IncomingCallView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IncomingCallView.h; sourceTree = "<group>"; };
 		92324BE21F4F66D3009DE194 /* IncomingCallView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IncomingCallView.m; sourceTree = "<group>"; };
@@ -2193,6 +2195,7 @@
 				F083BCD91E7009EC00A9B29C /* RoomInputToolbarView.h */,
 				F083BCDA1E7009EC00A9B29C /* RoomInputToolbarView.m */,
 				F083BCDB1E7009EC00A9B29C /* RoomInputToolbarView.xib */,
+				83711A7B1F6F8E7D008F0D4D /* KeyboardGrowingTextView.m */,
 			);
 			path = RoomInputToolbar;
 			sourceTree = "<group>";
@@ -3092,6 +3095,7 @@
 				3205ED7D1E976C8A003D65FA /* DirectoryServerPickerViewController.m in Sources */,
 				F083BE7C1E7009ED00A9B29C /* DirectoryRecentTableViewCell.m in Sources */,
 				F0E05A031E963103004B83FB /* RoomsViewController.m in Sources */,
+				83711A7C1F6F8E7D008F0D4D /* KeyboardGrowingTextView.m in Sources */,
 				F083BE801E7009ED00A9B29C /* PublicRoomTableViewCell.m in Sources */,
 				322806A01F0F64C4008C53D7 /* RoomMembershipExpandedBubbleCell.m in Sources */,
 				F083BE031E7009ED00A9B29C /* EventFormatter.m in Sources */,

--- a/Riot/Views/RoomInputToolbar/KeyboardGrowingTextView.m
+++ b/Riot/Views/RoomInputToolbar/KeyboardGrowingTextView.m
@@ -1,0 +1,51 @@
+/*
+ Copyright 2015 OpenMarket Ltd
+ Copyright 2017 Vector Creations Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <HPGrowingTextView.h>
+#import "RoomInputToolbarView.h"
+
+@interface KeyboardGrowingTextView: HPGrowingTextView
+- (NSArray<UIKeyCommand *> *)keyCommands;
+@end
+
+@implementation KeyboardGrowingTextView
+
+- (NSArray<UIKeyCommand *> *)keyCommands {
+    return @[
+             [UIKeyCommand keyCommandWithInput:@"\r" modifierFlags:0 action:@selector(keyCommandSelector:)]
+            ];
+}
+
+- (void)keyCommandSelector:(UIKeyCommand *)sender {
+    if ([sender.input isEqualToString:@"\r"]){
+        // traverse the view hierarchy to get the RoomInputToolbarView
+        UIView *sv = [self superview];
+        int remainingDepth = 3; // give up after going up 3 levels.
+    
+        while((sv = [sv superview]) && remainingDepth > 0) {
+            if ([sv class] == [RoomInputToolbarView class]){
+                RoomInputToolbarView *ritv = (RoomInputToolbarView *)sv;
+                [ritv onTouchUpInside:ritv.rightInputToolbarButton]; // touch the Send button.
+                return;
+            }
+            remainingDepth--;
+        }
+    }
+}
+
+@end

--- a/Riot/Views/RoomInputToolbar/KeyboardGrowingTextView.m
+++ b/Riot/Views/RoomInputToolbar/KeyboardGrowingTextView.m
@@ -32,19 +32,9 @@
 }
 
 - (void)keyCommandSelector:(UIKeyCommand *)sender {
-    if ([sender.input isEqualToString:@"\r"]){
-        // traverse the view hierarchy to get the RoomInputToolbarView
-        UIView *sv = [self superview];
-        int remainingDepth = 3; // give up after going up 3 levels.
-    
-        while((sv = [sv superview]) && remainingDepth > 0) {
-            if ([sv class] == [RoomInputToolbarView class]){
-                RoomInputToolbarView *ritv = (RoomInputToolbarView *)sv;
-                [ritv onTouchUpInside:ritv.rightInputToolbarButton]; // touch the Send button.
-                return;
-            }
-            remainingDepth--;
-        }
+    if ([sender.input isEqualToString:@"\r"] && [self.delegate isKindOfClass: RoomInputToolbarView.class]){
+        RoomInputToolbarView *ritv = (RoomInputToolbarView *)self.delegate;
+        [ritv onTouchUpInside:ritv.rightInputToolbarButton]; // touch the Send button.
     }
 }
 

--- a/Riot/Views/RoomInputToolbar/RoomInputToolbarView.xib
+++ b/Riot/Views/RoomInputToolbar/RoomInputToolbarView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>

--- a/Riot/Views/RoomInputToolbar/RoomInputToolbarView.xib
+++ b/Riot/Views/RoomInputToolbar/RoomInputToolbarView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -46,7 +46,7 @@
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QWp-NV-uh5" userLabel="Message Composer Container">
                             <rect key="frame" x="62" y="4" width="443" height="38"/>
                             <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wgb-ON-N29" customClass="HPGrowingTextView">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wgb-ON-N29" customClass="KeyboardGrowingTextView">
                                     <rect key="frame" x="0.0" y="0.0" width="443" height="38"/>
                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                     <accessibility key="accessibilityConfiguration" identifier="GrowingTextView"/>


### PR DESCRIPTION
Signed-off-by: Vivian Lim <vivvnlim@gmail.com>

Create a class KeyboardGrowingTextView which inherits from HPGrowingTextView, but defines keyCommands. keyCommands defined at any other view or controller layer weren’t being picked up by the OS, but they did work when added to HPGrowingTextView.

I was able to validate this on my machine based on release-v0.5.1 but I can't figure out how to build the project after the App Extension was added. If you have any tips please let me know.

Also let me know if you have any ideas on better ways to call from KeyboardGrowingTextView to RoomInputToolbarView, or why defining keyCommands at any other layer didn't work (I had trouble pinning down exactly which class is the First Responder, and where the OS was looking for keyCommands)