### PR TITLE
fix almost all the warnings caused by -Wstrict-prototypes

### DIFF
--- a/Riot/AppDelegate.h
+++ b/Riot/AppDelegate.h
@@ -82,7 +82,7 @@ extern NSString *const kAppDelegateNetworkStatusDidChangeNotification;
 
 #pragma mark - Application layout handling
 
-- (void)restoreInitialDisplay:(void (^)())completion;
+- (void)restoreInitialDisplay:(void (^)(void))completion;
 
 /**
  Replace the secondary view controller of the split view controller (if any) with the default empty details view controller.

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -162,7 +162,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
      Completion block called when [self popToHomeViewControllerAnimated:] has been
      completed.
      */
-    void (^popToHomeViewControllerCompletion)();
+    void (^popToHomeViewControllerCompletion)(void);
     
     /**
      The listeners to call events.
@@ -755,7 +755,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
 
 #pragma mark - Application layout handling
 
-- (void)restoreInitialDisplay:(void (^)())completion
+- (void)restoreInitialDisplay:(void (^)(void))completion
 {
     // Suspend error notifications during navigation stack change.
     isErrorNotificationSuspended = YES;
@@ -976,7 +976,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
 
 #pragma mark
 
-- (void)popToHomeViewControllerAnimated:(BOOL)animated completion:(void (^)())completion
+- (void)popToHomeViewControllerAnimated:(BOOL)animated completion:(void (^)(void))completion
 {
     UINavigationController *secondNavController = self.secondaryNavigationController;
     if (secondNavController)
@@ -1024,7 +1024,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
         
         if (popToHomeViewControllerCompletion)
         {
-            void (^popToHomeViewControllerCompletion2)() = popToHomeViewControllerCompletion;
+            void (^popToHomeViewControllerCompletion2)(void) = popToHomeViewControllerCompletion;
             popToHomeViewControllerCompletion = nil;
             
             // Dispatch the completion in order to let navigation stack refresh itself.
@@ -1114,6 +1114,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     }
 }
 
+// "This block is not a prototype" - don't fix this, or it won't match Apple's definition
 - (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler
 {
     if ([identifier isEqualToString: @"inline-reply"])
@@ -3373,7 +3374,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
 
 #pragma mark - MXKCallViewControllerDelegate
 
-- (void)dismissCallViewController:(MXKCallViewController *)callViewController completion:(void (^)())completion
+- (void)dismissCallViewController:(MXKCallViewController *)callViewController completion:(void (^)(void))completion
 {
     if (currentCallViewController && callViewController == currentCallViewController)
     {
@@ -3467,7 +3468,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     }
 }
 
-- (void)presentJitsiViewController:(void (^)())completion
+- (void)presentJitsiViewController:(void (^)(void))completion
 {
     [self removeCallStatusBar];
 
@@ -3484,7 +3485,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     }
 }
 
-- (void)jitsiViewController:(JitsiViewController *)jitsiViewController dismissViewJitsiController:(void (^)())completion
+- (void)jitsiViewController:(JitsiViewController *)jitsiViewController dismissViewJitsiController:(void (^)(void))completion
 {
     if (jitsiViewController == _jitsiViewController)
     {
@@ -3495,7 +3496,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     }
 }
 
-- (void)jitsiViewController:(JitsiViewController *)jitsiViewController goBackToApp:(void (^)())completion
+- (void)jitsiViewController:(JitsiViewController *)jitsiViewController goBackToApp:(void (^)(void))completion
 {
     if (jitsiViewController == _jitsiViewController)
     {
@@ -3607,7 +3608,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     }
 }
 
-- (void)presentCallViewController:(BOOL)animated completion:(void (^)())completion
+- (void)presentCallViewController:(BOOL)animated completion:(void (^)(void))completion
 {
     [self removeCallStatusBar];
     
@@ -3936,7 +3937,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                 {
                     BOOL wasNewDevice = (deviceInfo.verified == MXDeviceUnknown);
 
-                    void (^openDialog)() = ^void()
+                    void (^openDialog)(void) = ^void()
                     {
                         NSLog(@"[AppDelegate] checkPendingRoomKeyRequestsInSession: Open dialog for %@", deviceInfo);
 

--- a/Riot/Categories/MXRoom+Riot.h
+++ b/Riot/Categories/MXRoom+Riot.h
@@ -49,7 +49,7 @@
  @param completion the block to execute at the end of the operation (independently if it succeeded or not).
  You may specify nil for this parameter.
  */
