### PR TITLE
Add support for interactive notifications (fixes #625)

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -1124,19 +1124,20 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             MXKRoomDataSource* roomDataSource = nil;
             for (MXKAccount* account in mxAccounts)
             {
-                MXKRoomDataSourceManager* manager = [MXKRoomDataSourceManager sharedManagerForMatrixSession:account.mxSession];
-                if (manager)
+                MXRoom* room = [account.mxSession roomWithRoomId:roomId];
+                if (room)
                 {
-                    roomDataSource = [manager roomDataSourceForRoom:roomId create:false];
-                    if (roomDataSource)
+                    MXKRoomDataSourceManager* manager = [MXKRoomDataSourceManager sharedManagerForMatrixSession:account.mxSession];
+                    if (manager)
                     {
-                        break;
+                        roomDataSource = [manager roomDataSourceForRoom:roomId create:YES];
                     }
+                    break;
                 }
             }
             if (roomDataSource == nil)
             {
-                NSLog(@"[AppDelegate][Push] handleActionWithIdentifier: room data source with id %@ not found", roomId);
+                NSLog(@"[AppDelegate][Push] handleActionWithIdentifier: room with id %@ not found", roomId);
             }
             else
             {

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -1406,7 +1406,8 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                                                @"user_id": account.mxCredentials.userId
                                                };
                 
-                if (event.eventType == MXEventTypeRoomMessage || (event.eventType == MXEventTypeRoomEncrypted && event.isEncrypted && account.showDecryptedContentInNotifications))
+                BOOL isNotificationContentShown = !event.isEncrypted || account.showDecryptedContentInNotifications;
+                if ((event.eventType == MXEventTypeRoomMessage || event.eventType == MXEventTypeRoomEncrypted) && isNotificationContentShown)
                 {
                     eventNotification.category = @"QUICK_REPLY";
                 }


### PR DESCRIPTION
This adds interactive notifications, so that you can quickly reply to messages from the notification. Visually, the feature looks and works exactly like WhatsApp's notification action. If you have the "Show decrypted content" setting turned off, the quick reply functionality is disabled for encrypted notifications (since it doesn't make sense to reply to a message before actually seeing its content).

#625 

Signed-off-by: Joey Watts <joey.watts.96@gmail.com>