### PR TITLE
Initial work on adding Dynamic Type support

### DIFF
--- a/Riot/Categories/MXKRoomBubbleTableViewCell+Riot.m
+++ b/Riot/Categories/MXKRoomBubbleTableViewCell+Riot.m
@@ -62,14 +62,7 @@ NSString *const kMXKRoomBubbleCellTapOnReceiptsContainer = @"kMXKRoomBubbleCellT
         timeLabel.text = [bubbleData.eventFormatter timeStringFromDate:component.date];
         timeLabel.textAlignment = NSTextAlignmentRight;
         timeLabel.textColor = kRiotSecondaryTextColor;
-        if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)])
-        {
-             timeLabel.font = [UIFont systemFontOfSize:12 weight:UIFontWeightLight];
-        }
-        else
-        {
-             timeLabel.font = [UIFont systemFontOfSize:12];
-        }
+        timeLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote];
         timeLabel.adjustsFontSizeToFitWidth = YES;
 
         timeLabel.tag = componentIndex;
@@ -264,14 +257,7 @@ NSString *const kMXKRoomBubbleCellTapOnReceiptsContainer = @"kMXKRoomBubbleCellT
         timeLabel.text = [bubbleData.eventFormatter dateStringFromDate:date withTime:NO];
         timeLabel.textAlignment = NSTextAlignmentRight;
         timeLabel.textColor = kRiotSecondaryTextColor;
-        if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)])
-        {
-            timeLabel.font = [UIFont systemFontOfSize:12 weight:UIFontWeightLight];
-        }
-        else
-        {
-            timeLabel.font = [UIFont systemFontOfSize:12];
-        }
+        timeLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote];
         timeLabel.adjustsFontSizeToFitWidth = YES;
         
         [timeLabel setTranslatesAutoresizingMaskIntoConstraints:NO];

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -147,6 +147,11 @@
         
         // Use the secondary bg color to set the background color in the default CSS.
         NSUInteger bgColor = [MXKTools rgbValueWithColor:kRiotSecondaryBgColor];
+
+        // The system font used for the body is oversized in relation
+        // to the font used for pre/code, so we're making it a bit smaller.
+        CGFloat fontSizeCode = kRiotTextFontBody.pointSize/1.5;
+
         self.defaultCSS = [NSString stringWithFormat:@" \
                            pre,code { \
                            background-color: #%06lX; \
@@ -154,9 +159,9 @@
                            font-family: monospace; \
                            white-space: pre; \
                            -coretext-fontname: Menlo-Regular; \
-                           font-size: small; \
-                           }", (unsigned long)bgColor];
-        
+                           font-size: %fpt; \
+                           }", (unsigned long)bgColor, fontSizeCode];
+
         self.defaultTextColor = kRiotPrimaryTextColor;
         self.subTitleTextColor = kRiotSecondaryTextColor;
         self.prefixTextColor = kRiotSecondaryTextColor;
@@ -164,20 +169,13 @@
         self.encryptingTextColor = kRiotColorGreen;
         self.sendingTextColor = kRiotSecondaryTextColor;
         self.errorTextColor = kRiotColorRed;
-        
-        self.defaultTextFont = [UIFont systemFontOfSize:15];
-        self.prefixTextFont = [UIFont boldSystemFontOfSize:15];
-        if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)])
-        {
-            self.bingTextFont = [UIFont systemFontOfSize:15 weight:UIFontWeightMedium];
-        }
-        else
-        {
-            self.bingTextFont = [UIFont systemFontOfSize:15];
-        }
-        self.stateEventTextFont = [UIFont italicSystemFontOfSize:15];
-        self.callNoticesTextFont = [UIFont italicSystemFontOfSize:15];
-        self.encryptedMessagesTextFont = [UIFont italicSystemFontOfSize:15];
+
+        self.defaultTextFont = kRiotTextFontBody;
+        self.prefixTextFont = kRiotTextFontBold;
+        self.bingTextFont = kRiotTextFontBody;
+        self.stateEventTextFont = kRiotTextFontEmphasized;
+        self.callNoticesTextFont = kRiotTextFontEmphasized;
+        self.encryptedMessagesTextFont = kRiotTextFontEmphasized;
         self.emojiOnlyTextFont = [UIFont systemFontOfSize:48];
     }
     return self;

--- a/Riot/Utils/RiotDesignValues.h
+++ b/Riot/Utils/RiotDesignValues.h
@@ -53,6 +53,11 @@ extern UIColor *kRiotColorRed;
 extern UIColor *kRiotColorIndigo;
 extern UIColor *kRiotColorOrange;
 
