### PR TITLE
 Add basic OLED black theme

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -348,6 +348,7 @@
 "settings_ui_theme_auto" = "Auto";
 "settings_ui_theme_light" = "Light";
 "settings_ui_theme_dark" = "Dark";
+"settings_ui_theme_black" = "Black";
 "settings_ui_theme_picker_title" = "Select a theme";
 "settings_ui_theme_picker_message" = "\"Auto\" uses your device \"Invert Colours\" settings";
 

--- a/Riot/Utils/RiotDesignValues.h
+++ b/Riot/Utils/RiotDesignValues.h
@@ -62,6 +62,8 @@ extern UIStatusBarStyle kRiotDesignStatusBarStyle;
 extern UIBarStyle kRiotDesignSearchBarStyle;
 extern UIColor *kRiotDesignSearchBarTintColor;
 
+extern UIKeyboardAppearance kRiotKeyboard;
+
 /**
  `RiotDesignValues` class manages the Riot design parameters
  */

--- a/Riot/Utils/RiotDesignValues.m
+++ b/Riot/Utils/RiotDesignValues.m
@@ -112,9 +112,7 @@ UIKeyboardAppearance kRiotKeyboard;
     // Colors copied from Vector web
     kRiotColorLightGreen = UIColorFromRGB(0x50e2c2);
     kRiotColorLightOrange = UIColorFromRGB(0xf4c371);
-    
-    kRiotKeyboard = UIKeyboardAppearanceLight;
-    
+
     // Observe user interface theme change.
     [[NSUserDefaults standardUserDefaults] addObserver:[RiotDesignValues sharedInstance] forKeyPath:@"userInterfaceTheme" options:0 context:nil];
     [[RiotDesignValues sharedInstance] userInterfaceThemeDidChange];

--- a/Riot/Utils/RiotDesignValues.m
+++ b/Riot/Utils/RiotDesignValues.m
@@ -43,6 +43,7 @@ UIColor *kRiotColorOrange;
 // Riot Background Colors
 UIColor *kRiotBgColorWhite;
 UIColor *kRiotBgColorBlack;
+UIColor *kRiotBgColorOLEDBlack;
 UIColor *kRiotColorLightGrey;
 UIColor *kRiotColorLightBlack;
 UIColor *kRiotColorLightKeyboard;
@@ -61,6 +62,8 @@ NSInteger const kRiotRoomAdminLevel = 100;
 UIStatusBarStyle kRiotDesignStatusBarStyle = UIStatusBarStyleDefault;
 UIBarStyle kRiotDesignSearchBarStyle = UIBarStyleDefault;
 UIColor *kRiotDesignSearchBarTintColor = nil;
+
+UIKeyboardAppearance kRiotKeyboard;
 
 @implementation RiotDesignValues
 
@@ -92,6 +95,7 @@ UIColor *kRiotDesignSearchBarTintColor = nil;
     
     kRiotBgColorWhite = [UIColor whiteColor];
     kRiotBgColorBlack = UIColorFromRGB(0x2D2D2D);
+    kRiotBgColorOLEDBlack = [UIColor blackColor];
     
     kRiotColorLightGrey = UIColorFromRGB(0xF2F2F2);
     kRiotColorLightBlack = UIColorFromRGB(0x353535);
@@ -108,6 +112,8 @@ UIColor *kRiotDesignSearchBarTintColor = nil;
     // Colors copied from Vector web
     kRiotColorLightGreen = UIColorFromRGB(0x50e2c2);
     kRiotColorLightOrange = UIColorFromRGB(0xf4c371);
+    
+    kRiotKeyboard = UIKeyboardAppearanceLight;
     
     // Observe user interface theme change.
     [[NSUserDefaults standardUserDefaults] addObserver:[RiotDesignValues sharedInstance] forKeyPath:@"userInterfaceTheme" options:0 context:nil];
@@ -145,7 +151,6 @@ UIColor *kRiotDesignSearchBarTintColor = nil;
         theme = UIAccessibilityIsInvertColorsEnabled() ? @"dark" : @"light";
     }
     
