### PR TITLE
Bug Fix - Member Info page avatars are systematically cropped (iOS 11)

### DIFF
--- a/Riot/ViewController/ContactDetailsViewController.h
+++ b/Riot/ViewController/ContactDetailsViewController.h
@@ -34,6 +34,7 @@ typedef enum : NSUInteger
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *contactAvatarHeaderBackgroundHeightConstraint;
 
 @property (weak, nonatomic) IBOutlet UIView *headerView;
+@property (weak, nonatomic) IBOutlet MXKImageView *contactAvatar;
 @property (weak, nonatomic) IBOutlet UIView *contactAvatarMask;
 @property (weak, nonatomic) IBOutlet UILabel *contactNameLabel;
 @property (weak, nonatomic) IBOutlet UIView *contactNameLabelMask;

--- a/Riot/ViewController/ContactDetailsViewController.xib
+++ b/Riot/ViewController/ContactDetailsViewController.xib
@@ -1,17 +1,19 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ContactDetailsViewController">
             <connections>
                 <outlet property="bottomImageView" destination="7Dc-jk-9sT" id="BVN-bt-VXI"/>
+                <outlet property="contactAvatar" destination="HFg-gC-lBP" id="CII-Wb-38w"/>
                 <outlet property="contactAvatarHeaderBackground" destination="ouj-VM-zdT" id="bEq-oW-fal"/>
                 <outlet property="contactAvatarHeaderBackgroundHeightConstraint" destination="dBL-G6-Yec" id="WWx-dy-WtS"/>
                 <outlet property="contactAvatarMask" destination="xHv-tg-mOt" id="lX8-ju-K6W"/>
@@ -41,10 +43,23 @@
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xHv-tg-mOt">
                             <rect key="frame" x="137.5" y="0.0" width="100" height="125"/>
+                            <subviews>
+                                <view clipsSubviews="YES" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="HFg-gC-lBP" customClass="MXKImageView">
+                                    <rect key="frame" x="7.5" y="31" width="84" height="84"/>
+                                    <color key="backgroundColor" red="0.6886889638" green="1" blue="0.74383144840000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <accessibility key="accessibilityConfiguration" identifier="MemberAvatar"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" secondItem="HFg-gC-lBP" secondAttribute="height" multiplier="1:1" id="EMi-8B-uQv"/>
+                                        <constraint firstAttribute="width" constant="84" id="ugh-Rg-dGz"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <accessibility key="accessibilityConfiguration" identifier="ContactDetailsVCAvatarMask"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="100" id="5BQ-kA-kNt"/>
+                                <constraint firstItem="HFg-gC-lBP" firstAttribute="centerX" secondItem="xHv-tg-mOt" secondAttribute="centerX" id="FGc-kn-wNk"/>
+                                <constraint firstAttribute="bottom" secondItem="HFg-gC-lBP" secondAttribute="bottom" constant="10" id="wfW-Ky-Kfc"/>
                             </constraints>
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="92g-hC-6jB">

--- a/Riot/ViewController/RoomMemberDetailsViewController.m
+++ b/Riot/ViewController/RoomMemberDetailsViewController.m
@@ -166,9 +166,6 @@
         [NSLayoutConstraint activateConstraints:@[topConstraint, bottomConstraint, leadingConstraint, trailingConstraint]];
     }
     
-    // Handle the member avatar at the view controller level.
-    self.memberThumbnail = memberTitleView.memberAvatar;
-    
     // Add tap gesture on member's name
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapGesture:)];
     [tap setNumberOfTouchesRequired:1];
@@ -182,17 +179,16 @@
     [tap setNumberOfTouchesRequired:1];
     [tap setNumberOfTapsRequired:1];
     [tap setDelegate:self];
-    [self.memberThumbnail addGestureRecognizer:tap];
-    self.memberThumbnail.userInteractionEnabled = YES;
-
-    // Need to listen tap gesture on the area part of the avatar image that is outside
-    // of the navigation bar, its parent but smaller view.
+    [self.roomMemberAvatarMask addGestureRecognizer:tap];
+    self.roomMemberAvatarMask.userInteractionEnabled = YES;
+    
+    // Need to listen to the tap gesture in the title view too.
     tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapGesture:)];
     [tap setNumberOfTouchesRequired:1];
     [tap setNumberOfTapsRequired:1];
     [tap setDelegate:self];
-    [self.roomMemberAvatarMask addGestureRecognizer:tap];
-    self.roomMemberAvatarMask.userInteractionEnabled = YES;
+    [memberTitleView.memberAvatarMask addGestureRecognizer:tap];
+    memberTitleView.memberAvatarMask.userInteractionEnabled = YES;
     
     // Register collection view cell class
     [self.tableView registerClass:TableViewCellWithButton.class forCellReuseIdentifier:[TableViewCellWithButton defaultReuseIdentifier]];
@@ -341,10 +337,10 @@
     {
         // Adjust the header height by taking into account the actual position of the member avatar in title view
         // This position depends automatically on the screen orientation.
-        CGRect memberAvatarFrame = memberTitleView.memberAvatar.frame;
-        CGPoint memberAvatarActualPosition = [memberTitleView convertPoint:memberAvatarFrame.origin toView:self.view];
+        CGPoint memberAvatarOriginInTitleView = memberTitleView.memberAvatarMask.frame.origin;
+        CGPoint memberAvatarActualPosition = [memberTitleView convertPoint:memberAvatarOriginInTitleView toView:self.view];
         
-        CGFloat avatarHeaderHeight = memberAvatarActualPosition.y + memberAvatarFrame.size.height;
+        CGFloat avatarHeaderHeight = memberAvatarActualPosition.y + self.memberThumbnail.frame.size.height;
         if (_roomMemberAvatarHeaderBackgroundHeightConstraint.constant != avatarHeaderHeight)
         {
             _roomMemberAvatarHeaderBackgroundHeightConstraint.constant = avatarHeaderHeight;
@@ -955,7 +951,7 @@
             self.roomMemberNameLabel.text = self.mxRoomMember.displayname;
         }
     }
