### PR TITLE
Render sticker events in the timeline

### DIFF
--- a/Riot/ViewController/RoomViewController.m
+++ b/Riot/ViewController/RoomViewController.m
@@ -1951,6 +1951,11 @@
                 // Force table refresh
                 [self dataSource:self.roomDataSource didCellChange:nil];
             }
+            else
+            {
+                // Keep default implementation
+                [super dataSource:dataSource didRecognizeAction:actionIdentifier inCell:cell userInfo:userInfo];
+            }
         }
         else if ([actionIdentifier isEqualToString:kRoomEncryptedDataBubbleCellTapOnEncryptionIcon])
         {


### PR DESCRIPTION
Fix a regression: the attachments viewer is not opened when user taps on an attachment

#1819