### PR TITLE
Fix crash in ShareExtensionManager

### DIFF
--- a/RiotShareExtension/Model/ShareExtensionManager.m
+++ b/RiotShareExtension/Model/ShareExtensionManager.m
@@ -221,7 +221,15 @@ typedef NS_ENUM(NSInteger, ImageCompressionMode)
                      {
                          typeof(self) self = weakSelf;
                          itemProvider.isLoaded = YES;
-                         [self.pendingImages addObject:imageData];
+
+                         if (imageData)
+                         {
+                             [self.pendingImages addObject:imageData];
+                         }
+                         else
+                         {
+                             NSLog(@"[ShareExtensionManager] sendContentToRoom: failed to loadItemForTypeIdentifier. Error: %@", error);
+                         }
                          
                          if ([self areAttachmentsFullyLoaded])
                          {


### PR DESCRIPTION
Reported in Xcode organiser so there is no detail how it happened.
The fix is a workaround to avoid the crash but it does not help the user for sending their image.