### PR TITLE
Crypto: BF: The share key dialog can appear with a 'null' device (#1683)

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -3412,22 +3412,58 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
         if (!roomKeyRequestViewController && pendingKeyRequests.count)
         {
             // Pick the first coming user/device pair
-            NSString *user = pendingKeyRequests.userIds.firstObject;
-            NSString *device = [pendingKeyRequests deviceIdsForUser:user].firstObject;
+            NSString *userId = pendingKeyRequests.userIds.firstObject;
+            NSString *deviceId = [pendingKeyRequests deviceIdsForUser:userId].firstObject;
 
-            [mxSession.crypto deviceWithDeviceId:device ofUser:user complete:^(MXDeviceInfo *device) {
+            // Give the client a chance to refresh the device list
+            // Note: react-sdk does not do a force download
+            [mxSession.crypto downloadKeys:@[userId] success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap) {
 
-                NSLog(@"[AppDelegate] checkPendingRoomKeyRequestsInSession: Open dialog");
+                MXDeviceInfo *deviceInfo = [usersDevicesInfoMap objectForDevice:deviceId forUser:userId];
+                if (deviceInfo)
+                {
+                    BOOL wasNewDevice = (deviceInfo.verified == MXDeviceUnknown);
 
-                roomKeyRequestViewController = [[RoomKeyRequestViewController alloc] initWithDeviceInfo:device andMatrixSession:mxSession onComplete:^{
+                    void (^openDialog)() = ^void()
+                    {
+                        NSLog(@"[AppDelegate] checkPendingRoomKeyRequestsInSession: Open dialog for %@", deviceInfo);
 
-                    roomKeyRequestViewController = nil;
+                        roomKeyRequestViewController = [[RoomKeyRequestViewController alloc] initWithDeviceInfo:deviceInfo wasNewDevice:wasNewDevice andMatrixSession:mxSession onComplete:^{
 
-                    // Check next pending key request, if any
-                    [self checkPendingRoomKeyRequests];
-                }];
+                            roomKeyRequestViewController = nil;
 
-                [roomKeyRequestViewController show];
+                            // Check next pending key request, if any
+                            [self checkPendingRoomKeyRequests];
+                        }];
+
+                        [roomKeyRequestViewController show];
+                    };
+
+                    // If the device was new before, it's not any more.
+                    if (wasNewDevice)
+                    {
+                        [mxSession.crypto setDeviceVerification:MXDeviceUnverified forDevice:deviceId ofUser:userId success:openDialog failure:nil];
+                    }
+                    else
+                    {
+                        openDialog();
+                    }
+                }
+                else
+                {
+                    NSLog(@"[AppDelegate] checkPendingRoomKeyRequestsInSession: No details found for device %@:%@", userId, deviceId);
+
+                    // Ignore this device to avoid to loop on it
+                    [mxSession.crypto ignoreAllPendingKeyRequestsFromUser:userId andDevice:deviceId onComplete:^{
+                        // And check next requests
+                        [self checkPendingRoomKeyRequests];
+                    }];
+                }
+
+            } failure:^(NSError *error) {
+                // Retry later
+                NSLog(@"[AppDelegate] checkPendingRoomKeyRequestsInSession: Failed to download device keys. Retry");
+                [self checkPendingRoomKeyRequests];
             }];
         }
     }];

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -544,6 +544,7 @@
 
 // Room key request dialog
 "e2e_room_key_request_title" = "Encryption key request";
+"e2e_room_key_request_message_new_device" = "You added a new device '%@', which is requesting encryption keys.";
 "e2e_room_key_request_message" = "Your unverified device '%@' is requesting encryption keys.";
 "e2e_room_key_request_start_verification" = "Start verification...";
 "e2e_room_key_request_share_without_verifying" = "Share without verifying";

