### PR TITLE
EventFormatter: Improve updateRoomSummary:withStateEvents: to avoid t…

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -534,6 +534,11 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     [self stopGoogleAnalytics];
 }
 
+- (void)applicationDidReceiveMemoryWarning:(UIApplication *)application
+{
+    NSLog(@"[AppDelegate] applicationDidReceiveMemoryWarning");
+}
+
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler
 {
     BOOL continueUserActivity = NO;

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -224,9 +224,9 @@
     BOOL ret = [super session:session updateRoomSummary:summary withStateEvents:stateEvents];
     
     // Check whether the room display name and/or the room avatar url should be updated at Riot level.
-    NSString *riotRoomDisplayName;
-    NSString *riotRoomAvatarURL;
-    
+    BOOL refreshRiotRoomDisplayName = NO;
+    BOOL refreshRiotRoomAvatarURL = NO;
+
     for (MXEvent *event in stateEvents)
     {
         switch (event.eventType)
@@ -235,45 +235,50 @@
             case MXEventTypeRoomAliases:
             case MXEventTypeRoomCanonicalAlias:
             {
-                if (!riotRoomDisplayName.length)
-                {
-                    riotRoomDisplayName = [self riotRoomDisplayNameFromRoomState:summary.room.state];
-                }
+                refreshRiotRoomDisplayName = YES;
                 break;
             }
             case MXEventTypeRoomMember:
             {
-                if (!riotRoomDisplayName.length)
-                {
-                    riotRoomDisplayName = [self riotRoomDisplayNameFromRoomState:summary.room.state];
-                }
+                refreshRiotRoomDisplayName = YES;
                 // Do not break here to check avatar url too.
             }
             case MXEventTypeRoomAvatar:
             {
-                if (!riotRoomAvatarURL.length)
-                {
-                    riotRoomAvatarURL = [self riotRoomAvatarURLFromRoomState:summary.room.state];
-                }
+                refreshRiotRoomAvatarURL = YES;
                 break;
             }
             default:
                 break;
         }
+
+        if (refreshRiotRoomDisplayName && refreshRiotRoomAvatarURL)
+        {
+            break;
+        }
     }
-    
-    if (riotRoomDisplayName.length && ![summary.displayname isEqualToString:riotRoomDisplayName])
+
+    if (refreshRiotRoomDisplayName)
     {
-        summary.displayname = riotRoomDisplayName;
-        ret = YES;
+        NSString *riotRoomDisplayName = [self riotRoomDisplayNameFromRoomState:summary.room.state];
+
+        if (riotRoomDisplayName.length && ![summary.displayname isEqualToString:riotRoomDisplayName])
+        {
+            summary.displayname = riotRoomDisplayName;
+            ret = YES;
+        }
     }
-    
-    if (riotRoomAvatarURL.length && ![summary.avatar isEqualToString:riotRoomAvatarURL])
+    if (refreshRiotRoomAvatarURL)
     {
-        summary.avatar = riotRoomAvatarURL;
-        ret = YES;
+        NSString *riotRoomAvatarURL = [self riotRoomAvatarURLFromRoomState:summary.room.state];
+
+        if (riotRoomAvatarURL.length && ![summary.avatar isEqualToString:riotRoomAvatarURL])
+        {
+            summary.avatar = riotRoomAvatarURL;
+            ret = YES;
+        }
     }
-    
+
     return ret;
 }
 


### PR DESCRIPTION
…o compute room avatar & displayname on almost every state events.

When initialsyncing with big rooms, the previous implementation leaded the app to out of memory because ARC did not have time to auto release objects (mainly objects returned by MXRoomState.members).