+#pragma mark - Riot Fonts
+extern UIFont *kRiotTextFontBody;
+extern UIFont *kRiotTextFontBold;
+extern UIFont *kRiotTextFontEmphasized;
+
 #pragma mark - Riot Standard Room Member Power Level
 extern NSInteger const kRiotRoomModeratorLevel;
 extern NSInteger const kRiotRoomAdminLevel;

--- a/Riot/Utils/RiotDesignValues.m
+++ b/Riot/Utils/RiotDesignValues.m
@@ -56,6 +56,11 @@ UIColor *kRiotTextColorGray;
 UIColor *kRiotTextColorWhite;
 UIColor *kRiotTextColorDarkWhite;
 
+// Riot Text Fonts
+UIFont *kRiotTextFontBody;
+UIFont *kRiotTextFontBold;
+UIFont *kRiotTextFontEmphasized;
+
 NSInteger const kRiotRoomModeratorLevel = 50;
 NSInteger const kRiotRoomAdminLevel = 100;
 
@@ -119,6 +124,26 @@ UIKeyboardAppearance kRiotKeyboard;
 
     // Observe "Invert Colours" settings changes (available since iOS 11)
     [[NSNotificationCenter defaultCenter] addObserver:[RiotDesignValues sharedInstance] selector:@selector(accessibilityInvertColorsStatusDidChange) name:UIAccessibilityInvertColorsStatusDidChangeNotification object:nil];
+
+    // Observe Dynamic Type changes
+    [[NSNotificationCenter defaultCenter] addObserver:[RiotDesignValues sharedInstance] selector:@selector(userInterfaceContentSizeCategoryDidChange) name:UIContentSizeCategoryDidChangeNotification object:nil];
+    [[RiotDesignValues sharedInstance] userInterfaceContentSizeCategoryDidChange];
+}
+
+- (void)userInterfaceContentSizeCategoryDidChange
+{
+    UIFontDescriptor *bodyDescriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleBody];
+    kRiotTextFontBody = [UIFont fontWithDescriptor:bodyDescriptor size:0.0];
+
+    UIFontDescriptor *boldDescriptor = [bodyDescriptor fontDescriptorWithSymbolicTraits:UIFontDescriptorTraitBold];
+    kRiotTextFontBold = [UIFont fontWithDescriptor:boldDescriptor size:0.0];
+
+    UIFontDescriptor *italicDescriptor = [bodyDescriptor fontDescriptorWithSymbolicTraits:UIFontDescriptorTraitItalic];
+    kRiotTextFontEmphasized = [UIFont fontWithDescriptor:italicDescriptor size:0.0];
+
+    // Reuse the "theme changed" notification to let the rest of the app know
+    // that some theme-related thing (in this case the font size) changed.
+    [[NSNotificationCenter defaultCenter] postNotificationName:kRiotDesignValuesDidChangeThemeNotification object:nil];
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context

--- a/Riot/ViewController/RoomViewController.m
+++ b/Riot/ViewController/RoomViewController.m
@@ -436,13 +436,14 @@
     // Prepare jump to last unread banner
     self.jumpToLastUnreadBannerContainer.backgroundColor = kRiotPrimaryBgColor;
     self.jumpToLastUnreadLabel.attributedText = [[NSAttributedString alloc] initWithString:NSLocalizedStringFromTable(@"room_jump_to_first_unread", @"Vector", nil) attributes:@{NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle), NSUnderlineColorAttributeName: kRiotPrimaryTextColor, NSForegroundColorAttributeName: kRiotPrimaryTextColor}];
-    
+
+    [(RoomInputToolbarView*)self.inputToolbarView userInterfaceThemeDidChange];
     
     self.expandedHeaderContainer.backgroundColor = kRiotSecondaryBgColor;
     self.previewHeaderContainer.backgroundColor = kRiotSecondaryBgColor;
     
     missedDiscussionsBadgeLabel.textColor = kRiotPrimaryBgColor;
-    missedDiscussionsBadgeLabel.font = [UIFont boldSystemFontOfSize:14];
+    missedDiscussionsBadgeLabel.font = kRiotTextFontBold;
     missedDiscussionsBadgeLabel.backgroundColor = [UIColor clearColor];
     
     // Check the table view style to select its bg color.

--- a/Riot/Views/Directory/DirectoryServerDetailTableViewCell.xib
+++ b/Riot/Views/Directory/DirectoryServerDetailTableViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -29,18 +29,18 @@
                         </constraints>
                     </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="matrix.org" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lg1-xQ-AGn">
