### PR TITLE
Key backup: Trust on Decrypt

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -719,6 +719,11 @@
 
 "key_backup_recover_title" = "Secure Messages";
 
+"key_backup_recover_invalid_passphrase_title" = "Incorrect Recovery Passphrase";
+"key_backup_recover_invalid_passphrase" = "Backup could not be decrypted with this passphrase: please verify that you entered the correct recovery passphrase.";
+"key_backup_recover_invalid_recovery_key_title" = "Recovery Key Mismatch";
+"key_backup_recover_invalid_recovery_key" = "Backup could not be decrypted with this key: please verify that you entered the correct recovery key.";
+
 // Recover from passphrase
 
 "key_backup_recover_from_passphrase_info" = "Use your recovery passphrase to unlock your secure message history";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -718,8 +718,6 @@
 // MARK: Key backup recover
 
 "key_backup_recover_title" = "Secure Messages";
-"key_backup_recover_empty_backup_title" = "Empty backup";
-"key_backup_recover_empty_backup_message" = "There is no key to restore";
 
 // Recover from passphrase
 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -722,6 +722,22 @@ internal enum VectorL10n {
   internal static var keyBackupRecoverFromRecoveryKeyRecoveryKeyTitle: String { 
     return VectorL10n.tr("Vector", "key_backup_recover_from_recovery_key_recovery_key_title") 
   }
+  /// Backup could not be decrypted with this passphrase: please verify that you entered the correct recovery passphrase.
+  internal static var keyBackupRecoverInvalidPassphrase: String { 
+    return VectorL10n.tr("Vector", "key_backup_recover_invalid_passphrase") 
+  }
+  /// Incorrect Recovery Passphrase
+  internal static var keyBackupRecoverInvalidPassphraseTitle: String { 
+    return VectorL10n.tr("Vector", "key_backup_recover_invalid_passphrase_title") 
+  }
+  /// Backup could not be decrypted with this key: please verify that you entered the correct recovery key.
+  internal static var keyBackupRecoverInvalidRecoveryKey: String { 
+    return VectorL10n.tr("Vector", "key_backup_recover_invalid_recovery_key") 
+  }
+  /// Recovery Key Mismatch
+  internal static var keyBackupRecoverInvalidRecoveryKeyTitle: String { 
+    return VectorL10n.tr("Vector", "key_backup_recover_invalid_recovery_key_title") 
+  }
   /// Backup Restored!
   internal static var keyBackupRecoverSuccessInfo: String { 
     return VectorL10n.tr("Vector", "key_backup_recover_success_info") 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -674,14 +674,6 @@ internal enum VectorL10n {
   internal static var keyBackupRecoverDoneAction: String { 
     return VectorL10n.tr("Vector", "key_backup_recover_done_action") 
   }
-  /// There is no key to restore
-  internal static var keyBackupRecoverEmptyBackupMessage: String { 
-    return VectorL10n.tr("Vector", "key_backup_recover_empty_backup_message") 
-  }
-  /// Empty backup
-  internal static var keyBackupRecoverEmptyBackupTitle: String { 
-    return VectorL10n.tr("Vector", "key_backup_recover_empty_backup_title") 
-  }
   /// Use your recovery passphrase to unlock your secure message history
   internal static var keyBackupRecoverFromPassphraseInfo: String { 
     return VectorL10n.tr("Vector", "key_backup_recover_from_passphrase_info") 

--- a/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewController.swift
+++ b/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewController.swift
@@ -190,8 +190,7 @@ final class KeyBackupRecoverFromPassphraseViewController: UIViewController {
                                              message: VectorL10n.keyBackupRecoverInvalidPassphrase,
                                              animated: true,
                                              handler: nil)
-        }
-        else {
+        } else {
             self.errorPresenter.presentError(from: self, forError: error, animated: true, handler: nil)
         }
     }

--- a/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewController.swift
+++ b/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewController.swift
@@ -163,8 +163,8 @@ final class KeyBackupRecoverFromPassphraseViewController: UIViewController {
         switch viewState {
         case .loading:
             self.renderLoading()
-        case .loaded(totalKeys: let totalKeys):
-            self.renderLoaded(with: totalKeys)
+        case .loaded:
+            self.renderLoaded()
         case .error(let error):
             self.render(error: error)
         }
@@ -175,16 +175,8 @@ final class KeyBackupRecoverFromPassphraseViewController: UIViewController {
         self.activityPresenter.presentActivityIndicator(on: self.view, animated: true)
     }
     
-    private func renderLoaded(with totalKeys: UInt) {
+    private func renderLoaded() {
         self.activityPresenter.removeCurrentActivityIndicator(animated: true)
-        
-        if totalKeys == 0 {
-            self.errorPresenter.presentError(from: self,
-                                             title: VectorL10n.keyBackupRecoverEmptyBackupTitle,
-                                             message: VectorL10n.keyBackupRecoverEmptyBackupMessage,
-                                             animated: true,
-                                             handler: nil)
-        }
     }
     
     private func render(error: Error) {

--- a/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewController.swift
+++ b/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewController.swift
@@ -181,7 +181,19 @@ final class KeyBackupRecoverFromPassphraseViewController: UIViewController {
     
     private func render(error: Error) {
         self.activityPresenter.removeCurrentActivityIndicator(animated: true)
-        self.errorPresenter.presentError(from: self, forError: error, animated: true, handler: nil)
+
+        if (error as NSError).domain == MXKeyBackupErrorDomain
+            && (error as NSError).code == Int(MXKeyBackupErrorInvalidRecoveryKeyCode.rawValue) {
+
+            self.errorPresenter.presentError(from: self,
+                                             title: VectorL10n.keyBackupRecoverInvalidPassphraseTitle,
+                                             message: VectorL10n.keyBackupRecoverInvalidPassphrase,
+                                             animated: true,
+                                             handler: nil)
+        }
+        else {
+            self.errorPresenter.presentError(from: self, forError: error, animated: true, handler: nil)
+        }
     }
     
     // MARK: - Actions

--- a/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewModel.swift
+++ b/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewModel.swift
@@ -73,12 +73,27 @@ final class KeyBackupRecoverFromPassphraseViewModel: KeyBackupRecoverFromPassphr
         
         self.update(viewState: .loading)
         
-        self.currentHTTPOperation = self.keyBackup.restore(self.keyBackupVersion, withPassword: passphrase, room: nil, session: nil, success: { [weak self] (totalKeys, _) in
+        self.currentHTTPOperation = self.keyBackup.restore(self.keyBackupVersion, withPassword: passphrase, room: nil, session: nil, success: { [weak self] (_, _) in
             guard let sself = self else {
                 return
             }
-            sself.update(viewState: .loaded)
-            sself.coordinatorDelegate?.keyBackupRecoverFromPassphraseViewModelDidRecover(sself)
+
+            // Trust on decrypt
+            sself.currentHTTPOperation = sself.keyBackup.trust(sself.keyBackupVersion, trust: true, success: { [weak sself] () in
+                guard let ssself = sself else {
+                    return
+                }
+
+                ssself.update(viewState: .loaded)
+                ssself.coordinatorDelegate?.keyBackupRecoverFromPassphraseViewModelDidRecover(ssself)
+
+                }, failure: { [weak sself] error in
+                    guard let ssself = sself else {
+                        return
+                    }
+                    ssself.update(viewState: .error(error))
+            })
+
         }, failure: { [weak self] error in
             guard let sself = self else {
                 return

--- a/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewModel.swift
+++ b/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewModel.swift
@@ -17,7 +17,6 @@
 import Foundation
 
 enum KeyBackupRecoverFromPassphraseViewModelError: Error {
-    case missingKeyBackupVersion
 }
 
 final class KeyBackupRecoverFromPassphraseViewModel: KeyBackupRecoverFromPassphraseViewModelType {
@@ -72,14 +71,9 @@ final class KeyBackupRecoverFromPassphraseViewModel: KeyBackupRecoverFromPassphr
             return
         }
         
-        guard let keyBackupVersion = self.keyBackupVersion.version else {
-            self.update(viewState: .error(KeyBackupRecoverFromPassphraseViewModelError.missingKeyBackupVersion))
-            return
-        }
-        
         self.update(viewState: .loading)
         
-        self.currentHTTPOperation = self.keyBackup.restore(keyBackupVersion, withPassword: passphrase, room: nil, session: nil, success: { [weak self] (totalKeys, _) in
+        self.currentHTTPOperation = self.keyBackup.restore(self.keyBackupVersion, withPassword: passphrase, room: nil, session: nil, success: { [weak self] (totalKeys, _) in
             guard let sself = self else {
                 return
             }
@@ -91,7 +85,7 @@ final class KeyBackupRecoverFromPassphraseViewModel: KeyBackupRecoverFromPassphr
             guard let sself = self else {
                 return
             }
-            sself.update(viewState: .error(error))            
+            sself.update(viewState: .error(error))
         })
     }
     

--- a/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewModel.swift
+++ b/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewModel.swift
@@ -77,10 +77,8 @@ final class KeyBackupRecoverFromPassphraseViewModel: KeyBackupRecoverFromPassphr
             guard let sself = self else {
                 return
             }
-            sself.update(viewState: .loaded(totalKeys: totalKeys))
-            if totalKeys > 0 {
-                sself.coordinatorDelegate?.keyBackupRecoverFromPassphraseViewModelDidRecover(sself)
-            }
+            sself.update(viewState: .loaded)
+            sself.coordinatorDelegate?.keyBackupRecoverFromPassphraseViewModelDidRecover(sself)
         }, failure: { [weak self] error in
             guard let sself = self else {
                 return

--- a/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewModel.swift
+++ b/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewModel.swift
@@ -16,9 +16,6 @@
 
 import Foundation
 
-enum KeyBackupRecoverFromPassphraseViewModelError: Error {
-}
-
 final class KeyBackupRecoverFromPassphraseViewModel: KeyBackupRecoverFromPassphraseViewModelType {
     
     // MARK: - Properties
@@ -88,17 +85,11 @@ final class KeyBackupRecoverFromPassphraseViewModel: KeyBackupRecoverFromPassphr
                 ssself.coordinatorDelegate?.keyBackupRecoverFromPassphraseViewModelDidRecover(ssself)
 
                 }, failure: { [weak sself] error in
-                    guard let ssself = sself else {
-                        return
-                    }
-                    ssself.update(viewState: .error(error))
+                    sself?.update(viewState: .error(error))
             })
 
         }, failure: { [weak self] error in
-            guard let sself = self else {
-                return
-            }
-            sself.update(viewState: .error(error))
+            self?.update(viewState: .error(error))
         })
     }
     

--- a/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewState.swift
+++ b/Riot/Modules/KeyBackup/Recover/Passphrase/KeyBackupRecoverFromPassphraseViewState.swift
@@ -19,6 +19,6 @@ import Foundation
 /// KeyBackupRecoverFromPassphraseViewController view state
 enum KeyBackupRecoverFromPassphraseViewState {
     case loading
-    case loaded(totalKeys: UInt)
+    case loaded
     case error(Error)
 }

--- a/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewController.swift
+++ b/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewController.swift
@@ -179,7 +179,19 @@ final class KeyBackupRecoverFromRecoveryKeyViewController: UIViewController {
     
     private func render(error: Error) {
         self.activityPresenter.removeCurrentActivityIndicator(animated: true)
-        self.errorPresenter.presentError(from: self, forError: error, animated: true, handler: nil)
+
+        if (error as NSError).domain == MXKeyBackupErrorDomain
+            && (error as NSError).code == Int(MXKeyBackupErrorInvalidRecoveryKeyCode.rawValue) {
+
+            self.errorPresenter.presentError(from: self,
+                                             title: VectorL10n.keyBackupRecoverInvalidRecoveryKeyTitle,
+                                             message: VectorL10n.keyBackupRecoverInvalidRecoveryKey,
+                                             animated: true,
+                                             handler: nil)
+        }
+        else {
+            self.errorPresenter.presentError(from: self, forError: error, animated: true, handler: nil)
+        }
     }
     
     private func showFileSelection() {

--- a/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewController.swift
+++ b/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewController.swift
@@ -161,8 +161,8 @@ final class KeyBackupRecoverFromRecoveryKeyViewController: UIViewController {
         switch viewState {
         case .loading:
             self.renderLoading()
-        case .loaded(totalKeys: let totalKeys):
-            self.renderLoaded(with: totalKeys)
+        case .loaded:
+            self.renderLoaded()
         case .error(let error):
             self.render(error: error)
         }
@@ -173,16 +173,8 @@ final class KeyBackupRecoverFromRecoveryKeyViewController: UIViewController {
         self.activityPresenter.presentActivityIndicator(on: self.view, animated: true)
     }
     
-    private func renderLoaded(with totalKeys: UInt) {
+    private func renderLoaded() {
         self.activityPresenter.removeCurrentActivityIndicator(animated: true)
-        
-        if totalKeys == 0 {
-            self.errorPresenter.presentError(from: self,
-                                             title: VectorL10n.keyBackupRecoverEmptyBackupTitle,
-                                             message: VectorL10n.keyBackupRecoverEmptyBackupMessage,
-                                             animated: true,
-                                             handler: nil)
-        }
     }
     
     private func render(error: Error) {

--- a/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewController.swift
+++ b/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewController.swift
@@ -188,8 +188,7 @@ final class KeyBackupRecoverFromRecoveryKeyViewController: UIViewController {
                                              message: VectorL10n.keyBackupRecoverInvalidRecoveryKey,
                                              animated: true,
                                              handler: nil)
-        }
-        else {
+        } else {
             self.errorPresenter.presentError(from: self, forError: error, animated: true, handler: nil)
         }
     }

--- a/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewModel.swift
+++ b/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewModel.swift
@@ -77,10 +77,9 @@ final class KeyBackupRecoverFromRecoveryKeyViewModel: KeyBackupRecoverFromRecove
             guard let sself = self else {
                 return
             }
-            sself.update(viewState: .loaded(totalKeys: totalKeys))
-            if totalKeys > 0 {
-                sself.coordinatorDelegate?.keyBackupRecoverFromRecoveryKeyViewModelDidRecover(sself)
-            }
+            sself.update(viewState: .loaded)
+            sself.coordinatorDelegate?.keyBackupRecoverFromRecoveryKeyViewModelDidRecover(sself)
+
         }, failure: { [weak self] error in
             guard let sself = self else {
                 return

--- a/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewModel.swift
+++ b/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewModel.swift
@@ -16,9 +16,6 @@
 
 import Foundation
 
-enum KeyBackupRecoverFromRecoveryKeyViewModelError: Error {
-}
-
 final class KeyBackupRecoverFromRecoveryKeyViewModel: KeyBackupRecoverFromRecoveryKeyViewModelType {
     
     // MARK: - Properties
@@ -87,18 +84,12 @@ final class KeyBackupRecoverFromRecoveryKeyViewModel: KeyBackupRecoverFromRecove
                 ssself.update(viewState: .loaded)
                 ssself.coordinatorDelegate?.keyBackupRecoverFromRecoveryKeyViewModelDidRecover(ssself)
 
-                }, failure: { [weak sself] error in
-                    guard let ssself = sself else {
-                        return
-                    }
-                    ssself.update(viewState: .error(error))
+                }, failure: {[weak sself]  error in
+                    sself?.update(viewState: .error(error))
             })
 
-        }, failure: { [weak self] error in
-            guard let sself = self else {
-                return
-            }
-            sself.update(viewState: .error(error))
+        }, failure: {[weak self]  error in
+            self?.update(viewState: .error(error))
         })
     }
     

--- a/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewModel.swift
+++ b/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewModel.swift
@@ -73,12 +73,26 @@ final class KeyBackupRecoverFromRecoveryKeyViewModel: KeyBackupRecoverFromRecove
         
         self.update(viewState: .loading)
         
-        self.currentHTTPOperation = self.keyBackup.restore(self.keyBackupVersion, withRecoveryKey: recoveryKey, room: nil, session: nil, success: { [weak self] (totalKeys, _) in
+        self.currentHTTPOperation = self.keyBackup.restore(self.keyBackupVersion, withRecoveryKey: recoveryKey, room: nil, session: nil, success: { [weak self] (_, _) in
             guard let sself = self else {
                 return
             }
-            sself.update(viewState: .loaded)
-            sself.coordinatorDelegate?.keyBackupRecoverFromRecoveryKeyViewModelDidRecover(sself)
+
+            // Trust on decrypt
+            sself.currentHTTPOperation = sself.keyBackup.trust(sself.keyBackupVersion, trust: true, success: { [weak sself] () in
+                guard let ssself = sself else {
+                    return
+                }
+
+                ssself.update(viewState: .loaded)
+                ssself.coordinatorDelegate?.keyBackupRecoverFromRecoveryKeyViewModelDidRecover(ssself)
+
+                }, failure: { [weak sself] error in
+                    guard let ssself = sself else {
+                        return
+                    }
+                    ssself.update(viewState: .error(error))
+            })
 
         }, failure: { [weak self] error in
             guard let sself = self else {

--- a/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewModel.swift
+++ b/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewModel.swift
@@ -17,7 +17,6 @@
 import Foundation
 
 enum KeyBackupRecoverFromRecoveryKeyViewModelError: Error {
-    case missingKeyBackupVersion
 }
 
 final class KeyBackupRecoverFromRecoveryKeyViewModel: KeyBackupRecoverFromRecoveryKeyViewModelType {
@@ -72,14 +71,9 @@ final class KeyBackupRecoverFromRecoveryKeyViewModel: KeyBackupRecoverFromRecove
             return
         }
         
-        guard let keyBackupVersion = self.keyBackupVersion.version else {
-            self.update(viewState: .error(KeyBackupRecoverFromRecoveryKeyViewModelError.missingKeyBackupVersion))
-            return
-        }
-        
         self.update(viewState: .loading)
         
-        self.currentHTTPOperation = self.keyBackup.restore(keyBackupVersion, withRecoveryKey: recoveryKey, room: nil, session: nil, success: { [weak self] (totalKeys, _) in
+        self.currentHTTPOperation = self.keyBackup.restore(self.keyBackupVersion, withRecoveryKey: recoveryKey, room: nil, session: nil, success: { [weak self] (totalKeys, _) in
             guard let sself = self else {
                 return
             }

--- a/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewState.swift
+++ b/Riot/Modules/KeyBackup/Recover/RecoveryKey/KeyBackupRecoverFromRecoveryKeyViewState.swift
@@ -19,6 +19,6 @@ import Foundation
 /// KeyBackupRecoverFromRecoveryKeyViewController view state
 enum KeyBackupRecoverFromRecoveryKeyViewState {
     case loading
-    case loaded(totalKeys: UInt)
+    case loaded
     case error(Error)
 }


### PR DESCRIPTION
Fixes #2223.

Requires https://github.com/matrix-org/matrix-ios-sdk/pull/634.

I have removed the error on empty backup because even if the backup is empty, the app will now trust it.

I have added errors on invalid passphrase or recovery key:

![simulator screen shot - iphone x - 2019-02-14 at 13 13 27](https://user-images.githubusercontent.com/8418515/52786263-bc8c1e00-305a-11e9-91f6-804621ed48cd.png)
![simulator screen shot - iphone x - 2019-02-14 at 13 13 13](https://user-images.githubusercontent.com/8418515/52786264-bc8c1e00-305a-11e9-8851-46d40ab1cbd4.png)
