### PR TITLE
MediaPickerViewController: Add sanity checks to avoid crashes

### DIFF
--- a/Riot/ViewController/MediaPickerViewController.m
+++ b/Riot/ViewController/MediaPickerViewController.m
@@ -1000,6 +1000,12 @@ static void *RecordingContext = &RecordingContext;
         NSLog(@"[MediaPickerVC] Attemping to setup AVCapture when it is already started!");
         return;
     }
+    if (!cameraQueue)
+    {
+        NSLog(@"[MediaPickerVC] Attemping to setup AVCapture when it is being destroyed!");
+        return;
+    }
+
     isCaptureSessionSetupInProgress = YES;
     
     [self.cameraActivityIndicator startAnimating];
@@ -1192,6 +1198,12 @@ static void *RecordingContext = &RecordingContext;
 
 - (void)tearDownAVCapture
 {
+    if (!cameraQueue)
+    {
+        NSLog(@"[MediaPickerVC] Attemping to tear down AVCapture when it is being destroyed!");
+        return;
+    }
+
     dispatch_sync(cameraQueue, ^{
         frontCameraInput = nil;
         backCameraInput = nil;


### PR DESCRIPTION
- [MediaPickerViewController setupAVCapture] (in Riot) (MediaPickerViewController.m:1158) (https://github.com/matrix-org/riot-ios-rageshakes/issues/312)
- [MediaPickerViewController tearDownAVCapture] (in Riot) (MediaPickerViewController.m:1198) (https://github.com/matrix-org/riot-ios-rageshakes/issues/314)