### PR TITLE
Fix display of build number in settings and bug reports

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -277,7 +277,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
         buildBranch = MAKE_NS_STRING(GIT_BRANCH);
 #endif
 #ifdef BUILD_NUMBER
-        buildNumber = [NSString stringWithFormat:@"#%d", BUILD_NUMBER];
+        buildNumber = [NSString stringWithFormat:@"#%@", @(BUILD_NUMBER)];
 #endif
         if (buildBranch && buildNumber)
         {


### PR DESCRIPTION
Jenkins now uses a timestamp as build number (ex:20190124155504) that is bigger than 32 bits

Before:
![](https://matrix.org/_matrix/media/v1/download/matrix.org/WrxUKWTHWrpUfwyocpPSZSiH)
After:
![simulator screen shot - iphone 6 plus - 2019-01-24 at 17 42 04](https://user-images.githubusercontent.com/8418515/51693961-2c7d2a80-2000-11e9-85a8-1b171b2042df.png)
