### PR TITLE
BF: Registration: email or phone number is no more skippable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Changes in 0.7.9 (2018-12-)
+===============================================
+
+Improvements:
+* Upgrade MatrixKit version (v0.9.2).
+
+Bug fix:
+* Registration: email or phone number is no more skippable (#2140).
+
 Changes in 0.7.8 (2018-12-12)
 ===============================================
 

--- a/Riot/Modules/Authentication/Views/AuthInputsView.m
+++ b/Riot/Modules/Authentication/Views/AuthInputsView.m
@@ -965,21 +965,10 @@
     // Check whether an account may be created without third-party identifiers.
     for (MXLoginFlow *loginFlow in currentSession.flows)
     {
-        if ([loginFlow.stages indexOfObject:kMXLoginFlowTypeDummy] != NSNotFound || [loginFlow.type isEqualToString:kMXLoginFlowTypeDummy])
+        if ([loginFlow.stages indexOfObject:kMXLoginFlowTypeEmailIdentity] == NSNotFound
+             && [loginFlow.stages indexOfObject:kMXLoginFlowTypeEmailCode] == NSNotFound)
         {
-            // The dummy flow is supported, the 3pid are then optional.
-            return NO;
-        }
-        
-        if ((loginFlow.stages.count == 1 && [loginFlow.stages[0] isEqualToString:kMXLoginFlowTypeRecaptcha]) || [loginFlow.type isEqualToString:kMXLoginFlowTypeRecaptcha])
-        {
-            // The recaptcha flow is supported alone, the 3pids are then optional.
-            return NO;
-        }
-        
-        if ((loginFlow.stages.count == 1 && [loginFlow.stages[0] isEqualToString:kMXLoginFlowTypePassword]) || [loginFlow.type isEqualToString:kMXLoginFlowTypePassword])
-        {
-            // The password flow is supported alone, the 3pids are then optional.
+            // There is a flow with no 3pids
             return NO;
         }
     }


### PR DESCRIPTION
#2140

Note: There is no more conditions linked to kMXLoginFlowTypeRecaptcha in the code, which makes it look more flexible.