### PR TITLE
RoomVC: BF: Read receipts processing dramatically slows down UI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Improvements:
  * RoomVC: Add a re-request keys button on message unable to decrypt (#1879).
  
 Bug fix:
+ * RoomVC: Read receipts processing dramatically slows down UI (#1899).
 
 Changes in 0.6.17 (2018-06-01)
 ===============================================

--- a/Riot/Model/Room/RoomBubbleCellData.h
+++ b/Riot/Model/Room/RoomBubbleCellData.h
@@ -34,10 +34,6 @@ typedef NS_ENUM(NSInteger, RoomBubbleCellDataTag)
  */
 @property(nonatomic) BOOL containsLastMessage;
 
-/**
- A Boolean value that determines whether some read receipts are currently displayed in this bubble.
- */
-@property(nonatomic) BOOL hasReadReceipts;
 
 /**
  The event id of the current selected event inside the bubble. Default is nil.

--- a/Riot/Model/Room/RoomBubbleCellData.m
+++ b/Riot/Model/Room/RoomBubbleCellData.m
@@ -48,13 +48,9 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
         // Increase maximum number of components
         self.maxComponentCount = 20;
         
-        // Initialize receipts flag
-        _hasReadReceipts = NO;
-        
-        // Force the update of the text message to take into account the potential read receipts in the bubble display.
-        // Note: we don't update this attributed string here because the RoomBubbleCellData instances are created on a processing
-        // thread different from the UI thread.
-        self.attributedTextMessage = nil;
+        // Initialize read receipts
+        self.readReceipts = [NSMutableDictionary dictionary];
+        self.readReceipts[event.eventId] = [roomDataSource.room getEventReceipts:event.eventId sorted:YES];
     }
     
     return self;
@@ -78,7 +74,6 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
         {
             [self refreshBubbleComponentsPosition];
         }
-        
         
         shouldUpdateComponentsPosition = NO;
     }
@@ -163,9 +158,6 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
 
     NSMutableAttributedString *currentAttributedTextMsg;
     
-    // Refresh the receipt flag during this process
-    _hasReadReceipts = NO;
-    
     NSInteger selectedComponentIndex = self.selectedComponentIndex;
     NSInteger lastMessageIndex = self.containsLastMessage ? self.mostRecentComponentIndex : NSNotFound;
     
@@ -203,11 +195,10 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
                 // Init attributed string with the first text component
                 currentAttributedTextMsg = [[NSMutableAttributedString alloc] initWithAttributedString:componentString];
             }
-            
-            // Vertical whitespace is added in case of read receipts
-            if ([roomDataSource.room getEventReceipts:component.event.eventId sorted:NO])
+
+            if (self.readReceipts[component.event.eventId].count)
             {
-                _hasReadReceipts = YES;
+                // Add vertical whitespace in case of read receipts
                 [currentAttributedTextMsg appendAttributedString:[RoomBubbleCellData readReceiptVerticalWhitespace]];
             }
             
@@ -246,10 +237,9 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
             // Append attributed text
             [currentAttributedTextMsg appendAttributedString:componentString];
             
-            // Add vertical whitespace in case of read receipts
-            if ([roomDataSource.room getEventReceipts:component.event.eventId sorted:NO])
+            if (self.readReceipts[component.event.eventId].count)
             {
-                _hasReadReceipts = YES;
+                // Add vertical whitespace in case of read receipts
                 [currentAttributedTextMsg appendAttributedString:[RoomBubbleCellData readReceiptVerticalWhitespace]];
             }
         }
@@ -261,9 +251,6 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
 - (void)refreshBubbleComponentsPosition
 {
     // CAUTION: This method must be called on the main thread.
-    
-    // Refresh the receipt flag during this process.
-    _hasReadReceipts = NO;
     
     @synchronized(bubbleComponents)
     {
@@ -283,7 +270,6 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
                 
                 if (component.attributedTextMessage)
                 {
-                    _hasReadReceipts = ([roomDataSource.room getEventReceipts:component.event.eventId sorted:NO] != nil);
                     break;
                 }
             }
@@ -308,7 +294,7 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
                 }
                 
                 // Vertical whitespace is added in case of read receipts
-                if (_hasReadReceipts)
+                if (self.readReceipts.count)
                 {
                     [attributedString appendAttributedString:[RoomBubbleCellData readReceiptVerticalWhitespace]];
                 }
@@ -348,9 +334,8 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
                         component.position = CGPointMake(0, positionY);
                         
                         // Add vertical whitespace in case of read receipts.
-                        if ([roomDataSource.room getEventReceipts:component.event.eventId sorted:NO])
+                        if (self.readReceipts[component.event.eventId])
                         {
-                            _hasReadReceipts = YES;
                             [attributedString appendAttributedString:[RoomBubbleCellData readReceiptVerticalWhitespace]];
                         }
                         
@@ -373,19 +358,6 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
     {
         // Update flag
         _containsLastMessage = containsLastMessage;
-        
-        // Recompute the text message layout
-        self.attributedTextMessage = nil;
-    }
-}
-
-- (void)setHasReadReceipts:(BOOL)hasReadReceipts
-{
-    // Check whether there is something to do
-    if (_hasReadReceipts || hasReadReceipts)
-    {
-        // Update flag
-        _hasReadReceipts = hasReadReceipts;
         
         // Recompute the text message layout
         self.attributedTextMessage = nil;
@@ -516,6 +488,9 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
         // One single bubble per membership event
         return NO;
     }
+
+    // Update read receipts for this bubble
+    self.readReceipts[event.eventId] = [roomDataSource.room getEventReceipts:event.eventId sorted:YES];
 
     return [super addEvent:event andRoomState:roomState];
 }

--- a/Riot/Model/Room/RoomBubbleCellData.m
+++ b/Riot/Model/Room/RoomBubbleCellData.m
@@ -51,6 +51,9 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
         // Initialize read receipts
         self.readReceipts = [NSMutableDictionary dictionary];
         self.readReceipts[event.eventId] = [roomDataSource.room getEventReceipts:event.eventId sorted:YES];
+
+        // Reset attributedTextMessage to force reset MXKRoomCellData parameters
+        self.attributedTextMessage = nil;
     }
     
     return self;


### PR DESCRIPTION
Closes #1899.
Requires https://github.com/matrix-org/matrix-ios-kit/pull/442.

Build, cache and update read receipts on the processing queue.