### PR TITLE
Fix - Room member details: the member's avatar is cropped in the header

### DIFF
--- a/Riot/ViewController/RoomMemberDetailsViewController.m
+++ b/Riot/ViewController/RoomMemberDetailsViewController.m
@@ -118,6 +118,58 @@
     [super viewDidLoad];
     // Do any additional setup after loading the view, typically from a nib.
     
+    if (@available(iOS 11.0, *))
+    {
+        // Define directly the navigation titleView with the custom title view instance. Do not use anymore a container.
+        memberTitleView = [RoomMemberTitleView roomMemberTitleView];
+        self.navigationItem.titleView = memberTitleView;
+    }
+    else
+    {
+        self.navigationItem.titleView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 600, 40)];
+        
+        memberTitleView = [RoomMemberTitleView roomMemberTitleView];
+        
+        // Add the title view and define edge constraints
+        memberTitleView.translatesAutoresizingMaskIntoConstraints = NO;
+        [self.navigationItem.titleView addSubview:memberTitleView];
+        
+        NSLayoutConstraint *topConstraint = [NSLayoutConstraint constraintWithItem:memberTitleView
+                                                                         attribute:NSLayoutAttributeTop
+                                                                         relatedBy:NSLayoutRelationEqual
+                                                                            toItem:self.navigationItem.titleView
+                                                                         attribute:NSLayoutAttributeTop
+                                                                        multiplier:1.0f
+                                                                          constant:0.0f];
+        NSLayoutConstraint *bottomConstraint = [NSLayoutConstraint constraintWithItem:memberTitleView
+                                                                            attribute:NSLayoutAttributeBottom
+                                                                            relatedBy:NSLayoutRelationEqual
+                                                                               toItem:self.navigationItem.titleView
+                                                                            attribute:NSLayoutAttributeBottom
+                                                                           multiplier:1.0f
+                                                                             constant:0.0f];
+        NSLayoutConstraint *leadingConstraint = [NSLayoutConstraint constraintWithItem:memberTitleView
+                                                                             attribute:NSLayoutAttributeLeading
+                                                                             relatedBy:NSLayoutRelationEqual
+                                                                                toItem:self.navigationItem.titleView
+                                                                             attribute:NSLayoutAttributeLeading
+                                                                            multiplier:1.0f
+                                                                              constant:0.0f];
+        NSLayoutConstraint *trailingConstraint = [NSLayoutConstraint constraintWithItem:memberTitleView
+                                                                              attribute:NSLayoutAttributeTrailing
+                                                                              relatedBy:NSLayoutRelationEqual
+                                                                                 toItem:self.navigationItem.titleView
+                                                                              attribute:NSLayoutAttributeTrailing
+                                                                             multiplier:1.0f
+                                                                               constant:0.0f];
+        
+        [NSLayoutConstraint activateConstraints:@[topConstraint, bottomConstraint, leadingConstraint, trailingConstraint]];
+    }
+    
+    // Handle the member avatar at the view controller level.
+    self.memberThumbnail = memberTitleView.memberAvatar;
+    
+    // Add tap gesture on member's name
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapGesture:)];
     [tap setNumberOfTouchesRequired:1];
     [tap setNumberOfTapsRequired:1];
@@ -125,11 +177,6 @@
     [self.roomMemberNameLabelMask addGestureRecognizer:tap];
     self.roomMemberNameLabelMask.userInteractionEnabled = YES;
     
-    self.navigationItem.titleView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 600, 40)];
-    
-    memberTitleView = [RoomMemberTitleView roomMemberTitleView];
-    self.memberThumbnail = memberTitleView.memberAvatar;
-
     // Add tap to show the room member avatar in fullscreen
     tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapGesture:)];
     [tap setNumberOfTouchesRequired:1];
@@ -146,40 +193,6 @@
     [tap setDelegate:self];
     [self.roomMemberAvatarMask addGestureRecognizer:tap];
     self.roomMemberAvatarMask.userInteractionEnabled = YES;