-- (void)setRoomTag:(NSString*)tag completion:(void (^)())completion;
+- (void)setRoomTag:(NSString*)tag completion:(void (^)(void))completion;
 
 /**
  Disable all the room notifications.
@@ -57,7 +57,7 @@
  @param completion the block to execute at the end of the operation (independently if it succeeded or not).
  You may specify nil for this parameter.
  */
-- (void)mute:(void (^)())completion;
+- (void)mute:(void (^)(void))completion;
 
 /**
  Set the room notifications in mention only mode.
@@ -65,7 +65,7 @@
  @param completion the block to execute at the end of the operation (independently if it succeeded or not).
  You may specify nil for this parameter.
  */
-- (void)mentionsOnly:(void (^)())completion;
+- (void)mentionsOnly:(void (^)(void))completion;
 
 /**
  Enable the room notifications.
@@ -73,6 +73,6 @@
  @param completion the block to execute at the end of the operation (independently if it succeeded or not).
  You may specify nil for this parameter.
  */
-- (void)allMessages:(void (^)())completion;
+- (void)allMessages:(void (^)(void))completion;
 
 @end

--- a/Riot/Categories/MXRoom+Riot.m
+++ b/Riot/Categories/MXRoom+Riot.m
@@ -26,7 +26,7 @@
 
 #pragma mark - Room tags
 
-- (void)setRoomTag:(NSString*)tag completion:(void (^)())completion
+- (void)setRoomTag:(NSString*)tag completion:(void (^)(void))completion
 {
     NSString* oldTag = nil;
     
@@ -126,7 +126,7 @@
     return NO;
 }
 
-- (void)mute:(void (^)())completion
+- (void)mute:(void (^)(void))completion
 {
     // Check the current notification mode
     if (self.isMute)
@@ -204,7 +204,7 @@
     }
 }
 
-- (void)mentionsOnly:(void (^)())completion
+- (void)mentionsOnly:(void (^)(void))completion
 {
     // Check the current notification mode
     if (self.isMentionsOnly)
@@ -282,7 +282,7 @@
     }
 }
 
-- (void)allMessages:(void (^)())completion
+- (void)allMessages:(void (^)(void))completion
 {
     // Check the current notification mode
     if (!self.isMentionsOnly && !self.isMute)
@@ -368,7 +368,7 @@
     return nil;
 }
 
-- (void)addPushRuleToMentionsOnly:(void (^)())completion
+- (void)addPushRuleToMentionsOnly:(void (^)(void))completion
 {
     MXNotificationCenter* notificationCenter = self.mxSession.notificationCenter;
     
@@ -427,7 +427,7 @@
                           highlight:NO];
 }
 
-- (void)addPushRuleToMute:(void (^)())completion
+- (void)addPushRuleToMute:(void (^)(void))completion
 {
     MXNotificationCenter* notificationCenter = self.mxSession.notificationCenter;
     
@@ -487,7 +487,7 @@
                                     highlight:NO];
 }
 
-- (void)removePushRule:(MXPushRule *)rule completion:(void (^)())completion
+- (void)removePushRule:(MXPushRule *)rule completion:(void (^)(void))completion
 {
     MXNotificationCenter* notificationCenter = self.mxSession.notificationCenter;
     
@@ -543,7 +543,7 @@
     [notificationCenter removeRule:rule];
 }
 
