### PR TITLE
Share Extension: Fix crash on a weak self

### DIFF
--- a/RiotShareExtension/Model/ShareExtensionManager.m
+++ b/RiotShareExtension/Model/ShareExtensionManager.m
@@ -219,6 +219,7 @@ typedef NS_ENUM(NSInteger, ImageCompressionMode)
                  {
                      if (weakSelf)
                      {
+                         typeof(self) self = weakSelf;
                          itemProvider.isLoaded = YES;
                          [self.pendingImages addObject:imageData];
                          


### PR DESCRIPTION
Reported only by app store because we do not catch crashes from the share extension nor siri extension.