### PR TITLE
reskin: kill riotColorRed & riotColorPinkRed

### DIFF
--- a/Riot/Managers/Theme/Theme.swift
+++ b/Riot/Managers/Theme/Theme.swift
@@ -46,6 +46,9 @@ import UIKit
     /// Color for notifications for mention messages
     var notificationPrimaryColor: UIColor { get }
 
+    /// Color for errors or warnings
+    var warningColor: UIColor { get }
+
     var avatarColors: [UIColor] { get }
 
 

--- a/Riot/Managers/Theme/ThemeService.h
+++ b/Riot/Managers/Theme/ThemeService.h
@@ -61,8 +61,6 @@ extern NSString *const kThemeServiceDidChangeThemeNotification;
 
 #pragma mark - Riot Colors not yet themeable
 
-@property (nonatomic, readonly) UIColor *riotColorPinkRed;
-@property (nonatomic, readonly) UIColor *riotColorRed;
 @property (nonatomic, readonly) UIColor *riotColorBlue;
 @property (nonatomic, readonly) UIColor *riotColorCuriousBlue;
 @property (nonatomic, readonly) UIColor *riotColorIndigo;

--- a/Riot/Managers/Theme/ThemeService.m
+++ b/Riot/Managers/Theme/ThemeService.m
@@ -92,8 +92,6 @@ NSString *const kThemeServiceDidChangeThemeNotification = @"kThemeServiceDidChan
     if (self)
     {
         // Riot Colors not yet themeable
-        _riotColorPinkRed = [[UIColor alloc] initWithRgb:0xFF0064];
-        _riotColorRed = [[UIColor alloc] initWithRgb:0xFF4444];
         _riotColorBlue = [[UIColor alloc] initWithRgb:0x81BDDB];
         _riotColorCuriousBlue = [[UIColor alloc] initWithRgb:0x2A9EDB];
         _riotColorIndigo = [[UIColor alloc] initWithRgb:0xBD79CC];

--- a/Riot/Managers/Theme/Themes/DarkTheme.swift
+++ b/Riot/Managers/Theme/Themes/DarkTheme.swift
@@ -44,6 +44,8 @@ class DarkTheme: NSObject, Theme {
     var notificationSecondaryColor: UIColor = UIColor(rgb: 0x7AC9A1)
     var notificationPrimaryColor: UIColor = UIColor(rgb: 0xF56679)
 
+    var warningColor: UIColor = UIColor(rgb: 0xF56679)
+
     var avatarColors: [UIColor] = [
         UIColor(rgb: 0x7AC9A1),
         UIColor(rgb: 0x1E7DDC),

--- a/Riot/Managers/Theme/Themes/DefaultTheme.swift
+++ b/Riot/Managers/Theme/Themes/DefaultTheme.swift
@@ -44,6 +44,8 @@ class DefaultTheme: NSObject, Theme {
     var notificationSecondaryColor: UIColor = UIColor(rgb: 0x7AC9A1)
     var notificationPrimaryColor: UIColor = UIColor(rgb: 0xF56679)
 
+    var warningColor: UIColor = UIColor(rgb: 0xF56679)
+
     var avatarColors: [UIColor] = [
         UIColor(rgb: 0x7AC9A1),
         UIColor(rgb: 0x1E7DDC),

--- a/Riot/Modules/Authentication/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/AuthenticationViewController.m
@@ -163,7 +163,7 @@
     self.submitButton.backgroundColor = ThemeService.shared.theme.tintColor;
     self.skipButton.backgroundColor = ThemeService.shared.theme.tintColor;
     
-    self.noFlowLabel.textColor = ThemeService.shared.riotColorRed;
+    self.noFlowLabel.textColor = ThemeService.shared.theme.warningColor;
     
     NSMutableAttributedString *forgotPasswordTitle = [[NSMutableAttributedString alloc] initWithString:NSLocalizedStringFromTable(@"auth_forgot_password", @"Vector", nil)];
     [forgotPasswordTitle addAttribute:NSUnderlineStyleAttributeName value:@(NSUnderlineStyleSingle) range:NSMakeRange(0, forgotPasswordTitle.length)];

--- a/Riot/Modules/Call/Views/IncomingCallView.m
+++ b/Riot/Modules/Call/Views/IncomingCallView.m
@@ -100,7 +100,7 @@ static const CGFloat kButtonSize = 80.0;
         self.answerTitleLabel.font = [UIFont systemFontOfSize:18.0 weight:UIFontWeightRegular];
         self.answerTitleLabel.text = NSLocalizedStringFromTable(@"accept", @"Vector", nil);
         
-        UIColor *rejectButtonBorderColor = ThemeService.shared.riotColorPinkRed;
+        UIColor *rejectButtonBorderColor = ThemeService.shared.theme.warningColor;
         
         self.rejectButton = [[CircleButton alloc] initWithImage:[UIImage imageNamed:@"call_hangup_icon"]
                                                     borderColor:rejectButtonBorderColor];

--- a/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
+++ b/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
@@ -777,8 +777,8 @@
             
             if (actionNumber.unsignedIntegerValue == MXKRoomMemberDetailsActionKick)
             {
-                [cellWithButton.mxkButton setTitleColor:ThemeService.shared.riotColorPinkRed forState:UIControlStateNormal];
-                [cellWithButton.mxkButton setTitleColor:ThemeService.shared.riotColorPinkRed forState:UIControlStateHighlighted];
+                [cellWithButton.mxkButton setTitleColor:ThemeService.shared.theme.warningColor forState:UIControlStateNormal];
+                [cellWithButton.mxkButton setTitleColor:ThemeService.shared.theme.warningColor forState:UIControlStateHighlighted];
             }
             else
             {

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -1331,7 +1331,7 @@
                     // Show it in red only for room widgets, not user's widgets
                     // TODO: Design must be reviewed
                     UIImage *icon = self.navigationItem.rightBarButtonItems[1].image;
-                    icon = [MXKTools paintImage:icon withColor:ThemeService.shared.riotColorPinkRed];
+                    icon = [MXKTools paintImage:icon withColor:ThemeService.shared.theme.warningColor];
                     icon = [icon imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
 
                     self.navigationItem.rightBarButtonItems[1].image = icon;

--- a/Riot/Modules/Room/Settings/RoomSettingsViewController.m
+++ b/Riot/Modules/Room/Settings/RoomSettingsViewController.m
@@ -2362,7 +2362,7 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
             cell = [tableView dequeueReusableCellWithIdentifier:kRoomSettingsWarningCellViewIdentifier forIndexPath:indexPath];
             
             cell.textLabel.font = [UIFont systemFontOfSize:17];
-            cell.textLabel.textColor = ThemeService.shared.riotColorPinkRed;
+            cell.textLabel.textColor = ThemeService.shared.theme.warningColor;
             cell.textLabel.numberOfLines = 0;
             cell.accessoryView = nil;
             cell.accessoryType = UITableViewCellAccessoryNone;

--- a/Riot/Modules/Room/Views/Activities/RoomActivitiesView.m
+++ b/Riot/Modules/Room/Views/Activities/RoomActivitiesView.m
@@ -113,7 +113,7 @@
     [super customizeViewRendering];
     
     self.separatorView.backgroundColor = ThemeService.shared.theme.headerBackgroundColor;
-    if (self.messageLabel.textColor != ThemeService.shared.riotColorPinkRed)
+    if (self.messageLabel.textColor != ThemeService.shared.theme.warningColor)
     {
         self.messageLabel.textColor = ThemeService.shared.theme.textSecondaryColor;
     }
@@ -145,18 +145,18 @@
         [tappableNotif addAttribute:NSLinkAttributeName value:@"onCancelLink" range:range];
         
         NSRange wholeString = NSMakeRange(0, tappableNotif.length);
-        [tappableNotif addAttribute:NSForegroundColorAttributeName value:ThemeService.shared.riotColorPinkRed range:wholeString];
+        [tappableNotif addAttribute:NSForegroundColorAttributeName value:ThemeService.shared.theme.warningColor range:wholeString];
         [tappableNotif addAttribute:NSFontAttributeName value:[UIFont systemFontOfSize:15] range:wholeString];
         
         self.messageTextView.attributedText = tappableNotif;
-        self.messageTextView.tintColor = ThemeService.shared.riotColorPinkRed;
+        self.messageTextView.tintColor = ThemeService.shared.theme.warningColor;
         self.messageTextView.hidden = NO;
         self.messageTextView.backgroundColor = [UIColor clearColor];
     }
     else
     {
         self.messageLabel.text = notification;
-        self.messageLabel.textColor = ThemeService.shared.riotColorPinkRed;
+        self.messageLabel.textColor = ThemeService.shared.theme.warningColor;
         self.messageLabel.hidden = NO;
     }
     
@@ -187,7 +187,7 @@
     {
         self.iconImageView.image = [UIImage imageNamed:@"error"];
         self.messageLabel.text = labelText;
-        self.messageLabel.textColor = ThemeService.shared.riotColorPinkRed;
+        self.messageLabel.textColor = ThemeService.shared.theme.warningColor;
         
         self.iconImageView.hidden = NO;
         self.messageLabel.hidden = NO;
@@ -261,15 +261,15 @@
     // Display the string in white on pink red
     NSRange wholeString = NSMakeRange(0, onGoingConferenceCallAttibutedString.length);
     [onGoingConferenceCallAttibutedString addAttribute:NSForegroundColorAttributeName value:ThemeService.shared.theme.backgroundColor range:wholeString];
-    [onGoingConferenceCallAttibutedString addAttribute:NSBackgroundColorAttributeName value:ThemeService.shared.riotColorPinkRed range:wholeString];
+    [onGoingConferenceCallAttibutedString addAttribute:NSBackgroundColorAttributeName value:ThemeService.shared.theme.warningColor range:wholeString];
     [onGoingConferenceCallAttibutedString addAttribute:NSFontAttributeName value:[UIFont systemFontOfSize:15] range:wholeString];
 
     self.messageTextView.attributedText = onGoingConferenceCallAttibutedString;
     self.messageTextView.tintColor = ThemeService.shared.theme.backgroundColor;
     self.messageTextView.hidden = NO;
 
-    self.backgroundColor = ThemeService.shared.riotColorPinkRed;
-    self.messageTextView.backgroundColor = ThemeService.shared.riotColorPinkRed;
+    self.backgroundColor = ThemeService.shared.theme.warningColor;
+    self.messageTextView.backgroundColor = ThemeService.shared.theme.warningColor;
 
     // Hide the separator to display correctly the red pink conf call banner
     self.separatorView.hidden = YES;
@@ -295,7 +295,7 @@
             notification = NSLocalizedStringFromTable(@"room_new_message_notification", @"Vector", nil);
         }
         self.messageLabel.text = [NSString stringWithFormat:notification, newMessagesCount];
-        self.messageLabel.textColor = ThemeService.shared.riotColorPinkRed;
+        self.messageLabel.textColor = ThemeService.shared.theme.warningColor;
         self.messageLabel.hidden = NO;
     }
     else
@@ -487,8 +487,8 @@
 
     if (hardLimit)
     {
-        self.backgroundColor = ThemeService.shared.riotColorPinkRed;
-        self.messageTextView.backgroundColor = ThemeService.shared.riotColorPinkRed;
+        self.backgroundColor = ThemeService.shared.theme.warningColor;
+        self.messageTextView.backgroundColor = ThemeService.shared.theme.warningColor;
     }
     else
     {

--- a/Riot/Modules/Room/Views/BubbleCells/RoomOutgoingAttachmentBubbleCell.m
+++ b/Riot/Modules/Room/Views/BubbleCells/RoomOutgoingAttachmentBubbleCell.m
@@ -49,7 +49,7 @@
         // Show a red border when the attachment sending failed
         if (bubbleCell->bubbleData.attachment.eventSentState == MXEventSentStateFailed)
         {
-            bubbleCell.attachmentView.layer.borderColor = ThemeService.shared.riotColorPinkRed.CGColor;
+            bubbleCell.attachmentView.layer.borderColor = ThemeService.shared.theme.warningColor.CGColor;
             bubbleCell.attachmentView.layer.borderWidth = 1;
         }
         else

--- a/Riot/Modules/Settings/DeactivateAccount/DeactivateAccountViewController.m
+++ b/Riot/Modules/Settings/DeactivateAccount/DeactivateAccountViewController.m
@@ -152,7 +152,7 @@ static CGFloat const kTextFontSize = 15.0;
 
 - (void)setupNavigationBar
 {
-    self.navigationController.navigationBar.titleTextAttributes = @{ NSForegroundColorAttributeName: ThemeService.shared.riotColorRed };
+    self.navigationController.navigationBar.titleTextAttributes = @{ NSForegroundColorAttributeName: ThemeService.shared.theme.warningColor };
     
     UIBarButtonItem *cancelBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedStringFromTable(@"cancel", @"Vector", nil) style:UIBarButtonItemStylePlain target:self action:@selector(cancelButtonAction:)];
     self.navigationItem.rightBarButtonItem = cancelBarButtonItem;

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -2226,7 +2226,7 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
         NSString *btnTitle = NSLocalizedStringFromTable(@"settings_deactivate_my_account", @"Vector", nil);
         [deactivateAccountBtnCell.mxkButton setTitle:btnTitle forState:UIControlStateNormal];
         [deactivateAccountBtnCell.mxkButton setTitle:btnTitle forState:UIControlStateHighlighted];
-        [deactivateAccountBtnCell.mxkButton setTintColor:ThemeService.shared.riotColorRed];
+        [deactivateAccountBtnCell.mxkButton setTintColor:ThemeService.shared.theme.warningColor];
         deactivateAccountBtnCell.mxkButton.titleLabel.font = [UIFont systemFontOfSize:17];
         
         [deactivateAccountBtnCell.mxkButton removeTarget:self action:nil forControlEvents:UIControlEventTouchUpInside];

--- a/Riot/Utils/EventFormatter.m
+++ b/Riot/Utils/EventFormatter.m
@@ -223,7 +223,7 @@ NSString *const kEventFormatterOnReRequestKeysLinkActionSeparator = @"/";
         self.bingTextColor = ThemeService.shared.theme.notificationPrimaryColor;
         self.encryptingTextColor = ThemeService.shared.theme.tintColor;
         self.sendingTextColor = ThemeService.shared.theme.textSecondaryColor;
-        self.errorTextColor = ThemeService.shared.riotColorRed;
+        self.errorTextColor = ThemeService.shared.theme.warningColor;
         
         self.defaultTextFont = [UIFont systemFontOfSize:15];
         self.prefixTextFont = [UIFont boldSystemFontOfSize:15];


### PR DESCRIPTION
Merge them into Theme.warningColor

Part of #2174

We still need to fix tint in multi-color icons.

![simulator screen shot - iphone 6s - 2019-01-18 at 13 44 45](https://user-images.githubusercontent.com/8418515/51387703-419d1980-1b27-11e9-8f85-e981ef00575e.png)
