### PR TITLE
Crypto: Key sharing: Move the check of incoming key requests so that …

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -580,9 +580,6 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     }
     
     [self handleLaunchAnimation];
-
-    // Check if we need to display a key share dialog
-    [self checkPendingRoomKeyRequests];
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application
@@ -1932,6 +1929,14 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                     NSLog(@"[AppDelegate] relaunch a background sync for the kMXSessionStateDidChangeNotificationpending incoming push");
                     [self launchBackgroundSync];
                 }
+            }
+        }
+        else if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateActive)
+        {
+            if (mxSession.state == MXSessionStateRunning)
+            {
+                // Check if we need to display a key share dialog
+                [self checkPendingRoomKeyRequests];
             }
         }
         


### PR DESCRIPTION
…we can detect them at app startup.

https://github.com/vector-im/riot-meta/issues/121

This is now required because, with https://github.com/matrix-org/matrix-ios-sdk/pull/414, key requests can be available when app starts.