### PR TITLE
BF: [iOS11] "Smart [colors] Invert" renders badly in the app

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -516,6 +516,12 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     [self refreshLocalContacts];
     
     _isAppForeground = YES;
+
+    if (@available(iOS 11.0, *))
+    {
+        // Riot has its own dark theme. Prevent iOS from applying its one
+        [[UIApplication sharedApplication] keyWindow].accessibilityIgnoresInvertColors = YES;
+    }
     
     [self handleLaunchAnimation];
 }

--- a/Riot/Assets/de.lproj/Vector.strings
+++ b/Riot/Assets/de.lproj/Vector.strings
@@ -416,8 +416,6 @@
 "auth_email_not_found" = "Fehler beim Senden der E-Mail: Die E-Mail-Adresse wurde nicht gefunden";
 "settings_user_interface" = "BENUTZEROBERFLÄCHE";
 "settings_ui_language" = "Sprache";
-"settings_ui_light_theme" = "Helles Design";
-"settings_ui_dark_theme" = "Dunkles Design";
 // Events formatter
 "event_formatter_member_updates" = "%tu Änderungen der Mitgliedschaft";
 "contacts_user_directory_section" = "NUTZER VERZEICHNIS";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -340,8 +340,12 @@
 //"settings_call_invitations" = "Call invitations";
 
 "settings_ui_language" = "Language";
-"settings_ui_light_theme" = "Light theme";
-"settings_ui_dark_theme" = "Dark theme";
+"settings_ui_theme" = "Theme";
+"settings_ui_theme_auto" = "Auto";
+"settings_ui_theme_light" = "Light";
+"settings_ui_theme_dark" = "Dark";
+"settings_ui_theme_picker_title" = "Select a theme";
+"settings_ui_theme_picker_message" = "\"Auto\" uses your device \"Invert Colours\" settings";
 
 "settings_unignore_user" = "Show all messages from %@?";
 

--- a/Riot/Assets/fr.lproj/Vector.strings
+++ b/Riot/Assets/fr.lproj/Vector.strings
@@ -417,8 +417,12 @@
 "auth_phone_in_use" = "Ce numéro de téléphone est déjà utilisé";
 "auth_email_not_found" = "Échec lors de l'envoi de l'e-mail : Cette adresse e-mail n'a pas pu être trouvée";
 "settings_ui_language" = "Langue";
-"settings_ui_light_theme" = "Thème clair";
-"settings_ui_dark_theme" = "Thème sombre";
+"settings_ui_theme" = "Thème";
+"settings_ui_theme_auto" = "Auto";
+"settings_ui_theme_light" = "Clair";
+"settings_ui_theme_dark" = "Sombre";
+"settings_ui_theme_picker_title" = "Selectionnez un thème";
+"settings_ui_theme_picker_message" = "\"Auto\" utilise le paramètre \"Inverser les couleurs\" de votre appareil";
 "collapse" = "réduire";
 "auth_untrusted_id_server" = "Le serveur d'identité n'est pas fiable";
 "settings_user_interface" = "INTERFACE UTILISATEUR";

--- a/Riot/Assets/nl.lproj/Vector.strings
+++ b/Riot/Assets/nl.lproj/Vector.strings
@@ -440,8 +440,6 @@
 "contacts_user_directory_offline_section" = "GEBRUIKERSADRESBOEK (offline)";
 "settings_user_interface" = "GEBRUIKERSINTERFACE";
 "settings_ui_language" = "Taal";
-"settings_ui_light_theme" = "Lichte thema";
-"settings_ui_dark_theme" = "Donkere thema";
 // Read Receipts
 "read_receipts_list" = "Leesbewijzen Lijst";
 "receipt_status_read" = "Lees: ";

--- a/Riot/Assets/ru.lproj/Vector.strings
+++ b/Riot/Assets/ru.lproj/Vector.strings
@@ -262,8 +262,6 @@
 "settings_global_settings_info" = "Глобальные настройки уведомлений доступны в вашем %@ веб-клиенте";
 "settings_on_denied_notification" = "Уведомления для %@ запрещены, пожалуйста, разрешите их в настройках вашего устройства";
 "settings_ui_language" = "Язык";
