### PR TITLE
Add message sending via Siri

### DIFF
--- a/SiriIntents/Info.plist
+++ b/SiriIntents/Info.plist
@@ -30,6 +30,7 @@
 			<array>
 				<string>INStartAudioCallIntent</string>
 				<string>INStartVideoCallIntent</string>
+				<string>INSendMessageIntent</string>
 			</array>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
This PR for #1496. 

I didn't add possibility for sending messages for encrypted rooms because I need your advice. For encrypted rooms we need to use `MXCrypto`.

 Firstly, we need to add ability for creation `MXCrypto` instance without `MXSession`. I suggest to add `checkCryptoWithCredentials:(MXCredentials *)credentials complete:(void (^)(MXCrypto *))complete` method that will have implementation of the existing one created for using with `MXSession`. Version with `MXSession` then will call this new method.

Secondly, we need new method for encryption that can work without `MXRoom` instance. It can look like `encryptEventContent:withType:forRoomState:success:failure:`. Since this method will work with `MXRoomState` a new async method for retrieving `MXRoomState` instances must be created. This signature looks good for me `asyncRoomStateForRoomIds:success:failure:`.

After this two enhancements we can add message sending for encrypted rooms too.

Signed-off-by: Denis Morozov dmorozkn@gmail.com