### PR TITLE
 Send Stickers: version 1

### DIFF
--- a/Riot.xcodeproj/project.pbxproj
+++ b/Riot.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		24EEE5A11F23A09A00B3C705 /* RiotDesignValues.m in Sources */ = {isa = PBXBuildFile; fileRef = F083BC171E7009EC00A9B29C /* RiotDesignValues.m */; };
 		24EEE5A21F23A8B400B3C705 /* MXRoom+Riot.m in Sources */ = {isa = PBXBuildFile; fileRef = F083BBE81E7009EC00A9B29C /* MXRoom+Riot.m */; };
 		24EEE5A31F23A8C300B3C705 /* AvatarGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = F083BC111E7009EC00A9B29C /* AvatarGenerator.m */; };
-		24EEE5A41F24C06E00B3C705 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
+		24EEE5A41F24C06E00B3C705 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		24EEE5A81F25529600B3C705 /* cancel@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = F0614A121EDEE65000F5DC9A /* cancel@3x.png */; };
 		24EEE5A91F25529900B3C705 /* cancel@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F0614A111EDEE65000F5DC9A /* cancel@2x.png */; };
 		24EEE5AA1F25529C00B3C705 /* cancel.png in Resources */ = {isa = PBXBuildFile; fileRef = F0614A101EDEE65000F5DC9A /* cancel.png */; };
@@ -70,11 +70,11 @@
 		327382C41F276AED00356143 /* Vector.strings in Resources */ = {isa = PBXBuildFile; fileRef = 327382C01F276AED00356143 /* Vector.strings */; };
 		32795C0B203DA4C4002420E2 /* DisabledRoomInputToolbarView.m in Sources */ = {isa = PBXBuildFile; fileRef = 32795C09203DA4C3002420E2 /* DisabledRoomInputToolbarView.m */; };
 		32795C0C203DA4C4002420E2 /* DisabledRoomInputToolbarView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 32795C0A203DA4C4002420E2 /* DisabledRoomInputToolbarView.xib */; };
+		3284A35120A07C210044F922 /* postMessageAPI.js in Resources */ = {isa = PBXBuildFile; fileRef = 3284A35020A07C210044F922 /* postMessageAPI.js */; };
 		3284D7FF1FBB34B70090AA80 /* RoomKeyRequestViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3284D7FE1FBB34B70090AA80 /* RoomKeyRequestViewController.m */; };
 		32918EA91F473BDB0076CA16 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 32918EA51F473BDB0076CA16 /* Localizable.strings */; };
 		32918EAA1F473BDB0076CA16 /* Vector.strings in Resources */ = {isa = PBXBuildFile; fileRef = 32918EA71F473BDB0076CA16 /* Vector.strings */; };
 		32935CB11F6056FD006888C8 /* IntegrationManagerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 32935CB01F6056FD006888C8 /* IntegrationManagerViewController.m */; };
-		32935CB41F628BCE006888C8 /* IntegrationManager.js in Resources */ = {isa = PBXBuildFile; fileRef = 32935CB31F628BCE006888C8 /* IntegrationManager.js */; };
 		329DCE191F988F8100468420 /* riot_icon_callkit.png in Resources */ = {isa = PBXBuildFile; fileRef = 329DCE161F988F8100468420 /* riot_icon_callkit.png */; };
 		329DCE1A1F988F8100468420 /* riot_icon_callkit@2.png in Resources */ = {isa = PBXBuildFile; fileRef = 329DCE171F988F8100468420 /* riot_icon_callkit@2.png */; };
 		329DCE1B1F988F8100468420 /* riot_icon_callkit@3.png in Resources */ = {isa = PBXBuildFile; fileRef = 329DCE181F988F8100468420 /* riot_icon_callkit@3.png */; };