-                        <rect key="frame" x="70" y="16" width="194" height="20"/>
+                        <rect key="frame" x="70" y="16" width="205.5" height="20"/>
                         <accessibility key="accessibilityConfiguration" identifier="TitleLabel"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="20" id="NW9-MB-gf4"/>
                         </constraints>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
-                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                        <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="All rooms on matrix.org server" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gm9-ft-UVV">
-                        <rect key="frame" x="70" y="44" width="194" height="17"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <rect key="frame" x="70" y="44" width="205.5" height="18"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>

--- a/Riot/Views/Directory/DirectoryServerTableViewCell.xib
+++ b/Riot/Views/Directory/DirectoryServerTableViewCell.xib
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
-        <capability name="Unknown constraint types" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,7 +20,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="600" height="73.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TPL-8D-oME" customClass="MXKImageView">
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TPL-8D-oME" customClass="MXKImageView">
                         <rect key="frame" x="14" y="16" width="42" height="42"/>
                         <accessibility key="accessibilityConfiguration" identifier="AvatarImageView"/>
                         <constraints>
@@ -28,7 +28,7 @@
                             <constraint firstAttribute="width" secondItem="TPL-8D-oME" secondAttribute="height" multiplier="1:1" id="wzs-X7-8wC"/>
                         </constraints>
                     </view>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" ambiguous="YES" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lg1-xQ-AGn">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lg1-xQ-AGn">
                         <rect key="frame" x="70" y="27" width="35" height="20"/>
                         <accessibility key="accessibilityConfiguration" identifier="TitleLabel"/>
                         <constraints>
@@ -50,8 +50,8 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <accessibility key="accessibilityConfiguration" identifier="DirectoryServerTableViewCell"/>
             <connections>
-                <outlet property="iconImageView" destination="TPL-8D-oME" id="bVo-bU-MBd"/>
                 <outlet property="descLabel" destination="Lg1-xQ-AGn" id="gmg-9Z-AKf"/>
+                <outlet property="iconImageView" destination="TPL-8D-oME" id="bVo-bU-MBd"/>
             </connections>
         </tableViewCell>
     </objects>

--- a/Riot/Views/RoomInputToolbar/RoomInputToolbarView.h
+++ b/Riot/Views/RoomInputToolbar/RoomInputToolbarView.h
@@ -58,4 +58,9 @@
  */
 @property (nonatomic) BOOL activeCall;
 
+/**
+ Handles user interface theme and font-size changes.
+ */
+- (void)userInterfaceThemeDidChange;
+
 @end

--- a/Riot/Views/RoomInputToolbar/RoomInputToolbarView.m
+++ b/Riot/Views/RoomInputToolbar/RoomInputToolbarView.m
@@ -78,18 +78,22 @@
 -(void)customizeViewRendering
 {
     [super customizeViewRendering];
-    
+    [self userInterfaceThemeDidChange];
+}
+
+- (void)userInterfaceThemeDidChange
+{
     // Remove default toolbar background color
     self.backgroundColor = [UIColor clearColor];
-    
+
     self.separatorView.backgroundColor = kRiotAuxiliaryColor;
-    
+
     // Custom the growingTextView display
     growingTextView.layer.cornerRadius = 0;
     growingTextView.layer.borderWidth = 0;
     growingTextView.backgroundColor = [UIColor clearColor];
-    
-    growingTextView.font = [UIFont systemFontOfSize:15];
+
+    growingTextView.font = kRiotTextFontBody;
     growingTextView.textColor = kRiotPrimaryTextColor;
     growingTextView.tintColor = kRiotColorGreen;
     

--- a/Riot/Views/RoomList/PublicRoomTableViewCell.xib
+++ b/Riot/Views/RoomList/PublicRoomTableViewCell.xib
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,7 +15,7 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="74"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="L2L-l5-wPx" id="aXz-IR-jj5">
-                <rect key="frame" x="0.0" y="0.0" width="600" height="73"/>
+                <rect key="frame" x="0.0" y="0.0" width="600" height="73.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RX5-eD-c3c" userLabel="Room avatar" customClass="MXKImageView">
@@ -33,7 +33,7 @@
                         <constraints>
                             <constraint firstAttribute="height" constant="21" id="vCd-fx-d5z"/>
                         </constraints>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
@@ -43,17 +43,17 @@
                         <constraints>
                             <constraint firstAttribute="height" constant="20" id="e6p-DU-3ny"/>
                         </constraints>
-                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                         <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="x users" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="360-Go-RcG">
-                        <rect key="frame" x="510" y="16" width="80" height="18"/>
+                        <rect key="frame" x="510" y="16" width="80" height="16"/>
                         <accessibility key="accessibilityConfiguration" identifier="MembersCount"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="uOj-6w-G8q"/>
                         </constraints>
-                        <fontDescription key="fontDescription" type="system" weight="light" pointSize="12"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                         <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>

--- a/Riot/Views/RoomList/RecentTableViewCell.m
+++ b/Riot/Views/RoomList/RecentTableViewCell.m
@@ -114,30 +114,16 @@
                 self.missedNotifAndUnreadIndicator.backgroundColor = kRiotAuxiliaryColor;
             }
             