-
-    // Add the title view and define edge constraints
-    memberTitleView.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.navigationItem.titleView addSubview:memberTitleView];
-    
-    NSLayoutConstraint *topConstraint = [NSLayoutConstraint constraintWithItem:memberTitleView
-                                                                        attribute:NSLayoutAttributeTop
-                                                                        relatedBy:NSLayoutRelationEqual
-                                                                           toItem:self.navigationItem.titleView
-                                                                        attribute:NSLayoutAttributeTop
-                                                                       multiplier:1.0f
-                                                                         constant:0.0f];
-    NSLayoutConstraint *bottomConstraint = [NSLayoutConstraint constraintWithItem:memberTitleView
-                                                                        attribute:NSLayoutAttributeBottom
-                                                                        relatedBy:NSLayoutRelationEqual
-                                                                           toItem:self.navigationItem.titleView
-                                                                        attribute:NSLayoutAttributeBottom
-                                                                       multiplier:1.0f
-                                                                         constant:0.0f];
-    NSLayoutConstraint *leadingConstraint = [NSLayoutConstraint constraintWithItem:memberTitleView
-                                                                     attribute:NSLayoutAttributeLeading
-                                                                     relatedBy:NSLayoutRelationEqual
-                                                                        toItem:self.navigationItem.titleView
-                                                                     attribute:NSLayoutAttributeLeading
-                                                                    multiplier:1.0f
-                                                                      constant:0.0f];
-    NSLayoutConstraint *trailingConstraint = [NSLayoutConstraint constraintWithItem:memberTitleView
-                                                                        attribute:NSLayoutAttributeTrailing
-                                                                        relatedBy:NSLayoutRelationEqual
-                                                                           toItem:self.navigationItem.titleView
-                                                                        attribute:NSLayoutAttributeTrailing
-                                                                       multiplier:1.0f
-                                                                         constant:0.0f];
-    [NSLayoutConstraint activateConstraints:@[topConstraint, bottomConstraint, leadingConstraint, trailingConstraint]];
     
     // Register collection view cell class
     [self.tableView registerClass:TableViewCellWithButton.class forCellReuseIdentifier:[TableViewCellWithButton defaultReuseIdentifier]];

--- a/Riot/Views/RoomMember/RoomMemberTitleView.m
+++ b/Riot/Views/RoomMember/RoomMemberTitleView.m
@@ -40,27 +40,56 @@
     
     if (self.superview)
     {
-        // Center horizontally the avatar into the navigation bar
-        CGRect frame = self.superview.frame;
-        UINavigationBar *navigationBar;
-        UIView *superView = self;
-        while (superView.superview)
+        if (@available(iOS 11.0, *))
         {
-            if ([superView.superview isKindOfClass:[UINavigationBar class]])
+            // Force the title view layout by adding 2 new constraints on the UINavigationBarContentView instance.
+            if (self.superview.clipsToBounds)
             {
-                navigationBar = (UINavigationBar*)superView.superview;
-                break;
+                NSLayoutConstraint *topConstraint = [NSLayoutConstraint constraintWithItem:self
+                                                                                 attribute:NSLayoutAttributeTop
+                                                                                 relatedBy:NSLayoutRelationEqual
+                                                                                    toItem:self.superview
+                                                                                 attribute:NSLayoutAttributeTop
+                                                                                multiplier:1.0f
+                                                                                  constant:0.0f];
+                NSLayoutConstraint *centerXConstraint = [NSLayoutConstraint constraintWithItem:self
+                                                                                     attribute:NSLayoutAttributeCenterX
+                                                                                     relatedBy:NSLayoutRelationEqual
+                                                                                        toItem:self.superview
+                                                                                     attribute:NSLayoutAttributeCenterX
+                                                                                    multiplier:1.0f
+                                                                                      constant:0.0f];
+                
+                [NSLayoutConstraint activateConstraints:@[topConstraint, centerXConstraint]];
+                
+                // Do not crop the avatar
+                self.superview.clipsToBounds = NO;
+            }
+        }
+        else
+        {
+            // Center horizontally the avatar into the navigation bar
+            CGRect frame = self.superview.frame;
+            UINavigationBar *navigationBar;
+            UIView *superView = self;
+            while (superView.superview)
+            {
+                if ([superView.superview isKindOfClass:[UINavigationBar class]])
+                {
+                    navigationBar = (UINavigationBar*)superView.superview;
+                    break;
+                }
+                
+                superView = superView.superview;
             }
             
-            superView = superView.superview;
-        }
-        
-        if (navigationBar)
-        {
-            CGSize navBarSize = navigationBar.frame.size;
-            CGFloat superviewCenterX = frame.origin.x + (frame.size.width / 2);
-            
-            self.memberAvatarCenterXConstraint.constant = (navBarSize.width / 2) - superviewCenterX;
+            if (navigationBar)
+            {
+                CGSize navBarSize = navigationBar.frame.size;
+                CGFloat superviewCenterX = frame.origin.x + (frame.size.width / 2);
+                
+                self.memberAvatarCenterXConstraint.constant = (navBarSize.width / 2) - superviewCenterX;
+            }
         }
     }
 }


### PR DESCRIPTION
Define directly the navigation titleView with the custom title view instance. Do not use anymore a container.
We had to add some constraints  to keep the custom title at the right position.