-    // Currently only 2 themes is supported
     if ([theme isEqualToString:@"dark"])
     {
         // Set dark theme colors
@@ -164,6 +169,31 @@ UIColor *kRiotDesignSearchBarTintColor = nil;
         kRiotAuxiliaryColor = kRiotTextColorGray;
         kRiotOverlayColor = [UIColor colorWithWhite:0.3 alpha:0.5];
         kRiotKeyboardColor = kRiotColorDarkKeyboard;
+        
+        [UITextField appearance].keyboardAppearance = UIKeyboardAppearanceDark;
+        kRiotKeyboard = UIKeyboardAppearanceDark;
+    }
+    else if ([theme isEqualToString:@"black"])
+    {
+        // Set black theme colors
+        kRiotPrimaryBgColor = kRiotBgColorOLEDBlack;
+        kRiotSecondaryBgColor = kRiotColorLightBlack;
+        kRiotPrimaryTextColor = kRiotTextColorWhite;
+        kRiotSecondaryTextColor = kRiotTextColorGray;
+        kRiotPlaceholderTextColor = [UIColor colorWithWhite:1.0 alpha:0.3];
+        kRiotTopicTextColor = kRiotTextColorDarkWhite;
+        kRiotSelectedBgColor = [UIColor blackColor];
+        
+        kRiotDesignStatusBarStyle = UIStatusBarStyleLightContent;
+        kRiotDesignSearchBarStyle = UIBarStyleBlack;
+        kRiotDesignSearchBarTintColor = kRiotColorGreen;
+        
+        kRiotAuxiliaryColor = kRiotTextColorGray;
+        kRiotOverlayColor = [UIColor colorWithWhite:0.3 alpha:0.5];
+        kRiotKeyboardColor = kRiotColorDarkKeyboard;
+        
+        [UITextField appearance].keyboardAppearance = UIKeyboardAppearanceDark;
+        kRiotKeyboard = UIKeyboardAppearanceDark;
     }
     else
     {
@@ -183,6 +213,9 @@ UIColor *kRiotDesignSearchBarTintColor = nil;
         kRiotAuxiliaryColor = kRiotColorSilver;
         kRiotOverlayColor = [UIColor colorWithWhite:0.7 alpha:0.5];
         kRiotKeyboardColor = kRiotColorLightKeyboard;
+                
+        [UITextField appearance].keyboardAppearance = UIKeyboardAppearanceLight;
+        kRiotKeyboard = UIKeyboardAppearanceLight;
     }
     
     [[NSNotificationCenter defaultCenter] postNotificationName:kRiotDesignValuesDidChangeThemeNotification object:nil];

--- a/Riot/ViewController/RoomSettingsViewController.m
+++ b/Riot/ViewController/RoomSettingsViewController.m
@@ -2081,6 +2081,8 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
             topicTextView.editable = (oneSelfPowerLevel >= [powerLevels minimumPowerLevelForSendingEventAsStateEvent:kMXEventTypeStringRoomTopic]);
             topicTextView.textColor = kRiotSecondaryTextColor;
             
+            topicTextView.keyboardAppearance = kRiotKeyboard;
+            
             cell = roomTopicCell;
         }
         else if (row == ROOM_SETTINGS_MAIN_SECTION_ROW_NAME)

--- a/Riot/ViewController/SettingsViewController.m
+++ b/Riot/ViewController/SettingsViewController.m
@@ -3542,7 +3542,7 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
 {
     __weak typeof(self) weakSelf = self;
 
-    __block UIAlertAction *autoAction, *lightAction, *darkAction;
+    __block UIAlertAction *autoAction, *lightAction, *darkAction, *blackAction;
     NSString *themePickerMessage;
 
     void (^actionBlock)(UIAlertAction *action) = ^(UIAlertAction * action) {
@@ -3563,6 +3563,10 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
             else if (action == darkAction)
             {
                 newTheme = @"dark";
+            }
+            else if (action == blackAction)
+            {
+                newTheme = @"black";
             }
 
             NSString *theme = [[NSUserDefaults standardUserDefaults] stringForKey:@"userInterfaceTheme"];
@@ -3598,6 +3602,10 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
     darkAction = [UIAlertAction actionWithTitle:NSLocalizedStringFromTable(@"settings_ui_theme_dark", @"Vector", nil)
                                            style:UIAlertActionStyleDefault
                                          handler:actionBlock];
+    blackAction = [UIAlertAction actionWithTitle:NSLocalizedStringFromTable(@"settings_ui_theme_black", @"Vector", nil)
+                                          style:UIAlertActionStyleDefault
+                                        handler:actionBlock];
+
 
     UIAlertController *themePicker = [UIAlertController alertControllerWithTitle:NSLocalizedStringFromTable(@"settings_ui_theme_picker_title", @"Vector", nil)
                                                                          message:themePickerMessage
@@ -3609,6 +3617,7 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
     }
     [themePicker addAction:lightAction];
     [themePicker addAction:darkAction];
+    [themePicker addAction:blackAction];
 
     // Cancel button
     [themePicker addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"cancel"]

--- a/Riot/Views/RoomInputToolbar/RoomInputToolbarView.m
+++ b/Riot/Views/RoomInputToolbar/RoomInputToolbarView.m
@@ -92,6 +92,8 @@
     growingTextView.font = [UIFont systemFontOfSize:15];
     growingTextView.textColor = kRiotPrimaryTextColor;
     growingTextView.tintColor = kRiotColorGreen;
+    
+    growingTextView.internalTextView.keyboardAppearance = kRiotKeyboard;
 }
 
 #pragma mark -


### PR DESCRIPTION
Adds a basic OLED black theme. Only the main background color is changed in this PR but it opens up the ability to change other colors to work well on OLED screens.

This PR also changes the keyboard to be dark in the dark and black themes.

Works on #1444, fixes #1620 