### PR TITLE
Fix - tableView cellForRowAtIndexPath:

### DIFF
--- a/Riot/Model/Contact/ContactsDataSource.m
+++ b/Riot/Model/Contact/ContactsDataSource.m
@@ -640,8 +640,6 @@
         }
         return tableViewCell;
     }
-    
-    return nil;
 }
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath

--- a/Riot/ViewController/PeopleViewController.m
+++ b/Riot/ViewController/PeopleViewController.m
@@ -223,7 +223,8 @@
         }
     }
     
-    return nil;
+    // Return a fake cell to prevent app from crashing.
+    return [[UITableViewCell alloc] init];
 }
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath

--- a/Riot/ViewController/RoomParticipantsViewController.m
+++ b/Riot/ViewController/RoomParticipantsViewController.m
@@ -1123,6 +1123,11 @@
         
         cell = participantCell;
     }
+    else
+    {
+        // Return a fake cell to prevent app from crashing.
+        cell = [[UITableViewCell alloc] init];
+    }
     
     return cell;
 }

--- a/Riot/ViewController/StartChatViewController.m
+++ b/Riot/ViewController/StartChatViewController.m
@@ -353,6 +353,11 @@
         
         cell = participantCell;
     }
+    else
+    {
+        // Return a fake cell to prevent app from crashing.
+        cell = [[UITableViewCell alloc] init];
+    }
     
     return cell;
 }

--- a/Riot/ViewController/UsersDevicesViewController.m
+++ b/Riot/ViewController/UsersDevicesViewController.m
@@ -169,6 +169,11 @@
 
         cell = deviceCell;
     }
+    else
+    {
+        // Return a fake cell to prevent app from crashing.
+        cell = [[UITableViewCell alloc] init];
+    }
 
     return cell;
 }


### PR DESCRIPTION
return a fake cell to prevent app from crashing.