-- (void)enablePushRule:(MXPushRule *)rule completion:(void (^)())completion
+- (void)enablePushRule:(MXPushRule *)rule completion:(void (^)(void))completion
 {
     MXNotificationCenter* notificationCenter = self.mxSession.notificationCenter;
     

--- a/Riot/Modules/Call/Views/IncomingCallView.h
+++ b/Riot/Modules/Call/Views/IncomingCallView.h
@@ -18,7 +18,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^IncomingCallViewAction)();
+typedef void (^IncomingCallViewAction)(void);
 @class MXMediaManager;
 
 @interface IncomingCallView : UIView

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.h
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.h
@@ -135,7 +135,7 @@ extern NSString *const kRecentsDataSourceTapOnDirectoryServerChange;
  Move a cell from a path to another one.
  It is based on room Tag.
  */
-- (void)moveRoomCell:(MXRoom*)room from:(NSIndexPath*)oldPath to:(NSIndexPath*)newPath success:(void (^)())moveSuccess failure:(void (^)(NSError *error))moveFailure;
+- (void)moveRoomCell:(MXRoom*)room from:(NSIndexPath*)oldPath to:(NSIndexPath*)newPath success:(void (^)(void))moveSuccess failure:(void (^)(NSError *error))moveFailure;
 
 /**
  The current number of the favourite rooms with missed notifications.

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
@@ -1513,7 +1513,7 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
     return nil;
 }
 
-- (void)moveRoomCell:(MXRoom*)room from:(NSIndexPath*)oldPath to:(NSIndexPath*)newPath success:(void (^)())moveSuccess failure:(void (^)(NSError *error))moveFailure;
+- (void)moveRoomCell:(MXRoom*)room from:(NSIndexPath*)oldPath to:(NSIndexPath*)newPath success:(void (^)(void))moveSuccess failure:(void (^)(NSError *error))moveFailure;
 {
     NSLog(@"[RecentsDataSource] moveCellFrom (%tu, %tu) to (%tu, %tu)", oldPath.section, oldPath.row, newPath.section, newPath.row);
     

--- a/Riot/Modules/Integrations/Widgets/Jitsi/JitsiViewController.h
+++ b/Riot/Modules/Integrations/Widgets/Jitsi/JitsiViewController.h
@@ -57,7 +57,7 @@
  @param failure A block object called when the operation fails.
  */
 - (void)openWidget:(Widget*)widget withVideo:(BOOL)video
-           success:(void (^)())success
+           success:(void (^)(void))success
            failure:(void (^)(NSError *error))failure;
 
 /**
@@ -95,7 +95,7 @@
  @param jitsiViewController the jitsi view controller.
  @param completion the block to execute at the end of the operation.
  */
-- (void)jitsiViewController:(JitsiViewController *)jitsiViewController dismissViewJitsiController:(void (^)())completion;
+- (void)jitsiViewController:(JitsiViewController *)jitsiViewController dismissViewJitsiController:(void (^)(void))completion;
 
 /**
  Tells the delegate to put the jitsi view controller in background.
@@ -103,6 +103,6 @@
  @param jitsiViewController the jitsi view controller.
  @param completion the block to execute at the end of the operation.
  */
-- (void)jitsiViewController:(JitsiViewController *)jitsiViewController goBackToApp:(void (^)())completion;
+- (void)jitsiViewController:(JitsiViewController *)jitsiViewController goBackToApp:(void (^)(void))completion;
 
 @end

--- a/Riot/Modules/Integrations/Widgets/Jitsi/JitsiViewController.m
+++ b/Riot/Modules/Integrations/Widgets/Jitsi/JitsiViewController.m
@@ -45,7 +45,7 @@ static const NSString *kJitsiServerUrl = @"https://jitsi.riot.im/";
 }
 
 - (void)openWidget:(Widget*)widget withVideo:(BOOL)aVideo
-           success:(void (^)())success
+           success:(void (^)(void))success
            failure:(void (^)(NSError *error))failure
 {
     video = aVideo;

--- a/Riot/Modules/Room/Settings/RoomSettingsViewController.m
+++ b/Riot/Modules/Room/Settings/RoomSettingsViewController.m
@@ -3226,7 +3226,7 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
     return canSetCanonicalAlias;
 }
 
