### PR TITLE
 BF: Cannot join from a room preview for room with a long topic

### DIFF
--- a/Riot/ViewController/RoomViewController.m
+++ b/Riot/ViewController/RoomViewController.m
@@ -1227,11 +1227,8 @@
     // Set the right room title view
     if (self.isRoomPreview)
     {
-        // Disable the right buttons
-        for (UIBarButtonItem *barButtonItem in self.navigationItem.rightBarButtonItems)
-        {
-            barButtonItem.enabled = NO;
-        }
+        // Do not show the right buttons
+        self.navigationItem.rightBarButtonItems = nil;
         
         [self showPreviewHeader:YES];
     }

--- a/Riot/ViewController/RoomViewController.m
+++ b/Riot/ViewController/RoomViewController.m
@@ -1581,7 +1581,7 @@
     if (previewHeader)
     {
         if (isLandscapeOriented
-            && [GBDeviceInfo deviceInfo].family == GBDeviceFamilyiPad)
+            && [GBDeviceInfo deviceInfo].family != GBDeviceFamilyiPad)
         {
             CGRect frame = self.navigationController.navigationBar.frame;
             
@@ -1608,8 +1608,7 @@
             {
                 // In case of preview, update the header height so that we can
                 // display as much as possible the room topic in this header.
-                // Note: the header height is the previewHeader.mainHeaderBackgroundHeightConstraint
-                // just computed
+                // Note: the header height is handled by the previewHeader.mainHeaderBackgroundHeightConstraint.
                 PreviewRoomTitleView *previewRoomTitleView = (PreviewRoomTitleView *)previewHeader;
 
                 // Compute the height required to display all the room topic

--- a/Riot/ViewController/RoomViewController.m
+++ b/Riot/ViewController/RoomViewController.m
@@ -1583,7 +1583,8 @@
 {
     if (previewHeader)
     {
-        if (isLandscapeOriented)
+        if (isLandscapeOriented
+            && [GBDeviceInfo deviceInfo].family == GBDeviceFamilyiPad)
         {
             CGRect frame = self.navigationController.navigationBar.frame;
             

--- a/Riot/ViewController/RoomViewController.m
+++ b/Riot/ViewController/RoomViewController.m
@@ -1605,7 +1605,33 @@
         {
             previewHeader.mainHeaderContainer.hidden = NO;
             previewHeader.mainHeaderBackgroundHeightConstraint.constant = previewHeader.mainHeaderContainer.frame.size.height;
-            
+
+            if ([previewHeader isKindOfClass:PreviewRoomTitleView.class])
+            {
+                // In case of preview, update the header height so that we can
+                // display as much as possible the room topic in this header.
+                // Note: the header height is the previewHeader.mainHeaderBackgroundHeightConstraint
+                // just computed
+                PreviewRoomTitleView *previewRoomTitleView = (PreviewRoomTitleView *)previewHeader;
+
+                // Compute the height required to display all the room topic
+                CGSize sizeThatFitsTextView = [previewRoomTitleView.roomTopic sizeThatFits:CGSizeMake(previewRoomTitleView.roomTopic.frame.size.width, MAXFLOAT)];
+
+                // Increase the preview header height according to the room topic height
+                // but limit it in order to let room for room messages at the screen bottom.
+                // This free space depends on the device.
+                // On an iphone 5 screen, the room topic height cannot be more than 50px.
+                // Then, on larger screen, we can allow it a bit more height but we
+                // apply a factor to give more priority to the display of more messages.
+                CGFloat screenHeight = [[UIScreen mainScreen] bounds].size.height;
+                CGFloat maxRoomTopicHeight = 50 + (screenHeight - 568) / 3;
+
+                CGFloat additionalHeight = MIN(maxRoomTopicHeight, sizeThatFitsTextView.height)
+                                            - previewRoomTitleView.roomTopic.frame.size.height;
+
+                previewHeader.mainHeaderBackgroundHeightConstraint.constant += additionalHeight;
+            }
+
             [self setRoomTitleViewClass:RoomAvatarTitleView.class];
             // Note the avatar title view does not define tap gesture.
             

--- a/Riot/Views/RoomTitle/PreviewRoomTitleView.h
+++ b/Riot/Views/RoomTitle/PreviewRoomTitleView.h
@@ -24,7 +24,7 @@
 @property (weak, nonatomic) IBOutlet UIView *mainHeaderContainer;
 
 @property (weak, nonatomic) IBOutlet MXKImageView *roomAvatar;
-@property (weak, nonatomic) IBOutlet UILabel *roomTopic;
+@property (weak, nonatomic) IBOutlet UITextView *roomTopic;
 @property (weak, nonatomic) IBOutlet UILabel *roomMembers;
 @property (weak, nonatomic) IBOutlet UIView *roomMembersDetailsIcon;
 

--- a/Riot/Views/RoomTitle/PreviewRoomTitleView.m
+++ b/Riot/Views/RoomTitle/PreviewRoomTitleView.m
@@ -153,7 +153,7 @@
             }
             else if (roomName.length > 20)
             {
-                // Would have beed nice to get the cropped string displayed by
+                // Would have been nice to get the cropped string displayed by
                 // self.displayNameTextField but the value is not accessible.
                 // Cut it off by hand
                 roomName = [NSString stringWithFormat:@"%@…",[roomName substringToIndex:20]];

--- a/Riot/Views/RoomTitle/PreviewRoomTitleView.m
+++ b/Riot/Views/RoomTitle/PreviewRoomTitleView.m
@@ -67,7 +67,6 @@
     self.displayNameTextField.textColor = (self.mxRoom.summary.displayname.length ? kRiotPrimaryTextColor : kRiotSecondaryTextColor);
     
     self.roomTopic.textColor = kRiotTopicTextColor;
-    self.roomTopic.numberOfLines = 0;
     
     self.roomMembers.textColor = kRiotColorGreen;
     

--- a/Riot/Views/RoomTitle/PreviewRoomTitleView.m
+++ b/Riot/Views/RoomTitle/PreviewRoomTitleView.m
@@ -105,6 +105,10 @@
         
         // Room topic
         self.roomTopic.text = self.roomPreviewData.roomTopic;
+
+        [UIView setAnimationsEnabled:NO];
+        [self.roomTopic scrollRangeToVisible:NSMakeRange(0, 0)];
+        [UIView setAnimationsEnabled:YES];
         
         // Joined members count
         if (self.roomPreviewData.numJoinedMembers > 1)

--- a/Riot/Views/RoomTitle/PreviewRoomTitleView.m
+++ b/Riot/Views/RoomTitle/PreviewRoomTitleView.m
@@ -153,8 +153,9 @@
             }
             else if (roomName.length > 20)
             {
-                // Would have nice to get the cropped string displayed by self.displayNameTextField
-                // but the value is not accessible. Cut it off by hand
+                // Would have beed nice to get the cropped string displayed by
+                // self.displayNameTextField but the value is not accessible.
+                // Cut it off by hand
                 roomName = [NSString stringWithFormat:@"%@…",[roomName substringToIndex:20]];
             }
 

--- a/Riot/Views/RoomTitle/PreviewRoomTitleView.m
+++ b/Riot/Views/RoomTitle/PreviewRoomTitleView.m
@@ -147,6 +147,13 @@
             {
                 roomName = NSLocalizedStringFromTable(@"room_preview_try_join_an_unknown_room_default", @"Vector", nil);
             }
+            else if (roomName.length > 20)
+            {
+                // Would have nice to get the cropped string displayed by self.displayNameTextField
+                // but the value is not accessible. Cut it off by hand
+                roomName = [NSString stringWithFormat:@"%@…",[roomName substringToIndex:20]];
+            }
+
             self.previewLabel.text = [NSString stringWithFormat:NSLocalizedStringFromTable(@"room_preview_try_join_an_unknown_room", @"Vector", nil), roomName];
         }
     }

--- a/Riot/Views/RoomTitle/PreviewRoomTitleView.xib
+++ b/Riot/Views/RoomTitle/PreviewRoomTitleView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -47,22 +47,25 @@
                                 <outlet property="delegate" destination="Cpa-Xt-cwB" id="BIq-nD-Pb9"/>
                             </connections>
                         </textField>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tk0-pA-9a0">
-                            <rect key="frame" x="282" y="153" width="36" height="17"/>
+                        <textView opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Room Topic" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Tk0-pA-9a0">
+                            <rect key="frame" x="262" y="153" width="76" height="17"/>
                             <accessibility key="accessibilityConfiguration" identifier="RoomTopic"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="76" id="BEk-1P-gqy"/>
+                            </constraints>
                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ou0-3Z-weL">
-                            <rect key="frame" x="282" y="184" width="36" height="17"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <textInputTraits key="textInputTraits"/>
+                        </textView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="X members" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ou0-3Z-weL">
+                            <rect key="frame" x="262" y="184" width="76" height="17"/>
                             <accessibility key="accessibilityConfiguration" identifier="RoomMembers"/>
                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="details_icon" translatesAutoresizingMaskIntoConstraints="NO" id="S3Y-wJ-HOe">
-                            <rect key="frame" x="325" y="187" width="6" height="12"/>
+                            <rect key="frame" x="345" y="187" width="6" height="12"/>
                             <accessibility key="accessibilityConfiguration" identifier="RoomMembersDetailsIcon"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="6" id="XTx-6p-2wB"/>
@@ -166,6 +169,7 @@
                 <constraint firstItem="BkF-x3-7fX" firstAttribute="leading" secondItem="Cpa-Xt-cwB" secondAttribute="leading" id="Uvb-cK-dQf"/>
                 <constraint firstItem="BkF-x3-7fX" firstAttribute="top" secondItem="Cpa-Xt-cwB" secondAttribute="top" id="Zru-9A-ifB"/>
                 <constraint firstAttribute="trailing" secondItem="y5s-FK-My4" secondAttribute="trailing" id="d4g-19-C58"/>
+                <constraint firstItem="BkF-x3-7fX" firstAttribute="bottom" secondItem="y5s-FK-My4" secondAttribute="bottom" id="gzp-8c-3iR"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IwA-0X-IYb" secondAttribute="trailing" constant="31" id="iGR-eh-0e9"/>
                 <constraint firstItem="WmW-5h-jL1" firstAttribute="top" secondItem="gIX-nY-f6M" secondAttribute="bottom" constant="17" id="ioD-jo-XQe"/>
                 <constraint firstItem="IwA-0X-IYb" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Cpa-Xt-cwB" secondAttribute="leading" constant="31" id="lpD-yd-qgt"/>

--- a/Riot/Views/RoomTitle/PreviewRoomTitleView.xib
+++ b/Riot/Views/RoomTitle/PreviewRoomTitleView.xib
@@ -47,7 +47,7 @@
                                 <outlet property="delegate" destination="Cpa-Xt-cwB" id="BIq-nD-Pb9"/>
                             </connections>
                         </textField>
-                        <textView opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Room Topic" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Tk0-pA-9a0">
+                        <textView opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" editable="NO" text="Room Topic" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Tk0-pA-9a0">
                             <rect key="frame" x="31" y="153" width="538" height="17"/>
                             <accessibility key="accessibilityConfiguration" identifier="RoomTopic"/>
                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>

--- a/Riot/Views/RoomTitle/PreviewRoomTitleView.xib
+++ b/Riot/Views/RoomTitle/PreviewRoomTitleView.xib
@@ -48,11 +48,8 @@
                             </connections>
                         </textField>
                         <textView opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Room Topic" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Tk0-pA-9a0">
-                            <rect key="frame" x="262" y="153" width="76" height="17"/>
+                            <rect key="frame" x="31" y="153" width="538" height="17"/>
                             <accessibility key="accessibilityConfiguration" identifier="RoomTopic"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="76" id="BEk-1P-gqy"/>
-                            </constraints>
                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <textInputTraits key="textInputTraits"/>
@@ -90,6 +87,7 @@
                         <constraint firstItem="Tk0-pA-9a0" firstAttribute="top" secondItem="6uH-I3-RQg" secondAttribute="bottom" constant="5" id="TUS-xE-O6O"/>
                         <constraint firstItem="6uH-I3-RQg" firstAttribute="top" secondItem="4yt-FK-V2Z" secondAttribute="bottom" constant="8" id="Wsd-KT-hxy"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6uH-I3-RQg" secondAttribute="trailing" constant="31" id="aK3-vQ-EVu"/>
+                        <constraint firstItem="Tk0-pA-9a0" firstAttribute="width" secondItem="BkF-x3-7fX" secondAttribute="width" priority="750" id="bWP-2y-KTg"/>
                         <constraint firstItem="ou0-3Z-weL" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="BkF-x3-7fX" secondAttribute="leading" constant="31" id="c9h-h2-VEs"/>
                         <constraint firstItem="6uH-I3-RQg" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="BkF-x3-7fX" secondAttribute="leading" constant="31" id="gnq-cO-l4Y"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ou0-3Z-weL" secondAttribute="trailing" constant="31" id="sPZ-Hp-JeH"/>


### PR DESCRIPTION
#1645 

Main changes are:
- replace the topic UILabel to a scrollable UITextView.
- make the parent give the right height for his child room preview header so that the topic height scale to display enough text without eating all the screen.

There is an additional fix that removea right buttons in the nav bar (screenshots below do not have this fix).

5s:
![simulator screen shot - iphone 5s - 2018-03-12 at 15 33 14](https://user-images.githubusercontent.com/8418515/37292533-4d707380-2611-11e8-847c-25e12b2d322b.png)

X:
![](https://matrix.org/_matrix/media/v1/download/matrix.org/aFuEiADbiNPXCBtnAzWAHSKY)

iPad:
![simulator screen shot - ipad pro 12 9-inch 2nd generation - 2018-03-12 at 15 52 20](https://user-images.githubusercontent.com/8418515/37292628-8a5a71ba-2611-11e8-9aca-34afbda257ea.png)