-"settings_ui_light_theme" = "Светлая тема";
-"settings_ui_dark_theme" = "Темная тема";
 "settings_unignore_user" = "Показать все сообщения от %@?";
 "settings_labs_e2e_encryption" = "Сквозное шифрование";
 "settings_labs_e2e_encryption_prompt_message" = "Чтобы завершить настройку шифрования, вы должны войти в систему еще раз.";

--- a/Riot/Utils/RiotDesignValues.m
+++ b/Riot/Utils/RiotDesignValues.m
@@ -112,8 +112,10 @@ UIColor *kRiotDesignSearchBarTintColor = nil;
     // Observe user interface theme change.
     [[NSUserDefaults standardUserDefaults] addObserver:[RiotDesignValues sharedInstance] forKeyPath:@"userInterfaceTheme" options:0 context:nil];
     [[RiotDesignValues sharedInstance] userInterfaceThemeDidChange];
-}
 
+    // Observe "Invert Colours" settings changes (available since iOS 11)
+    [[NSNotificationCenter defaultCenter] addObserver:[RiotDesignValues sharedInstance] selector:@selector(accessibilityInvertColorsStatusDidChange) name:UIAccessibilityInvertColorsStatusDidChangeNotification object:nil];
+}
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
@@ -123,10 +125,25 @@ UIColor *kRiotDesignSearchBarTintColor = nil;
     }
 }
 
+- (void)accessibilityInvertColorsStatusDidChange
+{
+    // Refresh the theme only for "auto"
+    NSString *theme = [[NSUserDefaults standardUserDefaults] stringForKey:@"userInterfaceTheme"];
+    if (!theme || [theme isEqualToString:@"auto"])
+    {
+        [self userInterfaceThemeDidChange];
+    }
+}
+
 - (void)userInterfaceThemeDidChange
 {
-    // Retrieve the current selected theme ("light" if none).
+    // Retrieve the current selected theme ("light" if none. "auto" is used as default from iOS 11).
     NSString *theme = [[NSUserDefaults standardUserDefaults] stringForKey:@"userInterfaceTheme"];
+
+    if (!theme || [theme isEqualToString:@"auto"])
+    {
+        theme = UIAccessibilityIsInvertColorsEnabled() ? @"dark" : @"light";
+    }
     
     // Currently only 2 themes is supported
     if ([theme isEqualToString:@"dark"])

--- a/Riot/Utils/Widgets/Widget.m
+++ b/Riot/Utils/Widgets/Widget.m
@@ -41,22 +41,25 @@
         MXJSONModelSetDictionary(_data, widgetEvent.content[@"data"]);
 
         // Format the url string with user data
-        _url = [_url stringByReplacingOccurrencesOfString:@"$matrix_user_id" withString:mxSession.myUser.userId];
-        _url = [_url stringByReplacingOccurrencesOfString:@"$matrix_display_name"
-                                               withString:mxSession.myUser.displayname ? mxSession.myUser.displayname : mxSession.myUser.userId];
-        _url = [_url stringByReplacingOccurrencesOfString:@"$matrix_avatar_url"
-                                               withString:mxSession.myUser.avatarUrl ? mxSession.myUser.avatarUrl : @""];
+        if (_url)
+        {
+            _url = [_url stringByReplacingOccurrencesOfString:@"$matrix_user_id" withString:mxSession.myUser.userId];
+            _url = [_url stringByReplacingOccurrencesOfString:@"$matrix_display_name"
+                                                   withString:mxSession.myUser.displayname ? mxSession.myUser.displayname : mxSession.myUser.userId];
+            _url = [_url stringByReplacingOccurrencesOfString:@"$matrix_avatar_url"
+                                                   withString:mxSession.myUser.avatarUrl ? mxSession.myUser.avatarUrl : @""];
 
-        // And their scalar token
-        NSString *scalarToken = [[WidgetManager sharedManager] scalarTokenForMXSession:mxSession];
-        if (scalarToken)
-        {
-            _url = [_url stringByAppendingString:[NSString stringWithFormat:@"&scalar_token=%@", scalarToken]];
-        }
-        else
-        {
-            // Some widget can live without scalar token (ex: Jitsi widget)
-            NSLog(@"[Widget] Note: There is no scalar token for %@", self);
+            // And their scalar token
+            NSString *scalarToken = [[WidgetManager sharedManager] scalarTokenForMXSession:mxSession];
+            if (scalarToken)
+            {
+                _url = [_url stringByAppendingString:[NSString stringWithFormat:@"&scalar_token=%@", scalarToken]];
+            }
+            else
+            {
+                // Some widget can live without scalar token (ex: Jitsi widget)
+                NSLog(@"[Widget] Note: There is no scalar token for %@", self);
+            }
         }
     }
 

--- a/Riot/ViewController/SettingsViewController.h
+++ b/Riot/ViewController/SettingsViewController.h
@@ -19,9 +19,8 @@
 #import "DeviceView.h"
 
 #import "MediaPickerViewController.h"
-#import "TableViewCellWithCheckBoxes.h"
 
-@interface SettingsViewController : MXKTableViewController<UITextFieldDelegate, MediaPickerViewControllerDelegate, MXKDeviceViewDelegate, UIDocumentInteractionControllerDelegate, MXKCountryPickerViewControllerDelegate, MXKLanguagePickerViewControllerDelegate, TableViewCellWithCheckBoxesDelegate>
+@interface SettingsViewController : MXKTableViewController<UITextFieldDelegate, MediaPickerViewControllerDelegate, MXKDeviceViewDelegate, UIDocumentInteractionControllerDelegate, MXKCountryPickerViewControllerDelegate, MXKLanguagePickerViewControllerDelegate>
 
 @end
 

--- a/Riot/ViewController/SettingsViewController.m
+++ b/Riot/ViewController/SettingsViewController.m
@@ -205,9 +205,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
     BOOL keepNewEmailEditing;
     BOOL keepNewPhoneNumberEditing;
     
-    // The user interface theme cell
-    TableViewCellWithCheckBoxes *uiThemeCell;
-    
     // The current pushed view controller
     UIViewController *pushedViewController;
 }
