### PR TITLE
Improve Error Notifications (based on kMXKErrorNotification)

### DIFF
--- a/Riot/Categories/MXRoom+Riot.m
+++ b/Riot/Categories/MXRoom+Riot.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -57,9 +58,12 @@
              } failure:^(NSError *error) {
                  
                  NSLog(@"[MXRoom+Riot] Failed to update the tag %@ of room (%@)", tag, self.state.roomId);
+                 NSString *userId = self.mxSession.myUser.userId;
                  
                  // Notify user
-                 [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                 [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification
+                                                                     object:error
+                                                                   userInfo:userId ? @{kMXKErrorUserIdKey: userId} : nil];
                  
                  if (completion)
                  {

--- a/Riot/ViewController/RoomMemberDetailsViewController.m
+++ b/Riot/ViewController/RoomMemberDetailsViewController.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2016 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -415,9 +416,7 @@
             {
                 // Restore the status bar
                 typeof(self) self = weakSelf;
-
                 self->devicesArray = usersDevicesInfoMap.map[userId].allValues;
-
                 // Reload the full table to take into account a potential change on a device status.
                 [super updateMemberInfo];
             }
@@ -425,9 +424,15 @@
         } failure:^(NSError *error) {
 
             NSLog(@"[RoomMemberDetailsVC] Crypto failed to download device info for user: %@", userId);
-
-            // Notify MatrixKit user
-            [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+            if (weakSelf)
+            {
+                // Restore the status bar
+                typeof(self) self = weakSelf;
+                // Notify the end user
+                NSString *myUserId = self.mainSession.myUser.userId;
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
+            }
+            
         }];
     }
     

--- a/Riot/ViewController/SettingsViewController.m
+++ b/Riot/ViewController/SettingsViewController.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2018 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -707,7 +708,8 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
                                                                            [self stopActivityIndicator];
                                                                            
                                                                            // Notify user
-                                                                           [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                                                                           NSString *myUserId = self.mainSession.myUser.userId; // TODO: Hanlde multi-account
+                                                                           [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                                                                        }
                                                                    }
                                                                }
@@ -817,8 +819,8 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
                                                                            {
                                                                                [self stopActivityIndicator];
                                                                                
-                                                                               // Notify user
-                                                                               [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                                                                               NSString *myUserId = self.mainSession.myUser.userId; // TODO: Hanlde multi-account
+                                                                               [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                                                                            }
                                                                        }
                                                                        
@@ -2446,8 +2448,8 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
                                                                            
                                                                            NSLog(@"[SettingsViewController] Unignore %@ failed", ignoredUserId);
                                                                            
-                                                                           // Notify user
-                                                                           [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                                                                           NSString *myUserId = session.myUser.userId;
+                                                                           [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                                                                            
                                                                        }];
                                                                    }
@@ -2724,8 +2726,8 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
                                                                            
                                                                            [self stopActivityIndicator];
                                                                            
-                                                                           // Notify user
-                                                                           [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+                                                                           NSString *myUserId = self.mainSession.myUser.userId; // TODO: Hanlde multi-account
+                                                                           [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                                                                        }
                                                                    }];
                                                                }
@@ -3413,7 +3415,8 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
         }
 
         // Notify user
-        [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+        NSString *myUserId = session.myUser.userId; // TODO: Hanlde multi-account
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
 
     }];
 }
@@ -3515,7 +3518,8 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)();
         }
         
         // Notify user
-        [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error];
+        NSString *myUserId = session.myUser.userId;
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
         
     }];
 }


### PR DESCRIPTION
Add the account identifier in userInfo dictionary to let the listener know which account is concerned by the error.

vector-im/riot-ios#1839