### PR TITLE
Missing Push Notifications again

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -180,7 +180,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     /**
      Cache for payloads received with incoming push notifications.
      The key is the event id. The value, the payload.
-     Note: for the moment, objets in this dictionary are never removed but
+     Note: for the moment, objects in this dictionary are never removed but
      the impact on memory is low.
      */
     NSMutableDictionary <NSString*, NSDictionary*> *incomingPushPayloads;
@@ -1228,7 +1228,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                 
                 NSLog(@"[AppDelegate][Push] launchBackgroundSync: the background sync failed. Error: %@ (%@). incomingPushEventIdsCopy: %@ - self.incomingPushEventIds: %@", error.domain, @(error.code), incomingPushEventIdsCopy, incomingPushEventIds);
 
-                // Trigger local notifications when the sync with HS fails
+                // Trigger limited local notifications when the sync with HS fails
                 [self handleLimitedLocalNotifications:account.mxSession events:incomingPushEventIdsCopy];
 
                 // Update app icon badge number
@@ -1262,7 +1262,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
         MXEvent *event;
 
         // Ignore event already notified to the user
-        if ([self displayedFailedSyncLocalNotificationForEvent:eventId andUser:account.mxCredentials.userId])
+        if ([self displayedLimitedLocalNotificationForEvent:eventId andUser:account.mxCredentials.userId])
         {
             NSLog(@"[AppDelegate][Push] handleLocalNotificationsForAccount: Skip event already displayed in a failed sync notif. Event id: %@", eventId);
             continue;
@@ -1502,7 +1502,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
 
     for (NSString *eventId in events)
     {
-        if ([self displayedFailedSyncLocalNotificationForEvent:eventId andUser:userId])
+        if ([self displayedLimitedLocalNotificationForEvent:eventId andUser:userId])
         {
             NSLog(@"[AppDelegate][Push] handleLocalNotificationsForFailedSync: Notification for event %@ already exists", eventId);
             continue;
@@ -1537,7 +1537,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
 }
 
 /**
- Build the body of the "limited" notification to display to the user.
+ Build the body for the "limited" notification to display to the user.
 
  @param eventId the id of the event the app failed to get data.
  @param mxSession the matrix session where the /sync failed.
@@ -1573,27 +1573,27 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
 }
 
 /**
- Return already displayed notification for a failed sync.
+ Return the already displayed limited notification for an event.
 
  @param eventId the id of the event attached to the notification to find.
  @param userId the id of the user attached to the notification to find.
  @return the local notification if any.
  */
-- (UILocalNotification*)displayedFailedSyncLocalNotificationForEvent:(NSString*)eventId andUser:(NSString*)userId
+- (UILocalNotification*)displayedLimitedLocalNotificationForEvent:(NSString*)eventId andUser:(NSString*)userId
 {
-    UILocalNotification *localNotificationForFailedSync;
+    UILocalNotification *limitedLocalNotification;
     for (UILocalNotification *localNotification in [[UIApplication sharedApplication] scheduledLocalNotifications])
     {
         if ([localNotification.userInfo[@"type"] isEqualToString:@"failed_sync"]
             && [localNotification.userInfo[@"event_id"] isEqualToString:eventId]
             && [localNotification.userInfo[@"user_id"] isEqualToString:userId])
         {
-            localNotificationForFailedSync = localNotification;
+            limitedLocalNotification = localNotification;
             break;
         }
     }
 
-    return localNotificationForFailedSync;
+    return limitedLocalNotification;
 }
 
 - (void)refreshApplicationIconBadgeNumber
@@ -2148,7 +2148,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                 {
                     NSLog(@"[AppDelegate][Push] initial sync failed with %tu pending incoming pushes", self.incomingPushEventIds[@(mxSession.hash)].count);
 
-                    // Trigger local notifications when the sync with HS fails
+                    // Trigger limited local notifications when the sync with HS fails
                     [self handleLimitedLocalNotifications:mxSession events:self.incomingPushEventIds[@(mxSession.hash)]];
 
                     // Update app icon badge number

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -180,8 +180,6 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     /**
      Cache for payloads received with incoming push notifications.
      The key is the event id. The value, the payload.
-     Note: for the moment, objects in this dictionary are never removed but
-     the impact on memory is low.
      */
     NSMutableDictionary <NSString*, NSDictionary*> *incomingPushPayloads;
 
@@ -548,6 +546,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     {
         [array removeAllObjects];
     }
+    [incomingPushPayloads removeAllObjects];
     
     // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     
@@ -1495,7 +1494,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     NSLog(@"[AppDelegate][Push] handleLocalNotificationsForFailedSync: incomingPushEventIds: %@", self.incomingPushEventIds[@(mxSession.hash)]);
     NSLog(@"[AppDelegate][Push] handleLocalNotificationsForFailedSync: events: %@", events);
 
-    if (events.count)
+    if (!events.count)
     {
         return;
     }

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -1469,13 +1469,15 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
 }
 
 /**
- Display limited notifications for events the app was not able to get data
+ Display "limited" notifications for events the app was not able to get data
  (because of /sync failure).
+
+ In this situation, we are only able to display "You received a message in %@".
 
  @param mxSession the matrix session where the /sync failed.
  @param events the list of events id we did not get data.
  */
-- (void)handleLocalNotificationsForFailedSync:(MXSession*)mxSession events:(NSArray<NSString *> *)events
+- (void)handleLimitedLocalNotifications:(MXSession*)mxSession events:(NSArray<NSString *> *)events
 {
     NSString *userId = mxSession.matrixRestClient.credentials.userId;
 
@@ -1518,7 +1520,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
 
         UILocalNotification *localNotificationForFailedSync =  [[UILocalNotification alloc] init];
         localNotificationForFailedSync.userInfo = userInfo;
-        localNotificationForFailedSync.alertBody = [self notificationBodyForFailedSyncEvent:eventId inMatrixSession:mxSession];
+        localNotificationForFailedSync.alertBody = [self limitedNotificationBodyForEvent:eventId inMatrixSession:mxSession];
 
         NSLog(@"[AppDelegate][Push] handleLocalNotificationsForFailedSync: Display notification for event %@", eventId);
         [[UIApplication sharedApplication] scheduleLocalNotification:localNotificationForFailedSync];
@@ -1532,8 +1534,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
  @param mxSession the matrix session where the /sync failed.
  @return the string to display in the local notification.
  */
-- (nullable NSString *)limited otificationBodyForEvent:(MXEvent *)event pushRule:(MXPushRule*)rule inAccount:(MXKAccount*)account
-- (nullable NSString *)notificationBodyForFailedSyncEvent:(NSString *)eventId inMatrixSession:(MXSession*)mxSession
+- (nullable NSString *)limitedNotificationBodyForEvent:(NSString *)eventId inMatrixSession:(MXSession*)mxSession
 {
     NSString *notificationBody;
 
@@ -2139,7 +2140,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                     NSLog(@"[AppDelegate][Push] initial sync failed with %tu pending incoming pushes", self.incomingPushEventIds[@(mxSession.hash)].count);
 
                     // Trigger local notifications when the sync with HS fails
-                    [self handleLocalNotificationsForFailedSync:mxSession events:self.incomingPushEventIds[@(mxSession.hash)]];
+                    [self handleLimitedLocalNotifications:mxSession events:self.incomingPushEventIds[@(mxSession.hash)]];
 
                     // Update app icon badge number
                     [self refreshApplicationIconBadgeNumber];

--- a/Riot/Assets/en.lproj/Localizable.strings
+++ b/Riot/Assets/en.lproj/Localizable.strings
@@ -44,6 +44,12 @@
 /* New action message from a specific person in a named room. */
 "IMAGE_FROM_USER_IN_ROOM" = "%@ posted a picture %@ in %@";
 
+/* A single unread message in a room */
+"SINGLE_UNREAD_IN_ROOM" = "You received a message in %@";
+
+/* A single unread message */
+"SINGLE_UNREAD" = "You received a message";
+
 /** Coalesced messages **/
 
 /* Multiple unread messages in a room */


### PR DESCRIPTION
Show a notification even if the app fails to sync with its hs to get all data.
#1696

I was not able to reproduce the use case but some rageshake logs show that it happens.
Commands to grep right lines:
`find ./2017-12-* -name '*.gz' -exec zgrep -- 'background sync fails' {} +`
or
`find ./2017-12-* -name '*.gz' -exec zgrep -- 'MXSession state changed while in background. mxSession.state: (' {} +`

A log file where the use case happened: https://riot.im/bugreports/listing/2017-12-27/163238/console.2.log.gz