### PR TITLE
Add UITextContentType values to AuthInputsView

### DIFF
--- a/Riot/Modules/Authentication/AuthenticationViewController.xib
+++ b/Riot/Modules/Authentication/AuthenticationViewController.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.23.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.16.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -102,13 +102,13 @@
                                             </userDefinedRuntimeAttributes>
                                         </activityIndicatorView>
                                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Currently we do not support authentication flows defined by this Home Server" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="54b-4O-ip9" userLabel="noFlowLabel">
-                                            <rect key="frame" x="28.333333333333343" y="8" width="319.33333333333326" height="33.666666666666664"/>
+                                            <rect key="frame" x="28" y="8" width="319.33333333333331" height="33.666666666666664"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <color key="textColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wIH-Kd-r7q" userLabel="retryButton">
-                                            <rect key="frame" x="165.66666666666666" y="46.666666666666686" width="45" height="30"/>
+                                            <rect key="frame" x="165" y="46.666666666666686" width="45" height="30"/>
                                             <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCRetryButton"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="30" id="WtO-NT-ei8"/>
@@ -242,7 +242,7 @@
                                                                         <constraint firstAttribute="height" constant="21" id="RT2-FT-tLZ"/>
                                                                     </constraints>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                                    <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done"/>
+                                                                    <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="URL" returnKeyType="done" textContentType="url"/>
                                                                     <connections>
                                                                         <outlet property="delegate" destination="-1" id="UVr-c4-V8L"/>
                                                                     </connections>
@@ -290,7 +290,7 @@
                                                                         <constraint firstAttribute="height" constant="21" id="XTt-dw-c6p"/>
                                                                     </constraints>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                                    <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done"/>
+                                                                    <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="URL" returnKeyType="done" textContentType="url"/>
                                                                     <connections>
                                                                         <outlet property="delegate" destination="-1" id="nZF-by-6t6"/>
                                                                     </connections>

--- a/Riot/Modules/Authentication/Views/AuthInputsView.xib
+++ b/Riot/Modules/Authentication/Views/AuthInputsView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.23.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.16.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -24,7 +24,7 @@
                                 <constraint firstAttribute="height" constant="21" id="x3j-uC-j0U"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                            <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="next"/>
+                            <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="next" textContentType="username"/>
                             <connections>
                                 <outlet property="delegate" destination="x74-04-ezp" id="cIj-f6-NKj"/>
                             </connections>
@@ -59,7 +59,7 @@
                                 <constraint firstAttribute="height" constant="21" id="iai-tB-l7T"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                            <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done" secureTextEntry="YES"/>
+                            <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done" secureTextEntry="YES" textContentType="password"/>
                             <connections>
                                 <outlet property="delegate" destination="x74-04-ezp" id="GjY-xZ-s5J"/>
                             </connections>
@@ -94,7 +94,7 @@
                                 <constraint firstAttribute="height" constant="21" id="Kvu-hz-22A"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                            <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" returnKeyType="done"/>
+                            <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" returnKeyType="done" textContentType="email"/>
                             <connections>
                                 <outlet property="delegate" destination="x74-04-ezp" id="ViI-x8-eWu"/>
                             </connections>
@@ -162,7 +162,7 @@
                                 <constraint firstAttribute="height" constant="21" id="Atb-T3-6eG"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                            <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="phonePad" returnKeyType="next"/>
+                            <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="phonePad" returnKeyType="next" textContentType="tel"/>
                             <connections>
                                 <action selector="textFieldDidChange:" destination="x74-04-ezp" eventType="editingChanged" id="kR9-TL-ZDM"/>
                                 <outlet property="delegate" destination="x74-04-ezp" id="5Vt-tC-vJ4"/>
@@ -205,7 +205,7 @@
                                 <constraint firstAttribute="height" constant="21" id="87Q-0f-X45"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                            <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done" secureTextEntry="YES"/>
+                            <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done" secureTextEntry="YES" textContentType="new-password"/>
                             <connections>
                                 <outlet property="delegate" destination="x74-04-ezp" id="28g-3U-BBM"/>
                             </connections>

--- a/Riot/Modules/Authentication/Views/ForgotPasswordInputsView.xib
+++ b/Riot/Modules/Authentication/Views/ForgotPasswordInputsView.xib
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.23.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.16.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -31,7 +31,7 @@
                                 <constraint firstAttribute="height" constant="21" id="Kvu-hz-22A"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                            <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" returnKeyType="next"/>
+                            <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" returnKeyType="next" textContentType="email"/>
                             <connections>
                                 <outlet property="delegate" destination="x74-04-ezp" id="ViI-x8-eWu"/>
                             </connections>
@@ -66,7 +66,7 @@
                                 <constraint firstAttribute="height" constant="21" id="iai-tB-l7T"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                            <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="next" secureTextEntry="YES"/>
+                            <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="next" secureTextEntry="YES" textContentType="new-password"/>
                             <connections>
                                 <outlet property="delegate" destination="x74-04-ezp" id="GjY-xZ-s5J"/>
                             </connections>
@@ -101,7 +101,7 @@
                                 <constraint firstAttribute="height" constant="21" id="87Q-0f-X45"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                            <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done" secureTextEntry="YES"/>
+                            <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done" secureTextEntry="YES" textContentType="new-password"/>
                             <connections>
                                 <outlet property="delegate" destination="x74-04-ezp" id="28g-3U-BBM"/>
                             </connections>
@@ -127,7 +127,7 @@
                     </constraints>
                 </view>
                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PFH-GE-fzb">
-                    <rect key="frame" x="233" y="42" width="135" height="30"/>
+                    <rect key="frame" x="232.5" y="42" width="135" height="30"/>
                     <color key="backgroundColor" red="0.028153735480000001" green="0.82494870580000002" blue="0.051896891280000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <accessibility key="accessibilityConfiguration" identifier="ForgotPasswordInputViewNextStepButton"/>
                     <constraints>

--- a/Riot/SupportingFiles/Riot.entitlements
+++ b/Riot/SupportingFiles/Riot.entitlements
@@ -10,6 +10,7 @@
 		<string>applinks:vector.im</string>
 		<string>applinks:riot.im</string>
 		<string>applinks:www.riot.im</string>
+		<string>webcredentials:riot.im</string>
 	</array>
 	<key>com.apple.developer.siri</key>
 	<true/>


### PR DESCRIPTION
Improves #2066

Not sure if there is anything better to be done with the current interface. With this patch iOS can now see the username field and password field. Unfortunately it tries to put the username in both the username field and the phone number field. I think that is a bug in the current heuristics for password autofill.

This patch is much improved over the old behavior though where it would only put the username in the home server field.