### PR TITLE
RoomVC: Fix regressions on vertical alignment of e2e padlock, read marker, etc

### DIFF
--- a/Riot/Model/Room/RoomBubbleCellData.m
+++ b/Riot/Model/Room/RoomBubbleCellData.m
@@ -260,6 +260,8 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
         // Check whether there is at least one component.
         if (bubbleComponents.count)
         {
+            BOOL hasReadReceipts = NO;
+
             // Set position of the first component
             CGFloat positionY = (self.attachment == nil || self.attachment.type == MXKAttachmentTypeFile || self.attachment.type == MXKAttachmentTypeAudio) ? MXKROOMBUBBLECELLDATA_TEXTVIEW_DEFAULT_VERTICAL_INSET : 0;
             MXKRoomBubbleComponent *component;
@@ -273,6 +275,7 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
                 
                 if (component.attributedTextMessage)
                 {
+                    hasReadReceipts = (self.readReceipts[component.event.eventId].count > 0);
                     break;
                 }
             }
@@ -297,7 +300,7 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
                 }
                 
                 // Vertical whitespace is added in case of read receipts
-                if (self.readReceipts.count)
+                if (hasReadReceipts)
                 {
                     [attributedString appendAttributedString:[RoomBubbleCellData readReceiptVerticalWhitespace]];
                 }
@@ -337,7 +340,7 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
                         component.position = CGPointMake(0, positionY);
                         
                         // Add vertical whitespace in case of read receipts.
-                        if (self.readReceipts[component.event.eventId])
+                        if (self.readReceipts[component.event.eventId].count)
                         {
                             [attributedString appendAttributedString:[RoomBubbleCellData readReceiptVerticalWhitespace]];
                         }


### PR DESCRIPTION
Regression due to read receipt perf improvement.

Before:
![img_1722](https://user-images.githubusercontent.com/8418515/42168001-17d2260e-7e10-11e8-9b4e-f8bf540db33e.png)

With this PR:
![img_1724](https://user-images.githubusercontent.com/8418515/42168011-1d798d68-7e10-11e8-9fb4-0bb0cc5a13f1.png)
