### PR TITLE
Pushkit: Remove APNS use.

### DIFF
--- a/Riot/AppDelegate.h
+++ b/Riot/AppDelegate.h
@@ -43,7 +43,7 @@ extern NSString *const kAppDelegateNetworkStatusDidChangeNotification;
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate, MXKCallViewControllerDelegate, UISplitViewControllerDelegate, UINavigationControllerDelegate, JitsiViewControllerDelegate>
 {
-    BOOL isAPNSRegistered;
+    BOOL isPushRegistered;
     
     // background sync management
     void (^_completionHandler)(UIBackgroundFetchResult);
@@ -112,7 +112,7 @@ extern NSString *const kAppDelegateNetworkStatusDidChangeNotification;
 - (void)startGoogleAnalytics;
 - (void)stopGoogleAnalytics;
 
-#pragma mark - APNS methods
+#pragma mark - Push notifications
 
 - (void)registerUserNotificationSettings;
 

--- a/Riot/Riot-Defaults.plist
+++ b/Riot/Riot-Defaults.plist
@@ -12,6 +12,8 @@
 	<string>im.vector.app.ios.dev</string>
 	<key>pusherAppIdProd</key>
 	<string>im.vector.app.ios.prod</string>
+	<key>pushKitAppIdProd</key>
+	<string>im.vector.app.ios.voip.prod</string>
 	<key>identityserverurl</key>
 	<string>https://vector.im</string>
 	<key>homeserverurl</key>
@@ -28,8 +30,6 @@
 	<string>https://scalar-staging.riot.im/scalar-web/</string>
 	<key>integrationsRestUrl</key>
 	<string>https://scalar-staging.riot.im/scalar/api</string>
-	<key>apnsDeviceToken</key>
-	<string></string>
 	<key>showAllEventsInRoomHistory</key>
 	<false/>
 	<key>showRedactionsInRoomHistory</key>

--- a/Riot/ViewController/SettingsViewController.m
+++ b/Riot/ViewController/SettingsViewController.m
@@ -133,7 +133,7 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
     // listener
     id removedAccountObserver;
     id accountUserInfoObserver;
-    id apnsInfoUpdateObserver;
+    id pushInfoUpdateObserver;
     
     id notificationCenterWillUpdateObserver;
     id notificationCenterDidUpdateObserver;
@@ -283,8 +283,8 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
         
     }];
     
-    // Add observer to apns
-    apnsInfoUpdateObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXKAccountAPNSActivityDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+    // Add observer to push settings
+    pushInfoUpdateObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXKAccountPushKitActivityDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
         
         [self stopActivityIndicator];
         
@@ -533,10 +533,10 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
         accountUserInfoObserver = nil;
     }
     
-    if (apnsInfoUpdateObserver)
+    if (pushInfoUpdateObserver)
     {
-        [[NSNotificationCenter defaultCenter] removeObserver:apnsInfoUpdateObserver];
-        apnsInfoUpdateObserver = nil;
+        [[NSNotificationCenter defaultCenter] removeObserver:pushInfoUpdateObserver];
+        pushInfoUpdateObserver = nil;
     }
     
     [[NSNotificationCenter defaultCenter] removeObserver:self];
@@ -1633,7 +1633,7 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
             MXKTableViewCellWithLabelAndSwitch* labelAndSwitchCell = [self getLabelAndSwitchCell:tableView forIndexPath:indexPath];
     
             labelAndSwitchCell.mxkLabel.text = NSLocalizedStringFromTable(@"settings_enable_push_notif", @"Vector", nil);
-            labelAndSwitchCell.mxkSwitch.on = account.pushNotificationServiceIsActive;
+            labelAndSwitchCell.mxkSwitch.on = account.isPushKitNotificationActive;
             labelAndSwitchCell.mxkSwitch.enabled = YES;
             [labelAndSwitchCell.mxkSwitch removeTarget:self action:nil forControlEvents:UIControlEventTouchUpInside];
             [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(togglePushNotifications:) forControlEvents:UIControlEventTouchUpInside];
@@ -1646,7 +1646,7 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
             
             labelAndSwitchCell.mxkLabel.text = NSLocalizedStringFromTable(@"settings_show_decrypted_content", @"Vector", nil);
             labelAndSwitchCell.mxkSwitch.on = account.showDecryptedContentInNotifications;
-            labelAndSwitchCell.mxkSwitch.enabled = account.pushNotificationServiceIsActive;
+            labelAndSwitchCell.mxkSwitch.enabled = account.isPushKitNotificationActive;
             [labelAndSwitchCell.mxkSwitch removeTarget:self action:nil forControlEvents:UIControlEventTouchUpInside];
             [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleShowDecodedContent:) forControlEvents:UIControlEventTouchUpInside];
             
@@ -2713,9 +2713,9 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
         MXKAccountManager *accountManager = [MXKAccountManager sharedManager];
         MXKAccount* account = accountManager.activeAccounts.firstObject;
         
-        if (accountManager.apnsDeviceToken)
+        if (accountManager.pushDeviceToken)
         {
-            [account setEnablePushNotifications:!account.pushNotificationServiceIsActive];
+            [account setEnablePushKitNotifications:!account.isPushKitNotificationActive];
         }
         else
         {
@@ -2728,7 +2728,7 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
                 }
                 else
                 {
-                    [account setEnablePushNotifications:YES];
+                    [account setEnablePushKitNotifications:YES];
                 }
             }];
         }


### PR DESCRIPTION
Use new MXKAccount API to handle push token and settings.
- add format: 'event_id_only' to the data dict when you add the pusher
- use the following app ID: im.vector.app.ios.voip.prod