@@ -250,7 +247,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
     [self.tableView registerClass:MXKTableViewCellWithLabelAndSwitch.class forCellReuseIdentifier:[MXKTableViewCellWithLabelAndSwitch defaultReuseIdentifier]];
     [self.tableView registerClass:MXKTableViewCellWithLabelAndMXKImageView.class forCellReuseIdentifier:[MXKTableViewCellWithLabelAndMXKImageView defaultReuseIdentifier]];
     [self.tableView registerClass:TableViewCellWithPhoneNumberTextField.class forCellReuseIdentifier:[TableViewCellWithPhoneNumberTextField defaultReuseIdentifier]];
-    [self.tableView registerClass:TableViewCellWithCheckBoxes.class forCellReuseIdentifier:[TableViewCellWithCheckBoxes defaultReuseIdentifier]];
     
     // Enable self sizing cells
     self.tableView.rowHeight = UITableViewAutomaticDimension;
@@ -3498,7 +3494,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
                                            style:UIAlertActionStyleDefault
                                          handler:actionBlock];
 
-    // Ask the user the kind of the call: voice or video?
     UIAlertController *themePicker = [UIAlertController alertControllerWithTitle:NSLocalizedStringFromTable(@"settings_ui_theme_picker_title", @"Vector", nil)
                                                                          message:themePickerMessage
                                                                   preferredStyle:UIAlertControllerStyleActionSheet];
@@ -3514,6 +3509,10 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
     [themePicker addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"cancel"]
                                                         style:UIAlertActionStyleDefault
                                                       handler:nil]];
+
+    UIView *fromCell = [self.tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:USER_INTERFACE_THEME_INDEX inSection:SETTINGS_SECTION_USER_INTERFACE_INDEX]];
+    [themePicker popoverPresentationController].sourceView = fromCell;
+    [themePicker popoverPresentationController].sourceRect = fromCell.bounds;
 
     [self presentViewController:themePicker animated:YES completion:nil];
 }
@@ -3855,12 +3854,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
             [[AppDelegate theDelegate] reloadMatrixSessions:NO];
         });
     }
-}
-
-#pragma mark - TableViewCellWithCheckBoxesDelegate
-
-- (void)tableViewCellWithCheckBoxes:(TableViewCellWithCheckBoxes *)tableViewCellWithCheckBoxes didTapOnCheckBoxAtIndex:(NSUInteger)index
-{
 }
 
 @end


### PR DESCRIPTION
https://github.com/vector-im/riot-ios/issues/1524

- the app does its own dark theme and prevents the OS from automatically revert the colors in the app
- there are 3 choices on iOS11 for the Riot theme: "auto", "light", "dark". "auto" uses the system settings