-    else if (view == self.memberThumbnail || view == self.roomMemberAvatarMask)
+    else if (view == memberTitleView.memberAvatarMask || view == self.roomMemberAvatarMask)
     {
         __weak typeof(self) weakSelf = self;
         

--- a/Riot/ViewController/RoomMemberDetailsViewController.xib
+++ b/Riot/ViewController/RoomMemberDetailsViewController.xib
@@ -1,11 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,6 +14,7 @@
             <connections>
                 <outlet property="bottomImageView" destination="7Dc-jk-9sT" id="BVN-bt-VXI"/>
                 <outlet property="memberHeaderView" destination="YXr-As-Mqh" id="Eqb-qr-iAo"/>
+                <outlet property="memberThumbnail" destination="GQ1-rP-ckr" id="abr-hr-C3p"/>
                 <outlet property="roomMemberAvatarHeaderBackground" destination="ouj-VM-zdT" id="YeD-zt-8y5"/>
                 <outlet property="roomMemberAvatarHeaderBackgroundHeightConstraint" destination="dBL-G6-Yec" id="QXZ-ZP-0Rn"/>
                 <outlet property="roomMemberAvatarMask" destination="MAS-3M-3cg" id="nLI-7d-5Hu"/>
@@ -41,9 +43,22 @@
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MAS-3M-3cg">
                             <rect key="frame" x="137.5" y="0.0" width="100" height="125"/>
+                            <subviews>
+                                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GQ1-rP-ckr" customClass="MXKImageView">
+                                    <rect key="frame" x="7.5" y="31" width="84" height="84"/>
+                                    <color key="backgroundColor" red="0.6886889638" green="1" blue="0.74383144840000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <accessibility key="accessibilityConfiguration" identifier="MemberAvatar"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="84" id="HfP-Pj-zLa"/>
+                                        <constraint firstAttribute="width" secondItem="GQ1-rP-ckr" secondAttribute="height" multiplier="1:1" id="a1T-Y0-Iic"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <accessibility key="accessibilityConfiguration" identifier="RoomMemberDetailsVCAvatarMask"/>
                             <constraints>
+                                <constraint firstAttribute="bottom" secondItem="GQ1-rP-ckr" secondAttribute="bottom" constant="10" id="3pC-So-WvO"/>
+                                <constraint firstItem="GQ1-rP-ckr" firstAttribute="centerX" secondItem="MAS-3M-3cg" secondAttribute="centerX" id="ZGI-nR-gGx"/>
                                 <constraint firstAttribute="width" constant="100" id="fwv-qE-IV1"/>
                             </constraints>
                         </view>
@@ -82,13 +97,11 @@
                         <constraint firstItem="wEo-Mk-SgZ" firstAttribute="centerY" secondItem="92g-hC-6jB" secondAttribute="centerY" id="3Zt-MD-sZK"/>
                         <constraint firstItem="5le-5e-Vml" firstAttribute="top" secondItem="92g-hC-6jB" secondAttribute="bottom" constant="7" id="5zX-1T-n38"/>
                         <constraint firstItem="92g-hC-6jB" firstAttribute="centerX" secondItem="YXr-As-Mqh" secondAttribute="centerX" id="7Is-d0-FZp"/>
-                        <constraint firstItem="MAS-3M-3cg" firstAttribute="centerY" secondItem="YXr-As-Mqh" secondAttribute="centerY" id="Ciw-T9-XBe"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="92g-hC-6jB" secondAttribute="trailing" constant="32" id="Eyx-UF-fYc"/>
                         <constraint firstAttribute="trailing" secondItem="ouj-VM-zdT" secondAttribute="trailing" id="FRy-TL-gS2"/>
                         <constraint firstItem="wEo-Mk-SgZ" firstAttribute="centerX" secondItem="92g-hC-6jB" secondAttribute="centerX" id="K1f-RX-kpp"/>
                         <constraint firstItem="wEo-Mk-SgZ" firstAttribute="width" secondItem="YXr-As-Mqh" secondAttribute="width" id="P5e-q6-OIS"/>
                         <constraint firstItem="92g-hC-6jB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YXr-As-Mqh" secondAttribute="leading" constant="32" id="QZB-ue-Sih"/>
-                        <constraint firstItem="MAS-3M-3cg" firstAttribute="centerY" secondItem="YXr-As-Mqh" secondAttribute="centerY" id="Vh6-q9-uJZ"/>
                         <constraint firstItem="5le-5e-Vml" firstAttribute="centerX" secondItem="YXr-As-Mqh" secondAttribute="centerX" id="bmA-Fq-uxO"/>
                         <constraint firstItem="5le-5e-Vml" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YXr-As-Mqh" secondAttribute="leading" constant="42" id="ioz-jk-jrE"/>
                         <constraint firstAttribute="bottom" secondItem="5le-5e-Vml" secondAttribute="bottom" constant="18" id="j10-rX-tMf"/>
@@ -99,15 +112,7 @@
                         <constraint firstItem="MAS-3M-3cg" firstAttribute="bottom" secondItem="92g-hC-6jB" secondAttribute="top" id="rgU-C1-YMW"/>
                         <constraint firstItem="ouj-VM-zdT" firstAttribute="top" secondItem="YXr-As-Mqh" secondAttribute="top" id="srY-tD-AhJ"/>
                         <constraint firstItem="MAS-3M-3cg" firstAttribute="centerX" secondItem="YXr-As-Mqh" secondAttribute="centerX" id="vNM-7Z-K2b"/>
-                        <constraint firstAttribute="bottom" secondItem="MAS-3M-3cg" secondAttribute="bottom" id="xEt-kv-tJd"/>
                     </constraints>
-                    <variation key="default">
-                        <mask key="constraints">
-                            <exclude reference="Ciw-T9-XBe"/>
-                            <exclude reference="Vh6-q9-uJZ"/>
-                            <exclude reference="xEt-kv-tJd"/>
-                        </mask>
-                    </variation>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RBF-EK-dhz">
                     <rect key="frame" x="0.0" y="317" width="375" height="33"/>

--- a/Riot/ViewController/RoomViewController.m
+++ b/Riot/ViewController/RoomViewController.m
@@ -669,14 +669,14 @@
     if (self.expandedHeaderContainer.isHidden == NO)
     {
         // Adjust the expanded header height by taking into account the actual position of the room avatar
-        // This position depends automaticcaly on the screen orientation.
+        // This position depends automatically on the screen orientation.
         if ([self.titleView isKindOfClass:[RoomAvatarTitleView class]])
         {
             RoomAvatarTitleView *avatarTitleView = (RoomAvatarTitleView*)self.titleView;
-            CGRect roomAvatarFrame = avatarTitleView.roomAvatar.frame;
-            CGPoint roomAvatarActualPosition = [avatarTitleView convertPoint:roomAvatarFrame.origin toView:self.view];
+            CGPoint roomAvatarOriginInTitleView = avatarTitleView.roomAvatarMask.frame.origin;
+            CGPoint roomAvatarActualPosition = [avatarTitleView convertPoint:roomAvatarOriginInTitleView toView:self.view];
             
-            CGFloat avatarHeaderHeight = roomAvatarActualPosition.y + roomAvatarFrame.size.height;
+            CGFloat avatarHeaderHeight = roomAvatarActualPosition.y + expandedHeader.roomAvatar.frame.size.height;
             if (expandedHeader.roomAvatarHeaderBackgroundHeightConstraint.constant != avatarHeaderHeight)
             {
                 expandedHeader.roomAvatarHeaderBackgroundHeightConstraint.constant = avatarHeaderHeight;
@@ -1358,15 +1358,13 @@
         // setBackgroundImage:forBarMetrics: method. If the default background image is used, then the default shadow
         // image will be used regardless of the value of this property.
         UIImage *shadowImage = nil;
-        MXKImageView *roomAvatarView = nil;
         
         if (isVisible)
         {
             [self setRoomTitleViewClass:RoomAvatarTitleView.class];
             // Note the avatar title view does not define tap gesture.
             
-            roomAvatarView = ((RoomAvatarTitleView*)self.titleView).roomAvatar;
-            roomAvatarView.alpha = 0.0;
+            expandedHeader.roomAvatar.alpha = 0.0;
             
             shadowImage = [[UIImage alloc] init];
             
@@ -1395,10 +1393,7 @@
                              self.bubblesTableViewTopConstraint.constant = (isVisible ? self.expandedHeaderContainerHeightConstraint.constant - self.bubblesTableView.mxk_adjustedContentInset.top : 0);
                              self.jumpToLastUnreadBannerContainerTopConstraint.constant = (isVisible ? self.expandedHeaderContainerHeightConstraint.constant : self.bubblesTableView.mxk_adjustedContentInset.top);
                              
-                             if (roomAvatarView)
-                             {
-                                 roomAvatarView.alpha = 1;
-                             }
+                             expandedHeader.roomAvatar.alpha = 1;
                              
                              // Force to render the view
                              [self forceLayoutRefresh];
@@ -1554,23 +1549,22 @@
             
             RoomAvatarTitleView *roomAvatarTitleView = (RoomAvatarTitleView*)self.titleView;
             
-            roomAvatarView = roomAvatarTitleView.roomAvatar;
-            roomAvatarView.alpha = 0.0;
+            previewHeader.roomAvatar.alpha = 0.0;
             
             // Set the avatar provided in preview data
             if (roomPreviewData.roomAvatarUrl)
             {
-                NSString *roomAvatarUrl = [self.mainSession.matrixRestClient urlOfContentThumbnail:roomPreviewData.roomAvatarUrl toFitViewSize:roomAvatarView.frame.size withMethod:MXThumbnailingMethodCrop];
+                NSString *roomAvatarUrl = [self.mainSession.matrixRestClient urlOfContentThumbnail:roomPreviewData.roomAvatarUrl toFitViewSize:previewHeader.roomAvatar.frame.size withMethod:MXThumbnailingMethodCrop];
                 
-                roomAvatarTitleView.roomAvatarURL = roomAvatarUrl;
+                previewHeader.roomAvatarURL = roomAvatarUrl;
             }
             else if (roomPreviewData.roomId && roomPreviewData.roomName)
             {
-                roomAvatarTitleView.roomAvatarPlaceholder = [AvatarGenerator generateAvatarForMatrixItem:roomPreviewData.roomId withDisplayName:roomPreviewData.roomName];
+                previewHeader.roomAvatarPlaceholder = [AvatarGenerator generateAvatarForMatrixItem:roomPreviewData.roomId withDisplayName:roomPreviewData.roomName];
             }
             else
             {
-                roomAvatarTitleView.roomAvatarPlaceholder = [UIImage imageNamed:@"placeholder"];
+                previewHeader.roomAvatarPlaceholder = [UIImage imageNamed:@"placeholder"];
             }
         }
         
@@ -1602,10 +1596,7 @@
                              self.bubblesTableViewTopConstraint.constant = self.previewHeaderContainerHeightConstraint.constant - self.bubblesTableView.mxk_adjustedContentInset.top;
                              self.jumpToLastUnreadBannerContainerTopConstraint.constant = self.previewHeaderContainerHeightConstraint.constant;
                              
-                             if (roomAvatarView)
-                             {
-                                 roomAvatarView.alpha = 1;
-                             }
+                             previewHeader.roomAvatar.alpha = 1;
                              
                              // Force to render the view
                              [self forceLayoutRefresh];
@@ -3186,11 +3177,9 @@
                     // Starting to move the local preview view
                     selectedRoomSettingsField = RoomSettingsViewControllerFieldTopic;
                 }
-                else if ([self.titleView isKindOfClass:[RoomAvatarTitleView class]])
+                else
                 {
-                    RoomAvatarTitleView *avatarTitleView = (RoomAvatarTitleView*)self.titleView;
-                    CGRect roomAvatarFrame = avatarTitleView.roomAvatar.frame;
-                    roomAvatarFrame.origin = [avatarTitleView convertPoint:roomAvatarFrame.origin toView:self.expandedHeaderContainer];
+                    CGRect roomAvatarFrame = expandedHeader.roomAvatar.frame;
                     if (CGRectContainsPoint(roomAvatarFrame, point))
                     {
                         // Starting to move the local preview view

--- a/Riot/Views/RoomMember/RoomMemberTitleView.h
+++ b/Riot/Views/RoomMember/RoomMemberTitleView.h
@@ -48,9 +48,9 @@
  */
 + (instancetype)roomMemberTitleView;
 
-@property (weak, nonatomic) IBOutlet MXKImageView *memberAvatar;
+@property (weak, nonatomic) IBOutlet UIView *memberAvatarMask;
 @property (weak, nonatomic) IBOutlet UIImageView *memberBadge;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *memberAvatarCenterXConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *memberAvatarMaskCenterXConstraint;
 
 /**
  The delegate.

--- a/Riot/Views/RoomMember/RoomMemberTitleView.m
+++ b/Riot/Views/RoomMember/RoomMemberTitleView.m
@@ -85,7 +85,7 @@
                 CGSize navBarSize = navigationBar.frame.size;
                 CGFloat superviewCenterX = frame.origin.x + (frame.size.width / 2);
                 
-                self.memberAvatarCenterXConstraint.constant = (navBarSize.width / 2) - superviewCenterX;
+                self.memberAvatarMaskCenterXConstraint.constant = (navBarSize.width / 2) - superviewCenterX;
             }
         }
     }

--- a/Riot/Views/RoomMember/RoomMemberTitleView.xib
+++ b/Riot/Views/RoomMember/RoomMemberTitleView.xib
@@ -1,51 +1,50 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="BkF-x3-7fX" customClass="RoomMemberTitleView">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="117"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7U9-Y6-cEm" customClass="MXKImageView">
-                    <rect key="frame" x="258" y="11" width="84" height="84"/>
-                    <color key="backgroundColor" red="0.6886889638" green="1" blue="0.74383144840000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <accessibility key="accessibilityConfiguration" identifier="MemberAvatar"/>
-                    <constraints>
-                        <constraint firstAttribute="width" secondItem="7U9-Y6-cEm" secondAttribute="height" multiplier="1:1" id="9ct-O9-7am"/>
-                        <constraint firstAttribute="width" constant="84" id="BeT-JY-cq1"/>
-                    </constraints>
-                </view>
                 <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="f6h-pw-FvU">
-                    <rect key="frame" x="322" y="6" width="30" height="32"/>
+                    <rect key="frame" x="209" y="6" width="30" height="32"/>
                     <accessibility key="accessibilityConfiguration" identifier="MemberBadge"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="30" id="Rz8-gR-gAm"/>
                         <constraint firstAttribute="height" constant="32" id="dHM-zo-WVT"/>
                     </constraints>
                 </imageView>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VJM-ib-LUP">
+                    <rect key="frame" x="132" y="11" width="110" height="33"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                    <accessibility key="accessibilityConfiguration" identifier="RoomMemberDetailsVCAvatarMask"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="110" id="IYH-gQ-dbK"/>
+                    </constraints>
+                </view>
             </subviews>
             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
             <accessibility key="accessibilityConfiguration" identifier="RoomMemberTitleView"/>
             <constraints>
-                <constraint firstItem="7U9-Y6-cEm" firstAttribute="centerX" secondItem="BkF-x3-7fX" secondAttribute="centerX" id="C5g-ho-90L"/>
-                <constraint firstItem="7U9-Y6-cEm" firstAttribute="top" secondItem="BkF-x3-7fX" secondAttribute="top" constant="11" id="Kwt-Sd-REk"/>
-                <constraint firstItem="f6h-pw-FvU" firstAttribute="trailing" secondItem="7U9-Y6-cEm" secondAttribute="trailing" constant="10" id="V4L-tJ-obt"/>
-                <constraint firstItem="7U9-Y6-cEm" firstAttribute="top" secondItem="f6h-pw-FvU" secondAttribute="top" constant="5" id="lPk-ot-k5l"/>
+                <constraint firstItem="f6h-pw-FvU" firstAttribute="top" secondItem="VJM-ib-LUP" secondAttribute="top" constant="-5" id="0pn-Nk-1zK"/>
+                <constraint firstAttribute="bottom" secondItem="VJM-ib-LUP" secondAttribute="bottom" id="5EZ-YP-0he"/>
+                <constraint firstItem="VJM-ib-LUP" firstAttribute="centerX" secondItem="BkF-x3-7fX" secondAttribute="centerX" id="I5C-UZ-BnC"/>
+                <constraint firstItem="VJM-ib-LUP" firstAttribute="top" secondItem="BkF-x3-7fX" secondAttribute="top" constant="11" id="gGL-UL-DHn"/>
+                <constraint firstItem="f6h-pw-FvU" firstAttribute="trailing" secondItem="VJM-ib-LUP" secondAttribute="trailing" constant="-3" id="ilt-qd-gIW"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="memberAvatar" destination="7U9-Y6-cEm" id="8PP-8r-xoI"/>
-                <outlet property="memberAvatarCenterXConstraint" destination="C5g-ho-90L" id="ILx-zG-Dbj"/>
+                <outlet property="memberAvatarMask" destination="VJM-ib-LUP" id="cnl-NC-4DH"/>
+                <outlet property="memberAvatarMaskCenterXConstraint" destination="I5C-UZ-BnC" id="rc9-oe-GrK"/>
                 <outlet property="memberBadge" destination="f6h-pw-FvU" id="pDM-O6-238"/>
             </connections>
         </view>

--- a/Riot/Views/RoomTitle/ExpandedRoomTitleView.h
+++ b/Riot/Views/RoomTitle/ExpandedRoomTitleView.h
@@ -18,6 +18,7 @@
 
 @interface ExpandedRoomTitleView : RoomTitleView
 
+@property (weak, nonatomic) IBOutlet MXKImageView *roomAvatar;
 @property (weak, nonatomic) IBOutlet UIView *roomAvatarHeaderBackground;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *roomAvatarHeaderBackgroundHeightConstraint;
 

--- a/Riot/Views/RoomTitle/ExpandedRoomTitleView.m
+++ b/Riot/Views/RoomTitle/ExpandedRoomTitleView.m
@@ -19,6 +19,8 @@
 
 #import "RiotDesignValues.h"
 
+#import "MXRoomSummary+Riot.h"
+
 @implementation ExpandedRoomTitleView
 
 + (UINib *)nib
@@ -47,6 +49,8 @@
     
     if (self.mxRoom)
     {
+        [self.mxRoom.summary setRoomAvatarImageIn:self.roomAvatar];
+        
         self.displayNameTextField.text = self.mxRoom.summary.displayname;
         if (!self.displayNameTextField.text.length)
         {
@@ -104,9 +108,17 @@
     }
     else
     {
+        self.roomAvatar.image = nil;
+        
         self.roomTopic.text = nil;
         self.roomMembers.text = nil;
     }
+    
+    // Round image view for thumbnail
+    self.roomAvatar.layer.cornerRadius = self.roomAvatar.frame.size.width / 2;
+    self.roomAvatar.clipsToBounds = YES;
+    
+    self.roomAvatar.defaultBackgroundColor = kRiotSecondaryBgColor;
     
     // Force the layout of subviews to update the position of 'bottomBorderView' which is used to define the actual height of the preview container.
     [self layoutIfNeeded];

--- a/Riot/Views/RoomTitle/ExpandedRoomTitleView.xib
+++ b/Riot/Views/RoomTitle/ExpandedRoomTitleView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,19 +13,32 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="BkF-x3-7fX" customClass="ExpandedRoomTitleView">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="215"/>
+            <rect key="frame" x="0.0" y="0.0" width="600" height="193"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uSp-YH-L18">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="117"/>
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="95"/>
+                    <subviews>
+                        <view clipsSubviews="YES" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-n9-4dA" customClass="MXKImageView">
+                            <rect key="frame" x="258" y="11" width="84" height="84"/>
+                            <color key="backgroundColor" red="0.6886889638" green="1" blue="0.74383144840000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <accessibility key="accessibilityConfiguration" identifier="MemberAvatar"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="eEk-n9-4dA" secondAttribute="height" multiplier="1:1" id="2HI-Mo-nH4"/>
+                                <constraint firstAttribute="width" constant="84" id="Yye-G1-hCH"/>
+                            </constraints>
+                        </view>
+                    </subviews>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <accessibility key="accessibilityConfiguration" identifier="RoomAvatarHeaderBackground"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="117" id="DzD-aR-3eV"/>
+                        <constraint firstAttribute="height" constant="95" id="DzD-aR-3eV"/>
+                        <constraint firstItem="eEk-n9-4dA" firstAttribute="centerX" secondItem="uSp-YH-L18" secondAttribute="centerX" id="W1w-ZX-f2d"/>
+                        <constraint firstAttribute="bottom" secondItem="eEk-n9-4dA" secondAttribute="bottom" id="hXd-bM-Bbb"/>
                     </constraints>
                 </view>
                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Room Name" textAlignment="center" adjustsFontSizeToFit="NO" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="6uH-I3-RQg">
-                    <rect key="frame" x="249" y="125" width="103" height="23"/>
+                    <rect key="frame" x="249" y="103" width="103" height="23"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <accessibility key="accessibilityConfiguration" identifier="DisplayNameTextField"/>
                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
@@ -35,21 +48,21 @@
                     </connections>
                 </textField>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qD3-kA-DSI">
-                    <rect key="frame" x="282" y="153" width="36" height="17"/>
+                    <rect key="frame" x="282" y="131" width="36" height="17"/>
                     <accessibility key="accessibilityConfiguration" identifier="RoomTopic"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ou0-3Z-weL">
-                    <rect key="frame" x="282" y="184" width="36" height="17"/>
+                    <rect key="frame" x="282" y="162" width="36" height="17"/>
                     <accessibility key="accessibilityConfiguration" identifier="RoomMembers"/>
                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="members_list_icon.png" translatesAutoresizingMaskIntoConstraints="NO" id="S3Y-wJ-HOe">
-                    <rect key="frame" x="260" y="185.5" width="15" height="15"/>
+                    <rect key="frame" x="260" y="163.5" width="15" height="15"/>
                     <accessibility key="accessibilityConfiguration" identifier="RoomMembersDetailsIcon"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="15" id="XTx-6p-2wB"/>
@@ -57,22 +70,22 @@
                     </constraints>
                 </imageView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ckb-7c-sTg">
-                    <rect key="frame" x="0.0" y="214" width="600" height="1"/>
+                    <rect key="frame" x="0.0" y="192" width="600" height="1"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="D7c-fR-aRY"/>
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8HH-9b-1yH">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="177"/>
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="155"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MFb-0F-eO8">
-                    <rect key="frame" x="0.0" y="177" width="322" height="38"/>
+                    <rect key="frame" x="0.0" y="155" width="322" height="38"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tsg-nl-P3k">
-                    <rect key="frame" x="322" y="173.5" width="38" height="38"/>
+                    <rect key="frame" x="322" y="151.5" width="38" height="38"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="add_participant.png" translatesAutoresizingMaskIntoConstraints="NO" id="i40-fd-AlH">
                             <rect key="frame" x="10" y="10" width="18" height="18"/>
@@ -133,6 +146,7 @@
                 <outlet property="addParticipantMask" destination="tsg-nl-P3k" id="ADj-t1-9wf"/>
                 <outlet property="bottomBorderView" destination="Ckb-7c-sTg" id="2Ky-GN-bO0"/>
                 <outlet property="displayNameTextField" destination="6uH-I3-RQg" id="MfX-LQ-C2K"/>
+                <outlet property="roomAvatar" destination="eEk-n9-4dA" id="5jd-Dx-tXE"/>
                 <outlet property="roomAvatarHeaderBackground" destination="uSp-YH-L18" id="sfW-ED-5bD"/>
                 <outlet property="roomAvatarHeaderBackgroundHeightConstraint" destination="DzD-aR-3eV" id="SuC-mO-epX"/>
                 <outlet property="roomDetailsMask" destination="MFb-0F-eO8" id="ajK-sr-qf7"/>
@@ -144,6 +158,6 @@
     </objects>
     <resources>
         <image name="add_participant.png" width="58" height="58"/>
-        <image name="members_list_icon.png" width="12" height="12"/>
+        <image name="members_list_icon.png" width="15" height="15"/>
     </resources>
 </document>

--- a/Riot/Views/RoomTitle/PreviewRoomTitleView.h
+++ b/Riot/Views/RoomTitle/PreviewRoomTitleView.h
@@ -23,6 +23,7 @@
 
 @property (weak, nonatomic) IBOutlet UIView *mainHeaderContainer;
 
+@property (weak, nonatomic) IBOutlet MXKImageView *roomAvatar;
 @property (weak, nonatomic) IBOutlet UILabel *roomTopic;
 @property (weak, nonatomic) IBOutlet UILabel *roomMembers;
 @property (weak, nonatomic) IBOutlet UIView *roomMembersDetailsIcon;
@@ -33,5 +34,8 @@
 @property (weak, nonatomic) IBOutlet UIButton *rightButton;
 @property (weak, nonatomic) IBOutlet UILabel *subNoticeLabel;
 @property (weak, nonatomic) IBOutlet UIView *bottomBorderView;
+
+@property (nonatomic) NSString *roomAvatarURL;
+@property (nonatomic) UIImage  *roomAvatarPlaceholder;
 
 @end

--- a/Riot/Views/RoomTitle/PreviewRoomTitleView.m
+++ b/Riot/Views/RoomTitle/PreviewRoomTitleView.m
@@ -19,6 +19,8 @@
 
 #import "RiotDesignValues.h"
 
+#import "MXRoomSummary+Riot.h"
+
 @implementation PreviewRoomTitleView
 
 + (UINib *)nib
@@ -93,6 +95,15 @@
     // Consider in priority the preview data (if any)
     if (self.roomPreviewData)
     {
+        if (self.roomAvatarURL)
+        {
+            [self.roomAvatar setImageURL:self.roomAvatarURL withType:nil andImageOrientation:UIImageOrientationUp previewImage:[UIImage imageNamed:@"placeholder"]];
+        }
+        else
+        {
+            self.roomAvatar.image = self.roomAvatarPlaceholder;
+        }
+        
         // Room topic
         self.roomTopic.text = self.roomPreviewData.roomTopic;
         
@@ -142,6 +153,8 @@
     }
     else if (self.mxRoom)
     {
+        [self.mxRoom.summary setRoomAvatarImageIn:self.roomAvatar];
+        
         // The user is here invited to join a room (This invitation has been received from server sync)
         self.displayNameTextField.text = self.mxRoom.summary.displayname;
         if (!self.displayNameTextField.text.length)
@@ -206,13 +219,35 @@
     }
     else
     {
+        self.roomAvatar.image = self.roomAvatarPlaceholder;
+        
         self.roomMembers.text = nil;
         self.roomTopic.text = nil;
         self.previewLabel.text = nil;
     }
     
+    // Round image view for thumbnail
+    self.roomAvatar.layer.cornerRadius = self.roomAvatar.frame.size.width / 2;
+    self.roomAvatar.clipsToBounds = YES;
+    
+    self.roomAvatar.defaultBackgroundColor = kRiotSecondaryBgColor;
+    
     // Force the layout of subviews to update the position of 'bottomBorderView' which is used to define the actual height of the preview container.
     [self layoutIfNeeded];
+}
+
+- (void)setRoomAvatarURL:(NSString *)roomAvatarURL
+{
+    _roomAvatarURL = roomAvatarURL;
+    
+    [self refreshDisplay];
+}
+
+- (void)setRoomAvatarPlaceholder:(UIImage *)roomAvatarPlaceholder
+{
+    _roomAvatarPlaceholder = roomAvatarPlaceholder;
+    
+    [self refreshDisplay];
 }
 
 @end

--- a/Riot/Views/RoomTitle/PreviewRoomTitleView.xib
+++ b/Riot/Views/RoomTitle/PreviewRoomTitleView.xib
@@ -1,11 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -27,6 +28,15 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BkF-x3-7fX">
                     <rect key="frame" x="0.0" y="0.0" width="600" height="215"/>
                     <subviews>
+                        <view clipsSubviews="YES" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="4yt-FK-V2Z" customClass="MXKImageView">
+                            <rect key="frame" x="258" y="34" width="84" height="84"/>
+                            <color key="backgroundColor" red="0.6886889638" green="1" blue="0.74383144840000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <accessibility key="accessibilityConfiguration" identifier="MemberAvatar"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="84" id="bVm-6i-oVQ"/>
+                                <constraint firstAttribute="width" secondItem="4yt-FK-V2Z" secondAttribute="height" multiplier="1:1" id="hvA-vY-Mhn"/>
+                            </constraints>
+                        </view>
                         <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Room Name" textAlignment="center" adjustsFontSizeToFit="NO" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="6uH-I3-RQg">
                             <rect key="frame" x="249" y="126" width="103" height="22"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -72,8 +82,10 @@
                         <constraint firstItem="S3Y-wJ-HOe" firstAttribute="leading" secondItem="ou0-3Z-weL" secondAttribute="trailing" constant="7" id="JrS-kW-PJv"/>
                         <constraint firstItem="6uH-I3-RQg" firstAttribute="top" secondItem="BkF-x3-7fX" secondAttribute="top" constant="126" id="Piq-rp-Pae"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Tk0-pA-9a0" secondAttribute="trailing" constant="31" id="RNL-2W-QLd"/>
+                        <constraint firstItem="4yt-FK-V2Z" firstAttribute="centerX" secondItem="BkF-x3-7fX" secondAttribute="centerX" id="Scs-DA-3V9"/>
                         <constraint firstAttribute="bottom" secondItem="ou0-3Z-weL" secondAttribute="bottom" constant="14" id="Sxa-8V-tnQ"/>
                         <constraint firstItem="Tk0-pA-9a0" firstAttribute="top" secondItem="6uH-I3-RQg" secondAttribute="bottom" constant="5" id="TUS-xE-O6O"/>
+                        <constraint firstItem="6uH-I3-RQg" firstAttribute="top" secondItem="4yt-FK-V2Z" secondAttribute="bottom" constant="8" id="Wsd-KT-hxy"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6uH-I3-RQg" secondAttribute="trailing" constant="31" id="aK3-vQ-EVu"/>
                         <constraint firstItem="ou0-3Z-weL" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="BkF-x3-7fX" secondAttribute="leading" constant="31" id="c9h-h2-VEs"/>
                         <constraint firstItem="6uH-I3-RQg" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="BkF-x3-7fX" secondAttribute="leading" constant="31" id="gnq-cO-l4Y"/>
@@ -174,6 +186,7 @@
                 <outlet property="mainHeaderContainer" destination="BkF-x3-7fX" id="1fp-xz-ETJ"/>
                 <outlet property="previewLabel" destination="gIX-nY-f6M" id="Bxi-6M-rTb"/>
                 <outlet property="rightButton" destination="461-vO-hLZ" id="u8R-Rg-WAv"/>
+                <outlet property="roomAvatar" destination="4yt-FK-V2Z" id="epr-4f-7cE"/>
                 <outlet property="roomMembers" destination="ou0-3Z-weL" id="lRs-fz-QXc"/>
                 <outlet property="roomMembersDetailsIcon" destination="S3Y-wJ-HOe" id="QjQ-wY-EOS"/>
                 <outlet property="roomTopic" destination="Tk0-pA-9a0" id="iAe-bC-f6X"/>

--- a/Riot/Views/RoomTitle/RoomAvatarTitleView.h
+++ b/Riot/Views/RoomTitle/RoomAvatarTitleView.h
@@ -18,10 +18,7 @@
 
 @interface RoomAvatarTitleView : MXKRoomTitleView
 
-@property (weak, nonatomic) IBOutlet MXKImageView *roomAvatar;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *roomAvatarCenterXConstraint;
-
-@property (nonatomic) NSString *roomAvatarURL;
-@property (nonatomic) UIImage  *roomAvatarPlaceholder;
+@property (weak, nonatomic) IBOutlet UIView *roomAvatarMask;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *roomAvatarMaskCenterXConstraint;
 
 @end

--- a/Riot/Views/RoomTitle/RoomAvatarTitleView.m
+++ b/Riot/Views/RoomTitle/RoomAvatarTitleView.m
@@ -85,52 +85,10 @@
                 CGSize navBarSize = navigationBar.frame.size;
                 CGFloat superviewCenterX = frame.origin.x + (frame.size.width / 2);
                 
-                self.roomAvatarCenterXConstraint.constant = (navBarSize.width / 2) - superviewCenterX;
+                self.roomAvatarMaskCenterXConstraint.constant = (navBarSize.width / 2) - superviewCenterX;
             }
         }
     }
-}
-
-- (void)refreshDisplay
-{
-    [super refreshDisplay];
-    
-    if (self.mxRoom)
-    {
-        [self.mxRoom.summary setRoomAvatarImageIn:self.roomAvatar];
-    }
-    else if (self.roomAvatarURL)
-    {
-        [self.roomAvatar setImageURL:self.roomAvatarURL withType:nil andImageOrientation:UIImageOrientationUp previewImage:[UIImage imageNamed:@"placeholder"]];
-    }
-    else if (self.roomAvatarPlaceholder)
-    {
-        self.roomAvatar.image = self.roomAvatarPlaceholder;
-    }
-    else
-    {
-        self.roomAvatar.image = nil;
-    }
-    
-    // Round image view for thumbnail
-    self.roomAvatar.layer.cornerRadius = self.roomAvatar.frame.size.width / 2;
-    self.roomAvatar.clipsToBounds = YES;
-    
-    self.roomAvatar.defaultBackgroundColor = kRiotSecondaryBgColor;
-}
-
-- (void)setRoomAvatarURL:(NSString *)roomAvatarURL
-{
-    _roomAvatarURL = roomAvatarURL;
-    
-    [self refreshDisplay];
-}
-
-- (void)setRoomAvatarPlaceholder:(UIImage *)roomAvatarPlaceholder
-{
-    _roomAvatarPlaceholder = roomAvatarPlaceholder;
-    
-    [self refreshDisplay];
 }
 
 @end

--- a/Riot/Views/RoomTitle/RoomAvatarTitleView.xib
+++ b/Riot/Views/RoomTitle/RoomAvatarTitleView.xib
@@ -1,41 +1,40 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11762"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13196"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="BkF-x3-7fX" customClass="RoomAvatarTitleView">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="117"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7U9-Y6-cEm" customClass="MXKImageView">
-                    <rect key="frame" x="258" y="11" width="84" height="84"/>
-                    <color key="backgroundColor" red="0.6886889638" green="1" blue="0.74383144840000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <accessibility key="accessibilityConfiguration" identifier="RoomAvatar"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cCf-8Q-ono">
+                    <rect key="frame" x="132" y="11" width="110" height="33"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                    <accessibility key="accessibilityConfiguration" identifier="RoomMemberDetailsVCAvatarMask"/>
                     <constraints>
-                        <constraint firstAttribute="width" secondItem="7U9-Y6-cEm" secondAttribute="height" multiplier="1:1" id="9ct-O9-7am"/>
-                        <constraint firstAttribute="width" constant="84" id="BeT-JY-cq1"/>
+                        <constraint firstAttribute="width" constant="110" id="pWS-KO-25W"/>
                     </constraints>
                 </view>
             </subviews>
             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
             <accessibility key="accessibilityConfiguration" identifier="RoomTitle"/>
             <constraints>
-                <constraint firstItem="7U9-Y6-cEm" firstAttribute="centerX" secondItem="BkF-x3-7fX" secondAttribute="centerX" id="C5g-ho-90L"/>
-                <constraint firstItem="7U9-Y6-cEm" firstAttribute="top" secondItem="BkF-x3-7fX" secondAttribute="top" constant="11" id="Kwt-Sd-REk"/>
+                <constraint firstAttribute="bottom" secondItem="cCf-8Q-ono" secondAttribute="bottom" id="Aog-XC-o0k"/>
+                <constraint firstItem="cCf-8Q-ono" firstAttribute="centerX" secondItem="BkF-x3-7fX" secondAttribute="centerX" id="WFK-47-fKx"/>
+                <constraint firstItem="cCf-8Q-ono" firstAttribute="top" secondItem="BkF-x3-7fX" secondAttribute="top" constant="11" id="bS7-H7-pxo"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="roomAvatar" destination="7U9-Y6-cEm" id="VWF-cH-9Jv"/>
-                <outlet property="roomAvatarCenterXConstraint" destination="C5g-ho-90L" id="D2d-zo-km6"/>
+                <outlet property="roomAvatarMask" destination="cCf-8Q-ono" id="7m3-ou-P9k"/>
+                <outlet property="roomAvatarMaskCenterXConstraint" destination="WFK-47-fKx" id="q9A-QQ-30L"/>
             </connections>
         </view>
     </objects>


### PR DESCRIPTION
#1590 

The avatar are not displayed anymore in the navigation bar. They are displayed in a dedicated view in the view controller.
This change has been applied on RoomMemberDetailsViewController, ContactDetailsViewController and RoomViewController.