--- a/Riot/Assets/fr.lproj/Vector.strings
+++ b/Riot/Assets/fr.lproj/Vector.strings
@@ -471,3 +471,10 @@
 // Share extension
 "share_extension_auth_prompt" = "Connectez-vous dans l'application pour partager du contenu";
 "share_extension_failed_to_encrypt" = "Échec d'envoi. Vérifiez les paramètres de chiffrement de ce salon dans l'application";
+// Room key request dialog
+"e2e_room_key_request_title" = "Demande de clés de chiffrement";
+"e2e_room_key_request_message_new_device" = "Vous avez ajouté un nouvel appareil '%@', qui demande les clés de chiffrement.";
+"e2e_room_key_request_message" = "Votre appareil non vérifié '%@' demande les clés de chiffrement.";
+"e2e_room_key_request_start_verification" = "Commencer la vérification...";
+"e2e_room_key_request_share_without_verifying" = "Partager sans vérifier";
+"e2e_room_key_request_ignore_request" = "Ignorer la demande";

--- a/Riot/ViewController/RoomKeyRequestViewController.h
+++ b/Riot/ViewController/RoomKeyRequestViewController.h
@@ -38,11 +38,12 @@
  Initialise an `RoomKeyRequestViewController` instance.
 
  @param deviceInfo the device to share keys to.
+ @param wasNewDevice flag indicating whether this is the first time we meet the device.
  @param session the related matrix session.
  @param onComplete a block called when the the dialog is closed.
  @return the newly created instance.
  */
-- (instancetype)initWithDeviceInfo:(MXDeviceInfo*)deviceInfo andMatrixSession:(MXSession*)session onComplete:(void (^)())onComplete;
+- (instancetype)initWithDeviceInfo:(MXDeviceInfo*)deviceInfo wasNewDevice:(BOOL)wasNewDevice andMatrixSession:(MXSession*)session onComplete:(void (^)())onComplete;
 
 /**
  Show the dialog in a modal way.

--- a/Riot/ViewController/RoomKeyRequestViewController.m
+++ b/Riot/ViewController/RoomKeyRequestViewController.m
@@ -24,18 +24,21 @@
     void (^onComplete)();
 
     EncryptionInfoView *encryptionInfoView;
+
+    BOOL wasNewDevice;
 }
 @end
 
 @implementation RoomKeyRequestViewController
 
-- (instancetype)initWithDeviceInfo:(MXDeviceInfo *)deviceInfo andMatrixSession:(MXSession *)session onComplete:(void (^)())onCompleteBlock
+- (instancetype)initWithDeviceInfo:(MXDeviceInfo *)deviceInfo wasNewDevice:(BOOL)theWasNewDevice andMatrixSession:(MXSession *)session onComplete:(void (^)())onCompleteBlock
 {
     self = [super init];
     if (self)
     {
         _mxSession = session;
         _device = deviceInfo;
+        wasNewDevice = theWasNewDevice;
         onComplete = onCompleteBlock;
     }
     return self;
@@ -48,7 +51,16 @@
     if (rootViewController)
     {
         NSString *title = NSLocalizedStringFromTable(@"e2e_room_key_request_title", @"Vector", nil);
-        NSString *message = [NSString stringWithFormat:NSLocalizedStringFromTable(@"e2e_room_key_request_message", @"Vector", nil), _device.displayName];
+        NSString *message;
+        if (wasNewDevice)
+        {
+            message = [NSString stringWithFormat:NSLocalizedStringFromTable(@"e2e_room_key_request_message_new_device", @"Vector", nil), _device.displayName];
+        }
+        else
+        {
+            message = [NSString stringWithFormat:NSLocalizedStringFromTable(@"e2e_room_key_request_message", @"Vector", nil), _device.displayName];
+        }
+
         _alertController = [UIAlertController alertControllerWithTitle:title
                                                                message:message
                                                         preferredStyle:UIAlertControllerStyleAlert];


### PR DESCRIPTION
Make sure we download requester device keys before showing the share dialog.
Also, add "You added a new device '%@', which is requesting encryption keys." string