### PR TITLE
Replies: Implement sending

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes in 0.6.21 ()
 Improvements:
 * Update project structure. Organize UI related files by feature (PR#1932).
 * Move image files to xcassets (PR#1932).
+* Replies: Implement sending (#1911).
 
 Changes in 0.6.20 (2018-07-13)
 ===============================================

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -233,9 +233,12 @@
 "room_two_users_are_typing" = "%@ & %@ are typing…";
 "room_many_users_are_typing" = "%@, %@ & others are typing…";
 "room_message_placeholder" = "Send a message (unencrypted)…";
+"room_message_reply_to_placeholder" = "Send a reply (unencrypted)…";
 "room_do_not_have_permission_to_post" = "You do not have permission to post to this room";
 "encrypted_room_message_placeholder" = "Send an encrypted message…";
+"encrypted_room_message_reply_to_placeholder" = "Send an encrypted reply…";
 "room_message_short_placeholder" = "Send a message…";
+"room_message_reply_to_short_placeholder" = "Send a reply…";
 "room_offline_notification" = "Connectivity to the server has been lost.";
 "room_unsent_messages_notification" = "Messages not sent. %@ or %@ now?";
 "room_unsent_messages_unknown_devices_notification" = "Message not sent due to unknown devices being present. %@ or %@ now?";

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -118,7 +118,7 @@
 #import "StickerPickerViewController.h"
 
 #import "EventFormatter.h"
-#import "MXKSlashCommands.h"
+#import <MatrixKit/MXKSlashCommands.h>
 
 #import "Riot-Swift.h"
 

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -118,6 +118,7 @@
 #import "StickerPickerViewController.h"
 
 #import "EventFormatter.h"
+#import "MXKSlashCommands.h"
 
 #import "Riot-Swift.h"
 
@@ -201,6 +202,7 @@
     // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
     id kRiotDesignValuesDidChangeThemeNotificationObserver;
     
+    // Tell whether the input text field is in send reply mode. If true typed message will be sent to highlighted event.
     BOOL isInReplyMode;
 }
 
@@ -986,15 +988,15 @@
 {
     // Override the default behavior for `/join` command in order to open automatically the joined room
     
-    if ([string hasPrefix:kCmdJoinRoom])
+    if ([string hasPrefix:kMXKSlashCmdJoinRoom])
     {
         // Join a room
         NSString *roomAlias;
         
         // Sanity check
-        if (string.length > kCmdJoinRoom.length)
+        if (string.length > kMXKSlashCmdJoinRoom.length)
         {
-            roomAlias = [string substringFromIndex:kCmdJoinRoom.length + 1];
+            roomAlias = [string substringFromIndex:kMXKSlashCmdJoinRoom.length + 1];
             
             // Remove white space from both ends
             roomAlias = [roomAlias stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];

--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.h
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.h
@@ -70,6 +70,11 @@
 @property (nonatomic) BOOL isEncryptionEnabled;
 
 /**
+ Tell whether the input text will be a reply to a message.
+ */
+@property (nonatomic, getter=isReplyToEnabled) BOOL replyToEnabled;
+
+/**
  Tell whether a call is active.
  */
 @property (nonatomic) BOOL activeCall;

--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
@@ -153,6 +153,41 @@
     self.placeholder = placeholder;
 }
 
+- (void)setReplyToEnabled:(BOOL)isReplyToEnabled
+{
+    _replyToEnabled = isReplyToEnabled;
+    
+    [self updatePlaceholder];
+}
+
+- (void)updatePlaceholder
+{
+    // Consider the default placeholder
+    
+    NSString *placeholder;
+    
+    // Check the device screen size before using large placeholder
+    BOOL shouldDisplayLargePlaceholder = [GBDeviceInfo deviceInfo].family == GBDeviceFamilyiPad || [GBDeviceInfo deviceInfo].displayInfo.display >= GBDeviceDisplay4p7Inch;
+    
+    if (shouldDisplayLargePlaceholder)
+    {
+        placeholder = _replyToEnabled ? NSLocalizedStringFromTable(@"room_message_reply_to_short_placeholder", @"Vector", nil) : NSLocalizedStringFromTable(@"room_message_short_placeholder", @"Vector", nil);
+    }
+    else
+    {
+        if (_isEncryptionEnabled)
+        {
+            placeholder = _replyToEnabled ? NSLocalizedStringFromTable(@"encrypted_room_message_reply_to_placeholder", @"Vector", nil) : NSLocalizedStringFromTable(@"encrypted_room_message_placeholder", @"Vector", nil);
+        }
+        else
+        {
+            placeholder = _replyToEnabled ? NSLocalizedStringFromTable(@"room_message_reply_to_placeholder", @"Vector", nil) : NSLocalizedStringFromTable(@"room_message_placeholder", @"Vector", nil);
+        }
+    }
+    
+    self.placeholder = placeholder;
+}
+
 - (void)setActiveCall:(BOOL)activeCall
 {
     if (_activeCall != activeCall)

--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
@@ -169,7 +169,7 @@
     // Check the device screen size before using large placeholder
     BOOL shouldDisplayLargePlaceholder = [GBDeviceInfo deviceInfo].family == GBDeviceFamilyiPad || [GBDeviceInfo deviceInfo].displayInfo.display >= GBDeviceDisplay4p7Inch;
     
-    if (shouldDisplayLargePlaceholder)
+    if (!shouldDisplayLargePlaceholder)
     {
         placeholder = _replyToEnabled ? NSLocalizedStringFromTable(@"room_message_reply_to_short_placeholder", @"Vector", nil) : NSLocalizedStringFromTable(@"room_message_short_placeholder", @"Vector", nil);
     }


### PR DESCRIPTION
#1911

Implement reply to an event with text message in a room. It is now possible to reply quickly to a message by highlighting it and then typing some text.

![send_reply](https://user-images.githubusercontent.com/2205780/43092186-9ee837d0-8eac-11e8-8149-237f6d7b9cb1.PNG)
