### PR TITLE
Take care of percent encoding related deprecations

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -1910,8 +1910,11 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                                 {
                                     // Retry opening the link but with the returned room id
                                     NSString *newUniversalLinkFragment =
-                                    [fragment stringByReplacingOccurrencesOfString:[roomIdOrAlias stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]
-                                                                        withString:[roomId stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+                                            [fragment stringByReplacingOccurrencesOfString:[roomIdOrAlias
+                                                            stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLFragmentAllowedCharacterSet]
+                                                                                withString:[roomId
+                                                            stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLFragmentAllowedCharacterSet]
+                                            ];
                                     
                                     universalLinkFragmentPendingRoomAlias = @{roomId: roomIdOrAlias};
                                     
@@ -2143,7 +2146,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
     NSMutableArray<NSString*> *pathParams2 = [NSMutableArray arrayWithArray:pathParams];
     for (NSInteger i = 0; i < pathParams.count; i++)
     {
-        pathParams2[i] = [pathParams2[i] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        pathParams2[i] = [pathParams2[i] stringByRemovingPercentEncoding];
     }
     pathParams = pathParams2;
     
@@ -2163,7 +2166,7 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             if (value.length)
             {
                 value = [value stringByReplacingOccurrencesOfString:@"+" withString:@" "];
-                value = [value stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+                value = [value stringByRemovingPercentEncoding];
                 
                 queryParams[key] = value;
             }

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -1910,10 +1910,8 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                                 {
                                     // Retry opening the link but with the returned room id
                                     NSString *newUniversalLinkFragment =
-                                            [fragment stringByReplacingOccurrencesOfString:[roomIdOrAlias
-                                                            stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLFragmentAllowedCharacterSet]
-                                                                                withString:[roomId
-                                                            stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLFragmentAllowedCharacterSet]
+                                            [fragment stringByReplacingOccurrencesOfString:[MXTools encodeURIComponent:roomIdOrAlias]
+                                                                                withString:[MXTools encodeURIComponent:roomId]
                                             ];
                                     
                                     universalLinkFragmentPendingRoomAlias = @{roomId: roomIdOrAlias};

--- a/Riot/Managers/Widgets/Widget.m
+++ b/Riot/Managers/Widgets/Widget.m
@@ -62,9 +62,9 @@
 
             // Escape everything to build a valid URL string
             // We can't know where the values escaped here will be inserted in the URL, so the alphanumeric charset is used
-            userId = [userId stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.alphanumericCharacterSet];
-            displayName = [displayName stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.alphanumericCharacterSet];
-            avatarUrl = [avatarUrl stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.alphanumericCharacterSet];
+            userId = [MXTools encodeURIComponent:userId];
+            displayName = [MXTools encodeURIComponent:displayName];
+            avatarUrl = [MXTools encodeURIComponent:avatarUrl];
 
             NSString *widgetUrl = _url;
             widgetUrl = [widgetUrl stringByReplacingOccurrencesOfString:@"$matrix_user_id" withString:userId];
@@ -88,7 +88,7 @@
                 if (dataString)
                 {
                     // same question as above
-                    NSString *value = [dataString stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.alphanumericCharacterSet];
+                    NSString *value = [MXTools encodeURIComponent:dataString];
 
                     widgetUrl = [widgetUrl stringByReplacingOccurrencesOfString:paramKey
                                                                      withString:value];

--- a/Riot/Managers/Widgets/Widget.m
+++ b/Riot/Managers/Widgets/Widget.m
@@ -61,9 +61,10 @@
             NSString *avatarUrl = self.mxSession.myUser.avatarUrl ? self.mxSession.myUser.avatarUrl : @"";
 
             // Escape everything to build a valid URL string
-            userId = [userId stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-            displayName = [displayName stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-            avatarUrl = [avatarUrl stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+            // We can't know where the values escaped here will be inserted in the URL, so the alphanumeric charset is used
+            userId = [userId stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.alphanumericCharacterSet];
+            displayName = [displayName stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.alphanumericCharacterSet];
+            avatarUrl = [avatarUrl stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.alphanumericCharacterSet];
 
             NSString *widgetUrl = _url;
             widgetUrl = [widgetUrl stringByReplacingOccurrencesOfString:@"$matrix_user_id" withString:userId];
@@ -86,7 +87,8 @@
 
                 if (dataString)
                 {
-                    NSString *value = [dataString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+                    // same question as above
+                    NSString *value = [dataString stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.alphanumericCharacterSet];
 
                     widgetUrl = [widgetUrl stringByReplacingOccurrencesOfString:paramKey
                                                                      withString:value];

--- a/Riot/Modules/Common/Recents/RecentsViewController.m
+++ b/Riot/Modules/Common/Recents/RecentsViewController.m
@@ -1251,8 +1251,7 @@
         if (roomIdOrAlias.length)
         {
             // Open the room or preview it
-            NSString *fragment = [NSString stringWithFormat:@"/room/%@",
-                    [roomIdOrAlias stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLPathAllowedCharacterSet]];
+            NSString *fragment = [NSString stringWithFormat:@"/room/%@", [MXTools encodeURIComponent:roomIdOrAlias]];
             [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment];
         }
         [tableView deselectRowAtIndexPath:indexPath animated:NO];

--- a/Riot/Modules/Common/Recents/RecentsViewController.m
+++ b/Riot/Modules/Common/Recents/RecentsViewController.m
@@ -1251,7 +1251,8 @@
         if (roomIdOrAlias.length)
         {
             // Open the room or preview it
-            NSString *fragment = [NSString stringWithFormat:@"/room/%@", [roomIdOrAlias stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+            NSString *fragment = [NSString stringWithFormat:@"/room/%@",
+                    [roomIdOrAlias stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLPathAllowedCharacterSet]];
             [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment];
         }
         [tableView deselectRowAtIndexPath:indexPath animated:NO];

--- a/Riot/Modules/Communities/Home/GroupHomeViewController.m
+++ b/Riot/Modules/Communities/Home/GroupHomeViewController.m
@@ -779,7 +779,7 @@
     
     // When a link refers to a room alias/id, a user id or an event id, the non-ASCII characters (like '#' in room alias) has been escaped
     // to be able to convert it into a legal URL string.
-    NSString *absoluteURLString = [URL.absoluteString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSString *absoluteURLString = [URL.absoluteString stringByRemovingPercentEncoding];
     
     // If the link can be open it by the app, let it do
     if ([Tools isUniversalLink:URL])
@@ -869,7 +869,8 @@
         shouldInteractWithURL = NO;
         
         // Open the group or preview it
-        NSString *fragment = [NSString stringWithFormat:@"/group/%@", [absoluteURLString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+        NSString *fragment = [NSString stringWithFormat:@"/group/%@",
+                [absoluteURLString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]]];
         [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment];
     }
     

--- a/Riot/Modules/Communities/Home/GroupHomeViewController.m
+++ b/Riot/Modules/Communities/Home/GroupHomeViewController.m
@@ -870,7 +870,7 @@
         
         // Open the group or preview it
         NSString *fragment = [NSString stringWithFormat:@"/group/%@",
-                [absoluteURLString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]]];
+                        [MXTools encodeURIComponent:absoluteURLString]];
         [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment];
     }
     

--- a/Riot/Modules/Integrations/IntegrationManagerViewController.m
+++ b/Riot/Modules/Integrations/IntegrationManagerViewController.m
@@ -104,20 +104,20 @@ NSString *const kIntegrationManagerAddIntegrationScreen = @"add_integ";
     {
         url = [NSMutableString stringWithFormat:@"%@?scalar_token=%@&room_id=%@",
                [[NSUserDefaults standardUserDefaults] objectForKey:@"integrationsUiUrl"],
-               [scalarToken stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding],
-               [roomId stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]
+               [scalarToken stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]],
+               [roomId stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]
                ];
 
         if (screen)
         {
             [url appendString:@"&screen="];
-            [url appendString:[screen stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+            [url appendString:[screen stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
         }
 
         if (widgetId)
         {
             [url appendString:@"&integ_id="];
-            [url appendString:[widgetId stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+            [url appendString:[widgetId stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
         }
     }
     

--- a/Riot/Modules/Integrations/IntegrationManagerViewController.m
+++ b/Riot/Modules/Integrations/IntegrationManagerViewController.m
@@ -104,20 +104,20 @@ NSString *const kIntegrationManagerAddIntegrationScreen = @"add_integ";
     {
         url = [NSMutableString stringWithFormat:@"%@?scalar_token=%@&room_id=%@",
                [[NSUserDefaults standardUserDefaults] objectForKey:@"integrationsUiUrl"],
-               [scalarToken stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]],
-               [roomId stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]
+               [MXTools encodeURIComponent:scalarToken],
+               [MXTools encodeURIComponent:roomId]
                ];
 
         if (screen)
         {
             [url appendString:@"&screen="];
-            [url appendString:[screen stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+            [url appendString:[MXTools encodeURIComponent:screen]];
         }
 
         if (widgetId)
         {
             [url appendString:@"&integ_id="];
-            [url appendString:[widgetId stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+            [url appendString:[MXTools encodeURIComponent:widgetId]];
         }
     }
     

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -2756,7 +2756,7 @@
         
         // When a link refers to a room alias/id, a user id or an event id, the non-ASCII characters (like '#' in room alias) has been escaped
         // to be able to convert it into a legal URL string.
-        NSString *absoluteURLString = [url.absoluteString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        NSString *absoluteURLString = [url.absoluteString stringByRemovingPercentEncoding];
         
         // If the link can be open it by the app, let it do
         if ([Tools isUniversalLink:url])
@@ -2805,7 +2805,8 @@
             NSString *roomIdOrAlias = absoluteURLString;
             
             // Open the room or preview it
-            NSString *fragment = [NSString stringWithFormat:@"/room/%@", [roomIdOrAlias stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+            NSString *fragment = [NSString stringWithFormat:@"/room/%@",
+                    [roomIdOrAlias stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]]];
             [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment];
         }
         // Preview the clicked group
@@ -2814,7 +2815,8 @@
             shouldDoAction = NO;
             
             // Open the group or preview it
-            NSString *fragment = [NSString stringWithFormat:@"/group/%@", [absoluteURLString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+            NSString *fragment = [NSString stringWithFormat:@"/group/%@",
+                    [absoluteURLString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]]];
             [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment];
         }
         else if ([absoluteURLString hasPrefix:kEventFormatterOnReRequestKeysLinkAction])
@@ -3961,7 +3963,8 @@
         else if (customizedRoomDataSource.roomState.isObsolete)
         {
             NSString *replacementRoomId = customizedRoomDataSource.roomState.tombStoneContent.replacementRoomId;
-            NSString *roomLinkFragment = [NSString stringWithFormat:@"/room/%@", [replacementRoomId stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+            NSString *roomLinkFragment = [NSString stringWithFormat:@"/room/%@",
+                    [replacementRoomId stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]]];
             
             [roomActivitiesView displayRoomReplacementWithRoomLinkTappedHandler:^{
                 [[AppDelegate theDelegate] handleUniversalLinkFragment:roomLinkFragment];

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -2805,8 +2805,7 @@
             NSString *roomIdOrAlias = absoluteURLString;
             
             // Open the room or preview it
-            NSString *fragment = [NSString stringWithFormat:@"/room/%@",
-                    [roomIdOrAlias stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]]];
+            NSString *fragment = [NSString stringWithFormat:@"/room/%@", [MXTools encodeURIComponent:roomIdOrAlias]];
             [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment];
         }
         // Preview the clicked group
@@ -2815,8 +2814,7 @@
             shouldDoAction = NO;
             
             // Open the group or preview it
-            NSString *fragment = [NSString stringWithFormat:@"/group/%@",
-                    [absoluteURLString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]]];
+            NSString *fragment = [NSString stringWithFormat:@"/group/%@", [MXTools encodeURIComponent:absoluteURLString]];
             [[AppDelegate theDelegate] handleUniversalLinkFragment:fragment];
         }
         else if ([absoluteURLString hasPrefix:kEventFormatterOnReRequestKeysLinkAction])
@@ -3963,8 +3961,7 @@
         else if (customizedRoomDataSource.roomState.isObsolete)
         {
             NSString *replacementRoomId = customizedRoomDataSource.roomState.tombStoneContent.replacementRoomId;
-            NSString *roomLinkFragment = [NSString stringWithFormat:@"/room/%@",
-                    [replacementRoomId stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]]];
+            NSString *roomLinkFragment = [NSString stringWithFormat:@"/room/%@", [MXTools encodeURIComponent:replacementRoomId]];
             
             [roomActivitiesView displayRoomReplacementWithRoomLinkTappedHandler:^{
                 [[AppDelegate theDelegate] handleUniversalLinkFragment:roomLinkFragment];


### PR DESCRIPTION
The new way to do this is by specifying an NSCharacterSet with all the allowed characters. I used the correct ones where it was obvious in what part of an URL strings would end up, but in Widget.m, placeholders can be anywhere in the URL, so I used the generic alphanumericCharacterSet there.

Signed-off-by: Fridtjof Mund <2780577+fridtjof@users.noreply.github.com>