### PR TITLE
Use existing message.mp3 for notification sounds.

### DIFF
--- a/Riot/AppDelegate.h
+++ b/Riot/AppDelegate.h
@@ -74,6 +74,9 @@ extern NSString *const kAppDelegateNetworkStatusDidChangeNotification;
 // Current selected room id. nil if no room is presently visible.
 @property (strong, nonatomic) NSString *visibleRoomId;
 
+// New message sound id.
+@property (nonatomic, readonly) SystemSoundID messageSound;
+
 + (AppDelegate*)theDelegate;
 
 #pragma mark - Application layout handling

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -340,6 +340,10 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
 
 - (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions
 {
+    // Create message sound
+    NSURL *messageSoundURL = [[NSBundle mainBundle] URLForResource:@"message" withExtension:@"mp3"];
+    AudioServicesCreateSystemSoundID((__bridge CFURLRef)messageSoundURL, &_messageSound);
+    
     NSLog(@"[AppDelegate] willFinishLaunchingWithOptions: Done");
 
     return YES;
@@ -1461,7 +1465,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                         {
                             NSString *soundName = action.parameters[@"value"];
                             if ([soundName isEqualToString:@"default"])
-                                soundName = UILocalNotificationDefaultSoundName;
+                                soundName = @"message.mp3";
                             
                             eventNotification.soundName = soundName;
                         }
@@ -2954,8 +2958,8 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                             {
                                 if ([[ruleAction.parameters valueForKey:@"set_tweak"] isEqualToString:@"sound"])
                                 {
-                                    // Play system sound (VoicemailReceived)
-                                    AudioServicesPlaySystemSound (1002);
+                                    // Play message sound
+                                    AudioServicesPlaySystemSound(_messageSound);
                                 }
                             }
                         }


### PR DESCRIPTION
I noticed that the iOS app uses the default voicemail tone instead of the message sound already included in the bundle and used in the web app. Not sure if that's intentional but thought I'd fix it. The SystemSoundID is created in `application:willFinishLaunchingWithOptions:` which may not be desirable, but this can easily be moved to your preferred location.

**Note:** I couldn't directly test the changes with a push notification due to app id provisioning conflicts, but they work fine when firing from a local notification.