### PR TITLE
AppDelegate: Enable log to file earlier

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -223,6 +223,26 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
 
 #pragma mark -
 
++ (void)initialize
+{
+    NSLog(@"[AppDelegate] initialize");
+
+    // Set the App Group identifier.
+    MXSDKOptions *sdkOptions = [MXSDKOptions sharedInstance];
+    sdkOptions.applicationGroupIdentifier = @"group.im.vector";
+
+    // Track SDK performance on Google analytics
+    sdkOptions.analyticsDelegate = [[MXGoogleAnalytics alloc] init];
+
+    // Redirect NSLogs to files only if we are not debugging
+    if (!isatty(STDERR_FILENO))
+    {
+        [MXLogger redirectNSLogToFiles:YES];
+    }
+
+    NSLog(@"[AppDelegate] initialize: Done");
+}
+
 + (AppDelegate*)theDelegate
 {
     return (AppDelegate*)[[UIApplication sharedApplication] delegate];
@@ -323,20 +343,6 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
 
 - (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions
 {
-    NSLog(@"[AppDelegate] willFinishLaunchingWithOptions");
-
-    // Set the App Group identifier.
-    MXSDKOptions *sdkOptions = [MXSDKOptions sharedInstance];
-    sdkOptions.applicationGroupIdentifier = @"group.im.vector";
-
-    // Track SDK performance on Google analytics
-    sdkOptions.analyticsDelegate = [[MXGoogleAnalytics alloc] init];
-    
-    // Redirect NSLogs to files only if we are not debugging
-    if (!isatty(STDERR_FILENO)) {
-        [MXLogger redirectNSLogToFiles:YES];
-    }
-
     NSLog(@"[AppDelegate] willFinishLaunchingWithOptions: Done");
 
     return YES;


### PR DESCRIPTION
Try another technique to save logs to files earlier.

The goal is to track unexpected app startup cycle like in https://riot.im/bugreports/listing/2017-12-29/081732/console.1.log.gz (https://github.com/matrix-org/riot-ios-rageshakes/issues/797) and https://riot.im/bugreports/listing/2017-12-31/133345/console.log.gz (https://github.com/matrix-org/riot-ios-rageshakes/issues/805).