@@ -733,13 +733,13 @@
 		32795C08203DA4C3002420E2 /* DisabledRoomInputToolbarView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DisabledRoomInputToolbarView.h; sourceTree = "<group>"; };
 		32795C09203DA4C3002420E2 /* DisabledRoomInputToolbarView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DisabledRoomInputToolbarView.m; sourceTree = "<group>"; };
 		32795C0A203DA4C4002420E2 /* DisabledRoomInputToolbarView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DisabledRoomInputToolbarView.xib; sourceTree = "<group>"; };
+		3284A35020A07C210044F922 /* postMessageAPI.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = postMessageAPI.js; sourceTree = "<group>"; };
 		3284D7FD1FBB34B70090AA80 /* RoomKeyRequestViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RoomKeyRequestViewController.h; sourceTree = "<group>"; };
 		3284D7FE1FBB34B70090AA80 /* RoomKeyRequestViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RoomKeyRequestViewController.m; sourceTree = "<group>"; };
 		32918EA61F473BDB0076CA16 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = Localizable.strings; sourceTree = "<group>"; };
 		32918EA81F473BDB0076CA16 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = Vector.strings; sourceTree = "<group>"; };
 		32935CAF1F6056FD006888C8 /* IntegrationManagerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntegrationManagerViewController.h; sourceTree = "<group>"; };
 		32935CB01F6056FD006888C8 /* IntegrationManagerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IntegrationManagerViewController.m; sourceTree = "<group>"; };
-		32935CB31F628BCE006888C8 /* IntegrationManager.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = IntegrationManager.js; sourceTree = "<group>"; };
 		329DCE161F988F8100468420 /* riot_icon_callkit.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = riot_icon_callkit.png; sourceTree = "<group>"; };
 		329DCE171F988F8100468420 /* riot_icon_callkit@2.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "riot_icon_callkit@2.png"; sourceTree = "<group>"; };
 		329DCE181F988F8100468420 /* riot_icon_callkit@3.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "riot_icon_callkit@3.png"; sourceTree = "<group>"; };
@@ -1627,7 +1627,7 @@
 		32935CB21F628B98006888C8 /* js */ = {
 			isa = PBXGroup;
 			children = (
-				32935CB31F628BCE006888C8 /* IntegrationManager.js */,
+				3284A35020A07C210044F922 /* postMessageAPI.js */,
 			);
 			path = js;
 			sourceTree = "<group>";
@@ -2911,9 +2911,9 @@
 				F0BFBDBB1FF3BF6F00C88726 /* Vector.strings in Resources */,
 				F0BFBDBF1FF3BFD200C88726 /* Vector.strings in Resources */,
 				24D6B35E1F3CA03E00FC7A71 /* FallbackViewController.xib in Resources */,
-				24EEE5A41F24C06E00B3C705 /* BuildFile in Resources */,
+				24EEE5A41F24C06E00B3C705 /* (null) in Resources */,
 				2439DD641F6BBEA50090F42D /* RecentRoomTableViewCell.xib in Resources */,
-				24EEE5A41F24C06E00B3C705 /* BuildFile in Resources */,
+				24EEE5A41F24C06E00B3C705 /* (null) in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3270,7 +3270,6 @@
 				F083BD961E7009ED00A9B29C /* leave@2x.png in Resources */,
 				F0E05A461EA0F9EB004B83FB /* tab_rooms@2x.png in Resources */,
 				32AE61F41F0D2183007255F4 /* Vector.strings in Resources */,
-				32935CB41F628BCE006888C8 /* IntegrationManager.js in Resources */,
 				F083BD851E7009ED00A9B29C /* favouriteOff@3x.png in Resources */,
 				F083BD541E7009ED00A9B29C /* camera_switch@2x.png in Resources */,
 				F07CB3992029B20100C29C20 /* GroupTableViewCellWithSwitch.xib in Resources */,
@@ -3292,6 +3291,7 @@
 				327382C41F276AED00356143 /* Vector.strings in Resources */,
 				32BB89EF204D86DA002F3AEC /* Localizable.strings in Resources */,
 				F083BDE51E7009ED00A9B29C /* voice_call_icon@3x.png in Resources */,
+				3284A35120A07C210044F922 /* postMessageAPI.js in Resources */,
 				322806A11F0F64C4008C53D7 /* RoomMembershipExpandedBubbleCell.xib in Resources */,
 				F083BE201E7009ED00A9B29C /* RoomParticipantsViewController.xib in Resources */,
 				F083BE471E7009ED00A9B29C /* RoomIncomingEncryptedTextMsgWithPaginationTitleBubbleCell.xib in Resources */,

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -2200,7 +2200,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     sdkOptions.backgroundModeHandler = [[MXUIKitBackgroundModeHandler alloc] init];
 
     // Get modular widget events in rooms histories
-    [[MXKAppSettings standardAppSettings] addSupportedEventTypes:@[kWidgetEventTypeString]];
+    [[MXKAppSettings standardAppSettings] addSupportedEventTypes:@[kWidgetMatrixEventTypeString, kWidgetModularEventTypeString]];
     
     // Disable long press on event in bubble cells
     [MXKRoomBubbleTableViewCell disableLongPressGestureOnEvent:YES];
@@ -2259,9 +2259,10 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             // Each room member will be considered as a potential contact.
             [MXKContactManager sharedManager].contactManagerMXRoomSource = MXKContactManagerMXRoomSourceAll;
 
-            // Send read receipts for modular widgets events too
+            // Send read receipts for widgets events too
             NSMutableArray<MXEventTypeString> *acknowledgableEventTypes = [NSMutableArray arrayWithArray:mxSession.acknowledgableEventTypes];
-            [acknowledgableEventTypes addObject:kWidgetEventTypeString];
+            [acknowledgableEventTypes addObject:kWidgetMatrixEventTypeString];
+            [acknowledgableEventTypes addObject:kWidgetModularEventTypeString];
             mxSession.acknowledgableEventTypes = acknowledgableEventTypes;
         }
         else if (mxSession.state == MXSessionStateStoreDataReady)