-- (void)shouldRemoveCanonicalAlias:(void (^)())didRemoveCanonicalAlias
+- (void)shouldRemoveCanonicalAlias:(void (^)(void))didRemoveCanonicalAlias
 {
     // Prompt the user before removing the current main address
     [currentAlert dismissViewControllerAnimated:NO completion:nil];

--- a/Riot/Modules/RoomKeyRequest/RoomKeyRequestViewController.h
+++ b/Riot/Modules/RoomKeyRequest/RoomKeyRequestViewController.h
@@ -43,7 +43,7 @@
  @param onComplete a block called when the the dialog is closed.
  @return the newly created instance.
  */
-- (instancetype)initWithDeviceInfo:(MXDeviceInfo*)deviceInfo wasNewDevice:(BOOL)wasNewDevice andMatrixSession:(MXSession*)session onComplete:(void (^)())onComplete;
+- (instancetype)initWithDeviceInfo:(MXDeviceInfo*)deviceInfo wasNewDevice:(BOOL)wasNewDevice andMatrixSession:(MXSession*)session onComplete:(void (^)(void))onComplete;
 
 /**
  Show the dialog in a modal way.

--- a/Riot/Modules/RoomKeyRequest/RoomKeyRequestViewController.m
+++ b/Riot/Modules/RoomKeyRequest/RoomKeyRequestViewController.m
@@ -21,7 +21,7 @@
 
 @interface RoomKeyRequestViewController ()
 {
-    void (^onComplete)();
+    void (^onComplete)(void);
 
     EncryptionInfoView *encryptionInfoView;
 
@@ -31,7 +31,7 @@
 
 @implementation RoomKeyRequestViewController
 
-- (instancetype)initWithDeviceInfo:(MXDeviceInfo *)deviceInfo wasNewDevice:(BOOL)theWasNewDevice andMatrixSession:(MXSession *)session onComplete:(void (^)())onCompleteBlock
+- (instancetype)initWithDeviceInfo:(MXDeviceInfo *)deviceInfo wasNewDevice:(BOOL)theWasNewDevice andMatrixSession:(MXSession *)session onComplete:(void (^)(void))onCompleteBlock
 {
     self = [super init];
     if (self)

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -132,7 +132,7 @@ enum {
 
 #define SECTION_TITLE_PADDING_WHEN_HIDDEN 0.01f
 
-typedef void (^blockSettingsViewController_onReadyToDestroy)();
+typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
 
 
 @interface SettingsViewController () <DeactivateAccountViewControllerDelegate>

--- a/RiotShareExtension/Modules/Share/Listing/RoomsListViewController.h
+++ b/RiotShareExtension/Modules/Share/Listing/RoomsListViewController.h
@@ -20,6 +20,6 @@
 
 @interface RoomsListViewController : MXKRecentListViewController
 
-@property (copy) void (^failureBlock)();
+@property (copy) void (^failureBlock)(void);
 
 @end

--- a/RiotShareExtension/Modules/Share/ShareViewController.m
+++ b/RiotShareExtension/Modules/Share/ShareViewController.m
@@ -114,7 +114,7 @@
     
     NSArray *titles = @[NSLocalizedStringFromTable(@"title_rooms", @"Vector", nil) , NSLocalizedStringFromTable(@"title_people", @"Vector", nil)];
     
-    void (^failureBlock)() = ^void() {
+    void (^failureBlock)(void) = ^void() {
         [self dismissViewControllerAnimated:YES completion:^{
             [[ShareExtensionManager sharedManager] terminateExtensionCanceled:NO];
         }];


### PR DESCRIPTION
See: https://stackoverflow.com/questions/44473146/this-function-declaration-is-not-a-prototype-warning-in-xcode-9

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst) // too small of a change, I don't feel this belongs in the changelog
* [ ] Pull request includes screenshots or videos of UI changes // no UI changes
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Signed-off-by: Fridtjof Mund <2780577+fridtjof@users.noreply.github.com>