-            // Use bold font for the room title
-            if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)])
-            {
-                self.roomTitle.font = [UIFont systemFontOfSize:17 weight:UIFontWeightBold];
-            }
-            else
-            {
-                self.roomTitle.font = [UIFont boldSystemFontOfSize:17];
-            }
+            self.roomTitle.font = kRiotTextFontBold;
         }
         else
         {
             self.lastEventDate.textColor = kRiotSecondaryTextColor;
-            
-            // The room title is not bold anymore
-            if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)])
-            {
-                self.roomTitle.font = [UIFont systemFontOfSize:17 weight:UIFontWeightMedium];
-            }
-            else
-            {
-                self.roomTitle.font = [UIFont systemFontOfSize:17];
-            }
+
+            self.roomTitle.font = kRiotTextFontBody;
         }
+
+        self.lastEventDescription.font = kRiotTextFontBody;
         
         self.directRoomBorderView.hidden = !roomCellData.roomSummary.room.isDirect;
 

--- a/Riot/Views/RoomList/RecentTableViewCell.xib
+++ b/Riot/Views/RoomList/RecentTableViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -45,12 +45,12 @@
                         </constraints>
                     </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="RoomTitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lg1-xQ-AGn">
-                        <rect key="frame" x="69" y="14" width="451" height="21"/>
+                        <rect key="frame" x="69" y="14" width="446" height="21"/>
                         <accessibility key="accessibilityConfiguration" identifier="TitleLabel"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="21" id="vCd-fx-d5z"/>
                         </constraints>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
@@ -60,22 +60,22 @@
                         <constraints>
                             <constraint firstAttribute="height" constant="20" id="e6p-DU-3ny"/>
                         </constraints>
-                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                         <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sun 20:28" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="360-Go-RcG">
-                        <rect key="frame" x="532" y="16" width="58" height="15"/>
+                        <rect key="frame" x="527" y="16" width="63" height="16"/>
                         <accessibility key="accessibilityConfiguration" identifier="LastEventDate"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="uOj-6w-G8q"/>
                         </constraints>
-                        <fontDescription key="fontDescription" type="system" weight="light" pointSize="12"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                         <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OeZ-wN-eil">
-                        <rect key="frame" x="524" y="14" width="0.0" height="20"/>
+                        <rect key="frame" x="519" y="14.5" width="0.0" height="20"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mbn-A1-1Yw">
                                 <rect key="frame" x="-4" y="2" width="9" height="17"/>

--- a/Riot/Views/RoomList/RoomIdOrAliasTableViewCell.xib
+++ b/Riot/Views/RoomList/RoomIdOrAliasTableViewCell.xib
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,7 +17,7 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="74"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="L2L-l5-wPx" id="aXz-IR-jj5">
-                <rect key="frame" x="0.0" y="0.0" width="600" height="73"/>
+                <rect key="frame" x="0.0" y="0.0" width="600" height="74"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="TPL-8D-oME">


### PR DESCRIPTION
Related to issue #496.

This patch is not exhaustive - it doesn't make everything use Dynamic Type fonts.
Still, it makes most of the (frequently used) UI scalable, which should be a nice first step and an improvement for people with visibility problems.

Even in the generic case (no visibility problems and font size increase set in Accessibility settings), with this patch, the fonts appear a little larger and more legible than before (addresses issue #1487).

This patch defines some basic fonts, listens for a `UIContentSizeCategoryDidChangeNotification` and maintains these fonts updated accordingly.

To let the rest of the app know about such font size changes, we send the same `kRiotDesignValuesDidChangeThemeNotification` which gets dispatched when people change between the Dark/Light themes. Since the intention is similar (UI settings update & redraw), it seemed natural to repurpose it.

Not all fonts are assigned dynamically (`widget.font = ..`), so not all widgets use the new font values from `RiotDesignValues`.
In other places, we simply configure the Dynamic Type font inside the `.xib` file.

UI widgets which have their font defined in the `.xib` file do not get immediately updated. Using the "Automatically Adjust Font" property seems like an easy viable solution, but it requires iOS>=10, so it hasn't been done.

Signed-off-by: Slavi Pantaleev <s.pantaleev@gmail.com>