### PR TITLE
Lazy-loading: Fix search display

### DIFF
--- a/Riot/Modules/GlobalSearch/Messages/DataSources/HomeMessagesSearchDataSource.m
+++ b/Riot/Modules/GlobalSearch/Messages/DataSources/HomeMessagesSearchDataSource.m
@@ -67,6 +67,11 @@
                         // Highlight the search pattern
                         [cellData highlightPatternInTextMessage:self.searchText withForegroundColor:kRiotColorGreen andFont:patternFont];
 
+                        // Use profile information as data to display
+                        MXSearchUserProfile *userProfile = result.context.profileInfo[result.result.sender];
+                        cellData.senderDisplayName = userProfile.displayName;
+                        cellData.senderAvatarUrl = userProfile.avatarUrl;
+
                         [self->cellDataArray insertObject:cellData atIndex:0];
                     }
                 }

--- a/Riot/Modules/Room/Search/DataSources/RoomSearchDataSource.m
+++ b/Riot/Modules/Room/Search/DataSources/RoomSearchDataSource.m
@@ -69,7 +69,12 @@
         {
             // Highlight the search pattern
             [cellData highlightPatternInTextMessage:self.searchText withForegroundColor:kRiotColorGreen andFont:patternFont];
-            
+
+            // Use profile information as data to display
+            MXSearchUserProfile *userProfile = result.context.profileInfo[result.result.sender];
+            cellData.senderDisplayName = userProfile.displayName;
+            cellData.senderAvatarUrl = userProfile.avatarUrl;
+
             [cellDataArray insertObject:cellData atIndex:0];
         }
     }


### PR DESCRIPTION
Use profile info sent in the search response.

https://github.com/matrix-org/matrix-ios-kit/pull/455:

Before:
![simulator screen shot - iphone 6s plus - 2018-08-03 at 15 29 13](https://user-images.githubusercontent.com/8418515/43650172-644561b6-973f-11e8-86bd-1e6c1a5b951c.png)

After:
![simulator screen shot - iphone 6s plus - 2018-08-03 at 15 57 25](https://user-images.githubusercontent.com/8418515/43650187-6d7886b4-973f-11e8-82af-4531770ffb9c.png)