--- a/Riot/Assets/js/postMessageAPI.js
+++ b/Riot/Assets/js/postMessageAPI.js
@@ -28,7 +28,7 @@ window.riotIOS.sendObjectMessageToObjC = function(parameters) {
 
 window.riotIOS.events = {};
 
-// Listen to messages posted by Modular
+// Listen to messages posted by the widget
 window.riotIOS.onMessage = function(event) {
 
     // Do not SPAM ObjC with event already managed
@@ -50,7 +50,7 @@ window.riotIOS.onMessage = function(event) {
 window.addEventListener('message', riotIOS.onMessage, false);
 
 
-// ObjC -> Modular JS bridge
+// ObjC -> Widget JS bridge
 window.riotIOS.sendResponse = function(eventId, res) {
 
     // Retrieve the correspong JS event

--- a/Riot/Assets/js/postMessageAPI.js
+++ b/Riot/Assets/js/postMessageAPI.js
@@ -40,6 +40,19 @@ window.riotIOS.onMessage = function(event) {
         event.origin = event.originalEvent.origin;
     }
 
+    // Use an internal "_id" field for matching onMessage events and requests
+    // _id was originally used by the Modular API. Keep it
+    if (!event.data._id) {
+        // The Matrix Widget API v2 spec says:
+        // "The requestId field should be unique and included in all requests"
+        event.data._id = event.data.requestId;
+    }
+
+    // Make sure to have one id
+    if (!event.data._id) {
+        event.data._id = Date.now() + "-" + Math.random().toString(36);
+    }
+
     // Keep this event for future usage
     riotIOS.events[event.data._id] = event;
 

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -39,10 +39,10 @@
 
 - (NSAttributedString *)attributedStringFromEvent:(MXEvent *)event withRoomState:(MXRoomState *)roomState error:(MXKEventFormatterError *)error
 {
-    // Build strings for modular widget events
-    // TODO: At the moment, we support only jitsi widgets
+    // Build strings for widget events
     if (event.eventType == MXEventTypeCustom
-        && [event.type isEqualToString:kWidgetEventTypeString])
+        && ([event.type isEqualToString:kWidgetMatrixEventTypeString]
+            || [event.type isEqualToString:kWidgetModularEventTypeString]))
     {
         NSString *displayText;
 
@@ -71,7 +71,11 @@
                 // This is a closed widget
                 // Check if it corresponds to a jitsi widget by looking at other state events for
                 // this jitsi widget (widget id = event.stateKey).
-                for (MXEvent *widgetStateEvent in [roomState stateEventsWithType:kWidgetEventTypeString])
+                // Get all widgets state events in the room
+                NSMutableArray<MXEvent*> *widgetStateEvents = [NSMutableArray arrayWithArray:[roomState stateEventsWithType:kWidgetMatrixEventTypeString]];
+                [widgetStateEvents addObjectsFromArray:[roomState stateEventsWithType:kWidgetModularEventTypeString]];
+
+                for (MXEvent *widgetStateEvent in widgetStateEvents)
                 {
                     if ([widgetStateEvent.stateKey isEqualToString:widget.widgetId])
                     {

--- a/Riot/Utils/Widgets/Widget.m
+++ b/Riot/Utils/Widgets/Widget.m
@@ -70,9 +70,6 @@
             widgetUrl = [widgetUrl stringByReplacingOccurrencesOfString:@"$matrix_display_name" withString:displayName];
             widgetUrl = [widgetUrl stringByReplacingOccurrencesOfString:@"$matrix_avatar_url" withString:avatarUrl];
 
-            // And add the user scalar token
-            widgetUrl = [widgetUrl stringByAppendingString:[NSString stringWithFormat:@"&scalar_token=%@", scalarToken]];
-
             // Integrate widget data into widget url
             for (NSString *key in _data)
             {
@@ -99,6 +96,14 @@
                     NSLog(@"[Widget] Error: Invalid data field value in %@ for key %@ in data %@", self, key, _data);
                 }
             }
+
+            // Add the user scalar token
+            widgetUrl = [widgetUrl stringByAppendingString:[NSString stringWithFormat:@"%@scalar_token=%@",
+                                                            [widgetUrl containsString:@"?"] ? @"&" : @"?",
+                                                            scalarToken]];
+
+            // Add the widget id
+            widgetUrl = [widgetUrl stringByAppendingString:[NSString stringWithFormat:@"&widgetId=%@", _widgetId]];
 
             success(widgetUrl);
         }

--- a/Riot/Utils/Widgets/Widget.m
+++ b/Riot/Utils/Widgets/Widget.m
@@ -22,9 +22,12 @@
 
 - (instancetype)initWithWidgetEvent:(MXEvent *)widgetEvent inMatrixSession:(MXSession*)mxSession
 {
-    if (![widgetEvent.type isEqualToString:kWidgetEventTypeString])
+    // TODO - Room widgets need to be moved to 'm.widget' state events
+    // https://docs.google.com/document/d/1uPF7XWY_dXTKVKV7jZQ2KmsI19wn9-kFRgQ1tFQP7wQ/edit?usp=sharing
+    if (![widgetEvent.type isEqualToString:kWidgetMatrixEventTypeString]
+        && ![widgetEvent.type isEqualToString:kWidgetModularEventTypeString])
     {
-        // The Widget class works only with modular, aka "im.vector.modular.widgets", widgets
+        // The Widget class works only with modular, aka "m.widget" or "im.vector.modular.widgets", widgets
         return nil;
     }
 

--- a/Riot/Utils/Widgets/WidgetManager.h
+++ b/Riot/Utils/Widgets/WidgetManager.h
@@ -94,6 +94,14 @@ WidgetManagerErrorCode;
 - (NSArray<Widget*> *)widgetsNotOfTypes:(NSArray<NSString*>*)notWidgetTypes inRoom:(MXRoom*)room;
 
 /**
+ List all widgets of an account.
+
+ @param mxSession the session of the user account.
+ @return a list of widgets.
+ */
+- (NSArray<Widget*> *)userWidgets:(MXSession*)mxSession;
+
+/**
  Add a modular widget to a room.
 
  @param widgetId the id of the widget.

--- a/Riot/Utils/Widgets/WidgetManager.h
+++ b/Riot/Utils/Widgets/WidgetManager.h
@@ -21,9 +21,15 @@
 #import "Widget.h"
 
 /**
- The type of matrix event used for modular widgets.
+ The type of matrix event used for matrix widgets.
  */
-FOUNDATION_EXPORT NSString *const kWidgetEventTypeString;
+FOUNDATION_EXPORT NSString *const kWidgetMatrixEventTypeString;
+
+/**
+ The type of matrix event used for modular widgets.
+ TODO: It should be replaced by kWidgetMatrixEventTypeString.
+ */
+FOUNDATION_EXPORT NSString *const kWidgetModularEventTypeString;
 
 /**
  Known types widgets.

--- a/Riot/Utils/Widgets/WidgetManager.m
+++ b/Riot/Utils/Widgets/WidgetManager.m
@@ -178,7 +178,17 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
     NSMutableArray<Widget *> *userWidgets = [NSMutableArray array];
     for (NSDictionary *widgetEventContent in [mxSession.accountData accountDataForEventType:@"m.widgets"].allValues)
     {
-        MXEvent *widgetEvent = [MXEvent modelFromJSON:widgetEventContent];
+        // Patch: Modular uses a malformed key: "stateKey" instead of "state_key"
+        // TODO: To remove once fixed server side
+        NSDictionary *widgetEventContentFixed = widgetEventContent;
+        if (!widgetEventContent[@"state_key"] && widgetEventContent[@"stateKey"])
+        {
+            NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithDictionary:widgetEventContent];
+            dict[@"state_key"] = widgetEventContent[@"stateKey"];
+            widgetEventContentFixed = dict;
+        }
+
+        MXEvent *widgetEvent = [MXEvent modelFromJSON:widgetEventContentFixed];
         if (widgetEvent)
         {
             Widget *widget = [[Widget alloc] initWithWidgetEvent:widgetEvent inMatrixSession:mxSession];

--- a/Riot/Utils/Widgets/WidgetManager.m
+++ b/Riot/Utils/Widgets/WidgetManager.m
@@ -172,6 +172,26 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
     return activeWidgets;
 }
 
+- (NSArray<Widget*> *)userWidgets:(MXSession*)mxSession
+{
+    // Get all widgets in the user account data
+    NSMutableArray<Widget *> *userWidgets = [NSMutableArray array];
+    for (NSDictionary *widgetEventContent in [mxSession.accountData accountDataForEventType:@"m.widgets"].allValues)
+    {
+        MXEvent *widgetEvent = [MXEvent modelFromJSON:widgetEventContent];
+        if (widgetEvent)
+        {
+            Widget *widget = [[Widget alloc] initWithWidgetEvent:widgetEvent inMatrixSession:mxSession];
+            if (widget)
+            {
+                [userWidgets addObject:widget];
+            }
+        }
+    }
+
+    return userWidgets;
+}
+
 - (MXHTTPOperation *)createWidget:(NSString*)widgetId
                       withContent:(NSDictionary<NSString*, NSObject*>*)widgetContent
                            inRoom:(MXRoom*)room

--- a/Riot/Utils/Widgets/WidgetManager.m
+++ b/Riot/Utils/Widgets/WidgetManager.m
@@ -20,7 +20,8 @@
 
 #pragma mark - Contants
 
-NSString *const kWidgetEventTypeString = @"im.vector.modular.widgets";
+NSString *const kWidgetMatrixEventTypeString  = @"m.widget";
+NSString *const kWidgetModularEventTypeString = @"im.vector.modular.widgets";
 NSString *const kWidgetTypeJitsi = @"jitsi";
 
 NSString *const kWidgetManagerDidUpdateWidgetNotification = @"kWidgetManagerDidUpdateWidgetNotification";
@@ -102,10 +103,11 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
     // Widget id -> widget
     NSMutableDictionary <NSString*, Widget *> *widgets = [NSMutableDictionary dictionary];
 
-    // Get all im.vector.modular.widgets state events in the room
-    NSMutableArray<MXEvent*> *widgetEvents = [NSMutableArray arrayWithArray:[room.state stateEventsWithType:kWidgetEventTypeString]];
+    // Get all widgets state events in the room
+    NSMutableArray<MXEvent*> *widgetEvents = [NSMutableArray arrayWithArray:[room.state stateEventsWithType:kWidgetMatrixEventTypeString]];
+    [widgetEvents addObjectsFromArray:[room.state stateEventsWithType:kWidgetModularEventTypeString]];
 
-    // There can be several im.vector.modular.widgets state events for a same widget but
+    // There can be several widgets state events for a same widget but
     // only the last one must be considered.
 
     // Order widgetEvents with the last event first
@@ -124,7 +126,7 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
          return result;
      }];
 
-    // Create each widget from its lastest im.vector.modular.widgets state event
+    // Create each widget from its lastest widgets state event
     for (MXEvent *widgetEvent in widgetEvents)
     {
         // Filter widget types if required
@@ -192,7 +194,8 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
 
     // Send a state event with the widget data
     // TODO: This API will be shortly replaced by a pure modular API
-    return [room sendStateEventOfType:kWidgetEventTypeString
+    // TODO: Move to kWidgetMatrixEventTypeString ("m.widget") type but when?
+    return [room sendStateEventOfType:kWidgetModularEventTypeString
                               content:widgetContent
                              stateKey:widgetId
                               success:nil failure:failure];
@@ -247,7 +250,8 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
 
     // Send a state event with an empty content to disable the widget
     // TODO: This API will be shortly replaced by a pure modular API
-    return [room sendStateEventOfType:kWidgetEventTypeString
+    // TODO: Move to kWidgetMatrixEventTypeString ("m.widget") type but when?
+    return [room sendStateEventOfType:kWidgetModularEventTypeString
                               content:@{}
                              stateKey:widgetId
                               success:^(NSString *eventId)
@@ -292,7 +296,7 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
 
     NSString *hash = [NSString stringWithFormat:@"%p", mxSession];
 
-    id listener = [mxSession listenToEventsOfTypes:@[kWidgetEventTypeString] onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
+    id listener = [mxSession listenToEventsOfTypes:@[kWidgetMatrixEventTypeString, kWidgetModularEventTypeString] onEvent:^(MXEvent *event, MXTimelineDirection direction, id customObject) {
 
         typeof(self) self = weakSelf;
 

--- a/Riot/ViewController/RoomViewController.m
+++ b/Riot/ViewController/RoomViewController.m
@@ -1257,9 +1257,10 @@
                     // If the setting is disabled, do not show the icon
                     self.navigationItem.rightBarButtonItems = @[self.navigationItem.rightBarButtonItem];
                 }
-                else if (self.widgetsCount)
+                else if ([self widgetsCount:NO])
                 {
                     // Show there are widgets by changing the "apps" icon color
+                    // Show it in red only for room widgets, not user's widgets
                     // TODO: Design must be reviewed
                     UIImage *icon = self.navigationItem.rightBarButtonItems[1].image;
                     icon = [MXKTools paintImage:icon withColor:kRiotColorPinkRed];
@@ -3063,7 +3064,7 @@
     // Matrix Apps button
     else if (self.navigationItem.rightBarButtonItems.count == 2 && sender == self.navigationItem.rightBarButtonItems[1])
     {
-        if (self.widgetsCount)
+        if ([self widgetsCount:YES])
         {
             WidgetPickerViewController *widgetPicker = [[WidgetPickerViewController alloc] initForMXSession:self.roomDataSource.mxSession
                                                                                                      inRoom:self.roomDataSource.roomId];
@@ -3643,10 +3644,16 @@
     [[AppDelegate theDelegate] showErrorAsAlert:error];
 }
 
-- (NSUInteger)widgetsCount
+- (NSUInteger)widgetsCount:(BOOL)includeUserWidgets
 {
-    return [[WidgetManager sharedManager] widgetsNotOfTypes:@[kWidgetTypeJitsi]
-                                                     inRoom:self.roomDataSource.room].count;
+    NSUInteger widgetsCount = [[WidgetManager sharedManager] widgetsNotOfTypes:@[kWidgetTypeJitsi]
+                                                                        inRoom:self.roomDataSource.room].count;
+    if (includeUserWidgets)
+    {
+        widgetsCount = [[WidgetManager sharedManager] userWidgets:self.roomDataSource.room.mxSession].count;
+    }
+
+    return widgetsCount;
 }
 
 #pragma mark - Unreachable Network Handling

--- a/Riot/ViewController/Widgets/IntegrationManagerViewController.h
+++ b/Riot/ViewController/Widgets/IntegrationManagerViewController.h
@@ -25,7 +25,7 @@ FOUNDATION_EXPORT NSString *const kIntegrationManagerAddIntegrationScreen;
  `IntegrationManagerViewController` displays the Modular integration manager webapp
  into a webview.
  */
-@interface IntegrationManagerViewController : WebViewViewController <UIWebViewDelegate>
+@interface IntegrationManagerViewController : WebViewViewController
 
 /**
  Initialise with params for the Modular interface webapp.

--- a/Riot/ViewController/Widgets/IntegrationManagerViewController.h
+++ b/Riot/ViewController/Widgets/IntegrationManagerViewController.h
@@ -14,9 +14,7 @@
  limitations under the License.
  */
 
-#import "WebViewViewController.h"
-
-#import <MatrixSDK/MatrixSDK.h>
+#import "WidgetViewController.h"
 
 FOUNDATION_EXPORT NSString *const kIntegrationManagerMainScreen;
 FOUNDATION_EXPORT NSString *const kIntegrationManagerAddIntegrationScreen;
@@ -24,8 +22,10 @@ FOUNDATION_EXPORT NSString *const kIntegrationManagerAddIntegrationScreen;
 /**
  `IntegrationManagerViewController` displays the Modular integration manager webapp
  into a webview.
+
+ It reuses the postMessage API pipe defined in `WidgetViewController`.
  */
-@interface IntegrationManagerViewController : WebViewViewController
+@interface IntegrationManagerViewController : WidgetViewController
 
 /**
  Initialise with params for the Modular interface webapp.

--- a/Riot/ViewController/Widgets/IntegrationManagerViewController.m
+++ b/Riot/ViewController/Widgets/IntegrationManagerViewController.m
@@ -19,8 +19,6 @@
 #import "WidgetManager.h"
 #import "AppDelegate.h"
 
-#import <JavaScriptCore/JavaScriptCore.h>
-
 NSString *const kIntegrationManagerMainScreen = nil;
 NSString *const kIntegrationManagerAddIntegrationScreen = @"add_integ";
 
@@ -145,18 +143,6 @@ NSString *const kJavascriptSendResponseToModular = @"riotIOS.sendResponse('%@', 
     }
     
     return url;
-}
-
-- (void)enableDebug
-{
-    // Setup console.log() -> NSLog() route
-    JSContext *ctx = [webView valueForKeyPath:@"documentView.webView.mainFrame.javaScriptContext"];
-    ctx[@"console"][@"log"] = ^(JSValue * msg) {
-        NSLog(@"-- JavaScript: %@", msg);
-    };
-
-    // Redirect all console.* logging methods to console.log
-    [webView stringByEvaluatingJavaScriptFromString:@"console.debug = console.log; console.info = console.log; console.warn = console.log; console.error = console.log;"];
 }
 
 - (void)showErrorAsAlert:(NSError*)error

--- a/Riot/ViewController/Widgets/IntegrationManagerViewController.m
+++ b/Riot/ViewController/Widgets/IntegrationManagerViewController.m
@@ -522,7 +522,8 @@ NSString *const kJavascriptSendResponseToModular = @"riotIOS.sendResponse('%@', 
 
         __weak __typeof__(self) weakSelf = self;
 
-        [room sendStateEventOfType:kWidgetEventTypeString
+        // TODO: Move to kWidgetMatrixEventTypeString ("m.widget") type but when?
+        [room sendStateEventOfType:kWidgetModularEventTypeString
                            content:widgetEventContent
                           stateKey:widget_id
                            success:^(NSString *eventId) {

--- a/Riot/ViewController/Widgets/IntegrationManagerViewController.m
+++ b/Riot/ViewController/Widgets/IntegrationManagerViewController.m
@@ -551,20 +551,24 @@ NSString *const kJavascriptSendResponseToModular = @"riotIOS.sendResponse('%@', 
 - (void)getWidgets:(NSDictionary*)eventData
 {
     MXRoom *room = [self roomCheckWithEvent:eventData];
+    NSMutableArray<NSDictionary*> *widgetStateEvents = [NSMutableArray array];
 
     if (room)
     {
         NSArray<Widget*> *widgets = [[WidgetManager sharedManager] widgetsInRoom:room];
-
-        NSMutableArray<NSDictionary*> *widgetStateEvents = [NSMutableArray arrayWithCapacity:widgets.count];
-
         for (Widget *widget in widgets)
         {
             [widgetStateEvents addObject:widget.widgetEvent.JSONDictionary];
         }
-
-        [self sendNSObjectResponse:widgetStateEvents toEvent:eventData];
     }
+
+    // Add user widgets (not linked to a specific room)
+    for (Widget *widget in [[WidgetManager sharedManager] userWidgets:mxSession])
+    {
+        [widgetStateEvents addObject:widget.widgetEvent.JSONDictionary];
+    }
+
+    [self sendNSObjectResponse:widgetStateEvents toEvent:eventData];
 }
 
 - (void)canSendEvent:(NSDictionary*)eventData

--- a/Riot/ViewController/Widgets/WidgetPickerViewController.m
+++ b/Riot/ViewController/Widgets/WidgetPickerViewController.m
@@ -53,12 +53,19 @@
 
     MXRoom *room = [mxSession roomWithRoomId:roomId];
 
-    NSArray<Widget*> *widgets = [[WidgetManager sharedManager] widgetsNotOfTypes:@[kWidgetTypeJitsi]
+    NSArray<Widget*> *roomWidgets = [[WidgetManager sharedManager] widgetsNotOfTypes:@[kWidgetTypeJitsi]
                                                                           inRoom:room];
+
+    NSArray<Widget*> *userWidgets = [[WidgetManager sharedManager] userWidgets:room.mxSession];
+
+    NSMutableArray<Widget*> *widgets = [NSMutableArray array];
+    [widgets addObjectsFromArray:roomWidgets];
+    [widgets addObjectsFromArray:userWidgets];
+
     // List widgets
     for (Widget *widget in widgets)
     {
-        alertAction = [UIAlertAction actionWithTitle:widget.name
+        alertAction = [UIAlertAction actionWithTitle:widget.name ? widget.name : widget.type
                                                style:UIAlertActionStyleDefault
                                              handler:^(UIAlertAction * _Nonnull action)
                        {

--- a/Riot/ViewController/Widgets/WidgetPickerViewController.m
+++ b/Riot/ViewController/Widgets/WidgetPickerViewController.m
@@ -75,8 +75,12 @@
                            // Display the widget
                            [widget widgetUrl:^(NSString * _Nonnull widgetUrl) {
 
-                                WidgetViewController *widgetVC = [[WidgetViewController alloc] initWithUrl:widgetUrl forWidget:widget];
-                                [mxkViewController.navigationController pushViewController:widgetVC animated:YES];
+                               WidgetViewController *widgetVC = [[WidgetViewController alloc] initWithUrl:widgetUrl forWidget:widget];
+
+                               MXKRoomDataSourceManager *roomDataSourceManager = [MXKRoomDataSourceManager sharedManagerForMatrixSession:mxSession];
+                               widgetVC.roomDataSource = [roomDataSourceManager roomDataSourceForRoom:roomId create:NO];
+
+                               [mxkViewController.navigationController pushViewController:widgetVC animated:YES];
 
                             } failure:^(NSError * _Nonnull error) {
 

--- a/Riot/ViewController/Widgets/WidgetViewController.h
+++ b/Riot/ViewController/Widgets/WidgetViewController.h
@@ -20,6 +20,9 @@
 
 /**
  `WidgetViewController` displays widget within a webview.
+
+ It also exposes a generic pipe, the postMessage API, to communicate with the
+ content within the webview, ie the widget (matrix app).
  */
 @interface WidgetViewController : WebViewViewController
 
@@ -30,5 +33,65 @@
  @param widget the widget to open.
  */
 - (instancetype)initWithUrl:(NSString*)widgetUrl forWidget:(Widget*)widget;
+
+/**
+ Display an alert over this controller.
+
+ @param error the error to display.
+ */
+- (void)showErrorAsAlert:(NSError*)error;
+
+
+#pragma mark - postMessage API
+
+/**
+ Callback called when the widget make a postMessage API request.
+
+ This method can be overidden to implement a specific API between the matrix client
+ and widget.
+
+ @param @TODO
+ */
+- (void)onMessage:(NSDictionary*)JSData;
+
+/**
+ Send a boolean response to a request from the widget.
+
+ @param response the response to send.
+ @param @TODO
+ */
+- (void)sendBoolResponse:(BOOL)response toEvent:(NSDictionary*)eventData;
+
+/**
+ Send an integer response to a request from the widget.
+
+ @param response the response to send.
+ @param @TODO
+ */
+- (void)sendIntegerResponse:(NSUInteger)response toEvent:(NSDictionary*)eventData;
+
+/**
+ Send a serialiable object response to a request the widget.
+
+ @param response the response to send.
+ @param @TODO
+ */
+- (void)sendNSObjectResponse:(NSObject*)response toEvent:(NSDictionary*)eventData;
+
+/**
+ Send a message error to a request from the widget.
+
+ @param message the error message.
+ @param @TODO
+ */
+- (void)sendError:(NSString*)message toEvent:(NSDictionary*)eventData;
+
+/**
+ Send a localised message error to a request from the widget.
+
+ @param errorKey the string id of the message error.
+ @param @TODO
+ */
+- (void)sendLocalisedError:(NSString*)errorKey toEvent:(NSDictionary*)eventData;
 
 @end

--- a/Riot/ViewController/Widgets/WidgetViewController.h
+++ b/Riot/ViewController/Widgets/WidgetViewController.h
@@ -17,6 +17,7 @@
 #import "WebViewViewController.h"
 
 #import "WidgetManager.h"
+#import "MatrixKit/MatrixKit.h"
 
 /**
  `WidgetViewController` displays widget within a webview.
@@ -25,6 +26,12 @@
  content within the webview, ie the widget (matrix app).
  */
 @interface WidgetViewController : WebViewViewController
+
+/**
+ The room data source.
+ Required if the widget needs to post messages.
+ */
+@property (nonatomic) MXKRoomDataSource *roomDataSource;
 
 /**
  Init 'WidgetViewController' instance with a widget.

--- a/Riot/ViewController/Widgets/WidgetViewController.h
+++ b/Riot/ViewController/Widgets/WidgetViewController.h
@@ -50,48 +50,49 @@
  This method can be overidden to implement a specific API between the matrix client
  and widget.
 
- @param @TODO
+ @param requestId the id of the widget request.
+ @param requestData the request data.
  */
-- (void)onMessage:(NSDictionary*)JSData;
+- (void)onPostMessageRequest:(NSString*)requestId data:(NSDictionary*)requestData;
 
 /**
  Send a boolean response to a request from the widget.
 
  @param response the response to send.
- @param @TODO
+ @param requestId the id of the widget request.
  */
-- (void)sendBoolResponse:(BOOL)response toEvent:(NSDictionary*)eventData;
+- (void)sendBoolResponse:(BOOL)response toRequest:(NSString*)requestId;
 
 /**
  Send an integer response to a request from the widget.
 
  @param response the response to send.
- @param @TODO
+ @param requestId the id of the widget request.
  */
-- (void)sendIntegerResponse:(NSUInteger)response toEvent:(NSDictionary*)eventData;
+- (void)sendIntegerResponse:(NSUInteger)response toRequest:(NSString*)requestId;
 
 /**
  Send a serialiable object response to a request the widget.
 
  @param response the response to send.
- @param @TODO
+ @param requestId the id of the widget request.
  */
-- (void)sendNSObjectResponse:(NSObject*)response toEvent:(NSDictionary*)eventData;
+- (void)sendNSObjectResponse:(NSObject*)response toRequest:(NSString*)requestId;
 
 /**
  Send a message error to a request from the widget.
 
  @param message the error message.
- @param @TODO
+ @param requestId the id of the widget request.
  */
-- (void)sendError:(NSString*)message toEvent:(NSDictionary*)eventData;
+- (void)sendError:(NSString*)message toRequest:(NSString*)requestId;
 
 /**
  Send a localised message error to a request from the widget.
 
  @param errorKey the string id of the message error.
- @param @TODO
+ @param requestId the id of the widget request.
  */
-- (void)sendLocalisedError:(NSString*)errorKey toEvent:(NSDictionary*)eventData;
+- (void)sendLocalisedError:(NSString*)errorKey toRequest:(NSString*)requestId;
 
 @end

--- a/Riot/ViewController/Widgets/WidgetViewController.m
+++ b/Riot/ViewController/Widgets/WidgetViewController.m
@@ -16,6 +16,10 @@
 
 #import "WidgetViewController.h"
 
+#import "AppDelegate.h"
+
+NSString *const kJavascriptSendResponseToModular = @"riotIOS.sendResponse('%@', %@);";
+
 @interface WidgetViewController ()
 {
     Widget  *widget;
@@ -42,7 +46,198 @@
     webView.scalesPageToFit = NO;
     webView.scrollView.bounces = NO;
 
-    self.navigationItem.title = widget.name;
+    // Disable opacity so that the webview background uses the current interface theme
+    webView.opaque = NO;
+
+    if (widget)
+    {
+        self.navigationItem.title = widget.name ? widget.name : widget.type;
+    }
+}
+
+- (void)showErrorAsAlert:(NSError*)error
+{
+    NSString *title = [error.userInfo valueForKey:NSLocalizedFailureReasonErrorKey];
+    NSString *msg = [error.userInfo valueForKey:NSLocalizedDescriptionKey];
+    if (!title)
+    {
+        if (msg)
+        {
+            title = msg;
+            msg = nil;
+        }
+        else
+        {
+            title = [NSBundle mxk_localizedStringForKey:@"error"];
+        }
+    }
+
+    __weak __typeof__(self) weakSelf = self;
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:msg preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"ok"]
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(UIAlertAction * action) {
+
+                                                typeof(self) self = weakSelf;
+
+                                                if (self)
+                                                {
+                                                    // Leave this widget VC
+                                                    [self withdrawViewControllerAnimated:YES completion:nil];
+                                                }
+
+                                            }]];
+
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+#pragma mark - UIWebViewDelegate
+
+-(void)webViewDidFinishLoad:(UIWebView *)theWebView
+{
+    [self enableDebug];
+
+    // Setup js code
+    NSString *path = [[NSBundle mainBundle] pathForResource:@"postMessageAPI" ofType:@"js"];
+    NSString *js = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+    [webView stringByEvaluatingJavaScriptFromString:js];
+
+    [self stopActivityIndicator];
+
+    // Check connectivity
+    if ([AppDelegate theDelegate].isOffline)
+    {
+        // The web page may be in the cache, so its loading will be successful
+        // but we cannot go further, it often leads to a blank screen.
+        // So, display an error so that the user can escape.
+        NSError *error = [NSError errorWithDomain:NSURLErrorDomain
+                                             code:NSURLErrorNotConnectedToInternet
+                                         userInfo:@{
+                                                    NSLocalizedDescriptionKey : NSLocalizedStringFromTable(@"network_offline_prompt", @"Vector", nil)
+                                                    }];
+        [self showErrorAsAlert:error];
+    }
+}
+
+- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
+{
+    NSString *urlString = [[request URL] absoluteString];
+
+    if ([urlString hasPrefix:@"js:"])
+    {
+        // Listen only to scheme of the JS-UIWebView bridge
+        NSString *jsonString = [[[urlString componentsSeparatedByString:@"js:"] lastObject]  stringByReplacingPercentEscapesUsingEncoding:NSASCIIStringEncoding];
+        NSData *jsonData = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
+
+        NSError *error;
+        NSDictionary *parameters = [NSJSONSerialization JSONObjectWithData:jsonData options:NSJSONReadingMutableContainers
+                                                                     error:&error];
+        if (!error)
+        {
+            [self onMessage:parameters];
+        }
+
+        return NO;
+    }
+
+    if (navigationType == UIWebViewNavigationTypeLinkClicked )
+    {
+        // Open links outside the app
+        [[UIApplication sharedApplication] openURL:[request URL]];
+        return NO;
+    }
+
+    return YES;
+}
+
+- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
+{
+    // Filter out the users's scalar token
+    NSString *errorDescription = error.description;
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"scalar_token=\\w*"
+                                                                           options:NSRegularExpressionCaseInsensitive error:nil];
+    errorDescription = [regex stringByReplacingMatchesInString:errorDescription
+                                                       options:0
+                                                         range:NSMakeRange(0, errorDescription.length)
+                                                  withTemplate:@"scalar_token=..."];
+
+    NSLog(@"[WidgetVC] didFailLoadWithError: %@", errorDescription);
+
+    [self stopActivityIndicator];
+    [self showErrorAsAlert:error];
+}
+
+#pragma mark - postMessage API
+
+- (void)onMessage:(NSDictionary*)JSData
+{
+    // @TODO
+    NSDictionary *eventData;
+    MXJSONModelSetDictionary(eventData, JSData[@"event.data"]);
+}
+
+- (void)sendBoolResponse:(BOOL)response toEvent:(NSDictionary*)eventData
+{
+    // Convert BOOL to "true" or "false"
+    NSString *js = [NSString stringWithFormat:kJavascriptSendResponseToModular,
+                    eventData[@"_id"],
+                    response ? @"true" : @"false"];
+
+    [webView stringByEvaluatingJavaScriptFromString:js];
+}
+
+- (void)sendIntegerResponse:(NSUInteger)response toEvent:(NSDictionary*)eventData
+{
+    NSString *js = [NSString stringWithFormat:kJavascriptSendResponseToModular,
+                    eventData[@"_id"],
+                    @(response)];
+
+    [webView stringByEvaluatingJavaScriptFromString:js];
+}
+
+- (void)sendNSObjectResponse:(NSObject*)response toEvent:(NSDictionary*)eventData
+{
+    NSString *jsString;
+
+    if (response)
+    {
+        // Convert response into a JS object through a JSON string
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:response
+                                                           options:0
+                                                             error:0];
+        NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+
+        jsString = [NSString stringWithFormat:@"JSON.parse('%@')", jsonString];
+    }
+    else
+    {
+        jsString = @"null";
+    }
+
+    NSString *js = [NSString stringWithFormat:kJavascriptSendResponseToModular,
+                    eventData[@"_id"],
+                    jsString];
+
+    [webView stringByEvaluatingJavaScriptFromString:js];
+}
+
+- (void)sendError:(NSString*)message toEvent:(NSDictionary*)eventData
+{
+    NSLog(@"[WidgetVC] sendError: Action %@ failed with message: %@", eventData[@"action"], message);
+
+    // TODO: JS has an additional optional parameter: nestedError
+    [self sendNSObjectResponse:@{
+                                 @"error": @{
+                                         @"message": message
+                                         }
+                                 }
+                       toEvent:eventData];
+}
+
+- (void)sendLocalisedError:(NSString*)errorKey toEvent:(NSDictionary*)eventData
+{
+    [self sendError:NSLocalizedStringFromTable(errorKey, @"Vector", nil) toEvent:eventData];
 }
 
 @end


### PR DESCRIPTION
#1860

Requires https://github.com/matrix-org/matrix-ios-sdk/pull/492 & https://github.com/matrix-org/matrix-ios-kit/pull/425.

This code is able to retrieve user's widgets (like the sticker picker) as defined by [the spec proposal](https://docs.google.com/document/d/1uPF7XWY_dXTKVKV7jZQ2KmsI19wn9-kFRgQ1tFQP7wQ/edit?usp=sharing), to display the sticker picker widget and to send the selected picker.

Still missing:
 - a better way to open the picker. You currently need to display the list of widgets to open it
 - a screen name of the picker. This is currently m.stickerpicker, the widget type (because this widget has no name) 
 - access to the sticker pack configuration screen
 - a fix on the widget code for the display bug in a Safari webview (there is the same bug on MacOS/Safari). You currently need to rotate the screen to see stickers.

![simulator screen shot - iphone 5s - 2018-05-07 at 18 20 13](https://user-images.githubusercontent.com/8418515/39712436-55f64f28-5223-11e8-9c82-d0fc38feb62e.png)

![simulator screen shot - iphone 5s - 2018-05-07 at 18 20 19](https://user-images.githubusercontent.com/8418515/39712435-55db114a-5223-11e8-96bd-3749ae3c65d5.png)

