### PR TITLE
Small iOS version checking clean ups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Improvements:
  * Use modern literals and array/dictionary syntax where possible (PR #2160).
  * Add SwiftGen pod in order to generate Swift constants for assets (#2177).
  * RoomVC: `Redact` has been renamed to `Remove` to match riot/web (#2134).
+ * Clean up iOS version checking (#2190).
  
 Bug fix:
  * Use white scroll bar on dark themes (#2158).

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -892,7 +892,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     {
         self.isOffline = YES;
     }
-    
+
     return [self showAlertWithTitle:title message:msg];
 }
 
@@ -1077,20 +1077,18 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     if (!isPushRegistered)
     {
         NSMutableSet* notificationCategories = [NSMutableSet set];
-        if ([[UIMutableUserNotificationAction class] instancesRespondToSelector:@selector(behavior)])
-        {
-            UIMutableUserNotificationAction* quickReply = [[UIMutableUserNotificationAction alloc] init];
-            quickReply.title = NSLocalizedStringFromTable(@"room_message_short_placeholder", @"Vector", nil);
-            quickReply.identifier = @"inline-reply";
-            quickReply.activationMode = UIUserNotificationActivationModeBackground;
-            quickReply.authenticationRequired = true;
-            quickReply.behavior = UIUserNotificationActionBehaviorTextInput;
 
-            UIMutableUserNotificationCategory* quickReplyCategory = [[UIMutableUserNotificationCategory alloc] init];
-            quickReplyCategory.identifier = @"QUICK_REPLY";
-            [quickReplyCategory setActions:@[quickReply] forContext:UIUserNotificationActionContextDefault];
-            [notificationCategories addObject:quickReplyCategory];
-        }
+        UIMutableUserNotificationAction* quickReply = [[UIMutableUserNotificationAction alloc] init];
+        quickReply.title = NSLocalizedStringFromTable(@"room_message_short_placeholder", @"Vector", nil);
+        quickReply.identifier = @"inline-reply";
+        quickReply.activationMode = UIUserNotificationActivationModeBackground;
+        quickReply.authenticationRequired = true;
+        quickReply.behavior = UIUserNotificationActionBehaviorTextInput;
+
+        UIMutableUserNotificationCategory* quickReplyCategory = [[UIMutableUserNotificationCategory alloc] init];
+        quickReplyCategory.identifier = @"QUICK_REPLY";
+        [quickReplyCategory setActions:@[quickReply] forContext:UIUserNotificationActionContextDefault];
+        [notificationCategories addObject:quickReplyCategory];
 
         // Registration on iOS 8 and later
         UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:(UIUserNotificationTypeBadge | UIUserNotificationTypeSound |UIUserNotificationTypeAlert) categories:notificationCategories];

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -817,7 +817,7 @@
         
         self.tabBar.items[index].badgeValue = badgeValue;
         
-        if ([UITabBarItem instancesRespondToSelector:@selector(setBadgeColor:)])
+        if (@available(iOS 10, *))
         {
             self.tabBar.items[index].badgeColor = badgeColor;
         }
@@ -834,7 +834,7 @@
     {
         self.tabBar.items[index].badgeValue = mark;
         
-        if ([UITabBarItem instancesRespondToSelector:@selector(setBadgeColor:)])
+        if (@available(iOS 10, *))
         {
             self.tabBar.items[index].badgeColor = badgeColor;
         }


### PR DESCRIPTION
regarding the AppDelegate change: There is no need to check for iOS 8+ notifications anymore, the minimum supported version is iOS 9.

### Pull Request Checklist

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)

Signed-off-by: 2780577+fridtjof@users.noreply.github.com