### PR TITLE
Backup settings: Update wording and rendering to match riot-web

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -335,7 +335,7 @@
 "settings_flair" = "Show flair where allowed";
 "settings_devices" = "DEVICES";
 "settings_cryptography" = "CRYPTOGRAPHY";
-"settings_key_backup" = "SECURE MESSAGE RECOVERY";
+"settings_key_backup" = "KEY BACKUP";
 "settings_deactivate_account" = "DEACTIVATE ACCOUNT";
 
 "settings_sign_out" = "Sign Out";
@@ -421,16 +421,16 @@
 
 "settings_deactivate_my_account" = "Deactivate my account";
 
+"settings_key_backup_info" = "Encrypted messages are secured with end-to-end encryption. Only you and the recipient(s) have the keys to read these messages.";
 "settings_key_backup_info_checking" = "Checking...";
-"settings_key_backup_info_none" = "Secure Message Recovery has not been set up.";
+"settings_key_backup_info_none" = "Your keys are not being backed up from this device.";
+"settings_key_backup_info_signout_warning" = "Back up your keys before signing out to avoid losing them.";
 "settings_key_backup_info_version" = "Key Backup Version: %@";
 "settings_key_backup_info_algorithm" = "Algorithm: %@";
-"settings_key_backup_info_valid" = "Secure Message Recovery has been correctly set up for this device.";
-"settings_key_backup_info_not_valid" = "Secure Message Recovery is not active on this device.";
+"settings_key_backup_info_valid" = "This device is backing up your keys.";
+"settings_key_backup_info_not_valid" = "This device is not backing up your keys.";
 "settings_key_backup_info_progress" = "Backing up %@ keys...";
-"settings_key_backup_info_progress_done" = "All keys have been backed up";
-"settings_key_backup_info_not_trusted_from_verifiable_device_fix_action" = "To use Secure Message Recovery on this device, verify %@ now.";
-"settings_key_backup_info_not_trusted_fix_action" = "To use Secure Message Recovery on this device, provide your passphrase or recovery key now.";
+"settings_key_backup_info_progress_done" = "All keys backed up";
 
 "settings_key_backup_info_trust_signature_unknown" = "Backup has a signature from device with ID: %@";
 "settings_key_backup_info_trust_signature_valid" = "Backup has a valid signature from this device";
@@ -439,12 +439,12 @@
 "settings_key_backup_info_trust_signature_invalid_device_verified" = "Backup has an invalid signature from %@";
 "settings_key_backup_info_trust_signature_invalid_device_unverified" = "Backup has an invalid signature from %@";
 
-"settings_key_backup_button_create" = "Set up Secure Message Recovery";
-"settings_key_backup_button_restore" = "Restore backup";
-"settings_key_backup_button_delete" = "Delete backup";
-"settings_key_backup_button_verify" = "Verify";
+"settings_key_backup_button_create" = "Start using Key Backup";
+"settings_key_backup_button_restore" = "Restore from Backup";
+"settings_key_backup_button_delete" = "Delete Backup";
+"settings_key_backup_button_use" = "Use key backup";
 "settings_key_backup_delete_confirmation_prompt_title" = "Delete Backup";
-"settings_key_backup_delete_confirmation_prompt_msg" = "Delete your backed up encryption keys from the server? You will no longer be able to use your recovery key to read encrypted message history";
+"settings_key_backup_delete_confirmation_prompt_msg" = "Are you sure? You will lose your encrypted messages if your keys are not backed up properly.";
 
 // Room Details
 "room_details_title" = "Room Details";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -1970,33 +1970,37 @@ internal enum VectorL10n {
   internal static var settingsIgnoredUsers: String { 
     return VectorL10n.tr("Vector", "settings_ignored_users") 
   }
-  /// SECURE MESSAGE RECOVERY
+  /// KEY BACKUP
   internal static var settingsKeyBackup: String { 
     return VectorL10n.tr("Vector", "settings_key_backup") 
   }
-  /// Set up Secure Message Recovery
+  /// Start using Key Backup
   internal static var settingsKeyBackupButtonCreate: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_button_create") 
   }
-  /// Delete backup
+  /// Delete Backup
   internal static var settingsKeyBackupButtonDelete: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_button_delete") 
   }
-  /// Restore backup
+  /// Restore from Backup
   internal static var settingsKeyBackupButtonRestore: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_button_restore") 
   }
-  /// Verify
-  internal static var settingsKeyBackupButtonVerify: String { 
-    return VectorL10n.tr("Vector", "settings_key_backup_button_verify") 
+  /// Use key backup
+  internal static var settingsKeyBackupButtonUse: String { 
+    return VectorL10n.tr("Vector", "settings_key_backup_button_use") 
   }
-  /// Delete your backed up encryption keys from the server? You will no longer be able to use your recovery key to read encrypted message history
+  /// Are you sure? You will lose your encrypted messages if your keys are not backed up properly.
   internal static var settingsKeyBackupDeleteConfirmationPromptMsg: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_delete_confirmation_prompt_msg") 
   }
   /// Delete Backup
   internal static var settingsKeyBackupDeleteConfirmationPromptTitle: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_delete_confirmation_prompt_title") 
+  }
+  /// Encrypted messages are secured with end-to-end encryption. Only you and the recipient(s) have the keys to read these messages.
+  internal static var settingsKeyBackupInfo: String { 
+    return VectorL10n.tr("Vector", "settings_key_backup_info") 
   }
   /// Algorithm: %@
   internal static func settingsKeyBackupInfoAlgorithm(_ p1: String) -> String {
@@ -2006,19 +2010,11 @@ internal enum VectorL10n {
   internal static var settingsKeyBackupInfoChecking: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_info_checking") 
   }
-  /// Secure Message Recovery has not been set up.
+  /// Your keys are not being backed up from this device.
   internal static var settingsKeyBackupInfoNone: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_info_none") 
   }
-  /// To use Secure Message Recovery on this device, provide your passphrase or recovery key now.
-  internal static var settingsKeyBackupInfoNotTrustedFixAction: String { 
-    return VectorL10n.tr("Vector", "settings_key_backup_info_not_trusted_fix_action") 
-  }
-  /// To use Secure Message Recovery on this device, verify %@ now.
-  internal static func settingsKeyBackupInfoNotTrustedFromVerifiableDeviceFixAction(_ p1: String) -> String {
-    return VectorL10n.tr("Vector", "settings_key_backup_info_not_trusted_from_verifiable_device_fix_action", p1)
-  }
-  /// Secure Message Recovery is not active on this device.
+  /// This device is not backing up your keys.
   internal static var settingsKeyBackupInfoNotValid: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_info_not_valid") 
   }
@@ -2026,9 +2022,13 @@ internal enum VectorL10n {
   internal static func settingsKeyBackupInfoProgress(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "settings_key_backup_info_progress", p1)
   }
-  /// All keys have been backed up
+  /// All keys backed up
   internal static var settingsKeyBackupInfoProgressDone: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_info_progress_done") 
+  }
+  /// Back up your keys before signing out to avoid losing them.
+  internal static var settingsKeyBackupInfoSignoutWarning: String { 
+    return VectorL10n.tr("Vector", "settings_key_backup_info_signout_warning") 
   }
   /// Backup has an invalid signature from %@
   internal static func settingsKeyBackupInfoTrustSignatureInvalidDeviceUnverified(_ p1: String) -> String {
@@ -2054,7 +2054,7 @@ internal enum VectorL10n {
   internal static func settingsKeyBackupInfoTrustSignatureValidDeviceVerified(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "settings_key_backup_info_trust_signature_valid_device_verified", p1)
   }
-  /// Secure Message Recovery has been correctly set up for this device.
+  /// This device is backing up your keys.
   internal static var settingsKeyBackupInfoValid: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_info_valid") 
   }

--- a/Riot/Modules/Settings/KeyBackup/SettingsKeyBackupTableViewSection.swift
+++ b/Riot/Modules/Settings/KeyBackup/SettingsKeyBackupTableViewSection.swift
@@ -24,7 +24,6 @@ import UIKit
 
 
     func settingsKeyBackupTableViewSectionShowKeyBackupSetup(_ settingsKeyBackupTableViewSection: SettingsKeyBackupTableViewSection)
-    func settingsKeyBackup(_ settingsKeyBackupTableViewSection: SettingsKeyBackupTableViewSection, showVerifyDevice deviceId:String)
     func settingsKeyBackup(_ settingsKeyBackupTableViewSection: SettingsKeyBackupTableViewSection, showKeyBackupRecover keyBackupVersion:MXKeyBackupVersion)
     func settingsKeyBackup(_ settingsKeyBackupTableViewSection: SettingsKeyBackupTableViewSection, showKeyBackupDeleteConfirm keyBackupVersion:MXKeyBackupVersion)
 
@@ -130,7 +129,12 @@ import UIKit
         }
 
         let cell: MXKTableViewCellWithTextView = delegate.settingsKeyBackupTableViewSection(self, textCellForRow: row)
-        cell.mxkTextView.text = VectorL10n.settingsKeyBackupInfoChecking
+
+        let info = VectorL10n.settingsKeyBackupInfo
+        let checking = VectorL10n.settingsKeyBackupInfoChecking
+
+        let strings = [info, "", checking]
+        cell.mxkTextView.text = strings.joined(separator: "\n")
 
         return cell
     }
@@ -149,7 +153,13 @@ import UIKit
         switch row {
         case 0:
             let infoCell: MXKTableViewCellWithTextView = delegate.settingsKeyBackupTableViewSection(self, textCellForRow: row)
-            infoCell.mxkTextView.text = VectorL10n.settingsKeyBackupInfoNone
+
+            let noBackup = VectorL10n.settingsKeyBackupInfoNone
+            let info = VectorL10n.settingsKeyBackupInfo
+            let signoutWarning = VectorL10n.settingsKeyBackupInfoSignoutWarning
+
+            let strings = [noBackup, "", info, "", signoutWarning]
+            infoCell.mxkTextView.text = strings.joined(separator: "\n")
 
             cell = infoCell
 
@@ -178,10 +188,10 @@ import UIKit
         case 0:
             let infoCell: MXKTableViewCellWithTextView = delegate.settingsKeyBackupTableViewSection(self, textCellForRow: row)
 
+            let info = VectorL10n.settingsKeyBackupInfo
             let backupStatus = VectorL10n.settingsKeyBackupInfoValid
-            let uploadStatus = VectorL10n.settingsKeyBackupInfoProgressDone
 
-            let strings = [backupStatus, uploadStatus]
+            let strings = [info, "", backupStatus]
             infoCell.mxkTextView.text = strings.joined(separator: "\n")
 
             cell = infoCell
@@ -191,8 +201,9 @@ import UIKit
 
             let version = VectorL10n.settingsKeyBackupInfoVersion(keyBackupVersion.version ?? "")
             let algorithm = VectorL10n.settingsKeyBackupInfoAlgorithm(keyBackupVersion.algorithm)
+            let uploadStatus = VectorL10n.settingsKeyBackupInfoProgressDone
 
-            let strings = [version, algorithm]
+            let strings = [version, algorithm, uploadStatus]
             infoCell.mxkTextView.text = strings.joined(separator: "\n")
 
             cell = infoCell
@@ -233,12 +244,10 @@ import UIKit
         case 0:
             let infoCell: MXKTableViewCellWithTextView = delegate.settingsKeyBackupTableViewSection(self, textCellForRow: 0)
 
-            let remaining = backupProgress.totalUnitCount - backupProgress.completedUnitCount
-
+            let info = VectorL10n.settingsKeyBackupInfo
             let backupStatus = VectorL10n.settingsKeyBackupInfoValid
-            let uploadStatus = VectorL10n.settingsKeyBackupInfoProgress(String(remaining))
 
-            let strings = [backupStatus, uploadStatus]
+            let strings = [info, "", backupStatus]
             infoCell.mxkTextView.text = strings.joined(separator: "\n")
 
             cell = infoCell
@@ -246,10 +255,13 @@ import UIKit
         case 1:
             let infoCell: MXKTableViewCellWithTextView = delegate.settingsKeyBackupTableViewSection(self, textCellForRow: row)
 
+            let remaining = backupProgress.totalUnitCount - backupProgress.completedUnitCount
+
             let version = VectorL10n.settingsKeyBackupInfoVersion(keyBackupVersion.version ?? "")
             let algorithm = VectorL10n.settingsKeyBackupInfoAlgorithm(keyBackupVersion.algorithm)
+            let uploadStatus = VectorL10n.settingsKeyBackupInfoProgress(String(remaining))
 
-            let strings = [version, algorithm]
+            let strings = [version, algorithm, uploadStatus]
             infoCell.mxkTextView.text = strings.joined(separator: "\n")
 
             cell = infoCell
@@ -277,7 +289,7 @@ import UIKit
 
 
     private func numberOfBackupNotTrustedRows() -> Int {
-        return 6
+        return 5
     }
 
     private func renderBackupNotTrustedCell(atRow row: Int, keyBackupVersion: MXKeyBackupVersion, keyBackupVersionTrust: MXKeyBackupVersionTrust) -> UITableViewCell {
@@ -285,44 +297,21 @@ import UIKit
             return UITableViewCell.init()
         }
 
-        // Is the device that created the device verifiable?
-        // ie, is it known and already stored in crytpo store?
-        let lastNonVerifiedDevice = self.lastNonVerifiedDevice(keyBackupVersionTrust)
-        let lastUnVerifiableDevice = self.lastUnVerifiableDevice(keyBackupVersionTrust)
-
         var cell: UITableViewCell
         switch row {
         case 0:
             let infoCell: MXKTableViewCellWithTextView = delegate.settingsKeyBackupTableViewSection(self, textCellForRow: row)
 
+            let info = VectorL10n.settingsKeyBackupInfo
             let backupStatus = VectorL10n.settingsKeyBackupInfoNotValid
+            let signoutWarning = VectorL10n.settingsKeyBackupInfoSignoutWarning
 
-            var fixAction: [String] = []
-            if let lastNonVerifiedDevice = lastNonVerifiedDevice {
-                let deviceName = lastNonVerifiedDevice.displayName ?? lastNonVerifiedDevice.deviceId ?? ""
-                fixAction = [VectorL10n.settingsKeyBackupInfoNotTrustedFromVerifiableDeviceFixAction(deviceName)]
-            }
-            else if lastUnVerifiableDevice != nil {
-                fixAction = [VectorL10n.settingsKeyBackupInfoNotTrustedFixAction]
-            }
-
-            let strings = [backupStatus] + fixAction
+            let strings = [info, "", backupStatus, "", signoutWarning]
             infoCell.mxkTextView.text = strings.joined(separator: "\n")
 
             cell = infoCell
 
         case 1:
-            if let lastNonVerifiedDevice = lastNonVerifiedDevice {
-                cell = self.buttonCellForVerifyingDevice(lastNonVerifiedDevice.deviceId, atRow: row)
-            }
-            else if lastUnVerifiableDevice != nil {
-                cell = self.buttonCellForRestore(keyBackupVersion: keyBackupVersion, atRow: row, title: VectorL10n.settingsKeyBackupButtonVerify)
-            }
-            else {
-                cell = UITableViewCell.init()
-            }
-
-        case 2:
             let infoCell: MXKTableViewCellWithTextView = delegate.settingsKeyBackupTableViewSection(self, textCellForRow: row)
 
             let version = VectorL10n.settingsKeyBackupInfoVersion(keyBackupVersion.version ?? "")
@@ -333,7 +322,7 @@ import UIKit
 
             cell = infoCell
 
-        case 3:
+        case 2:
             let infoCell: MXKTableViewCellWithTextView = delegate.settingsKeyBackupTableViewSection(self, textCellForRow: row)
 
             let backupTrust = self.stringForKeyBackupTrust(keyBackupVersionTrust);
@@ -341,10 +330,10 @@ import UIKit
 
             cell = infoCell
 
-        case 4:
-            cell = self.buttonCellForRestore(keyBackupVersion: keyBackupVersion, atRow: row)
+        case 3:
+            cell = self.buttonCellForRestore(keyBackupVersion: keyBackupVersion, atRow: row, title: VectorL10n.settingsKeyBackupButtonUse)
 
-        case 5:
+        case 4:
             cell = self.buttonCellForDelete(keyBackupVersion: keyBackupVersion, atRow: row)
 
         default:
@@ -438,25 +427,6 @@ import UIKit
         return cell
     }
 
-    private func buttonCellForVerifyingDevice(_ deviceId: String, atRow row: Int) -> UITableViewCell {
-
-        guard let delegate = self.delegate else {
-            return UITableViewCell.init()
-        }
-
-        let cell:MXKTableViewCellWithButton = delegate.settingsKeyBackupTableViewSection(self, buttonCellForRow: row)
-
-        let btnTitle = VectorL10n.settingsKeyBackupButtonVerify
-        cell.mxkButton.setTitle(btnTitle, for: .normal)
-        cell.mxkButton.setTitle(btnTitle, for: .highlighted)
-
-        cell.mxkButton.vc_addAction {
-            self.viewModel.process(viewAction: .verify(deviceId))
-        }
-
-        return cell
-    }
-
     private func buttonCellForRestore(keyBackupVersion: MXKeyBackupVersion, atRow row: Int, title: String = VectorL10n.settingsKeyBackupButtonRestore) -> UITableViewCell {
         guard let delegate = self.delegate else {
             return UITableViewCell.init()
@@ -513,12 +483,11 @@ extension SettingsKeyBackupTableViewSection: SettingsKeyBackupViewModelViewDeleg
     func settingsKeyBackupViewModelShowKeyBackupSetup(_ viewModel: SettingsKeyBackupViewModelType) {
         self.delegate?.settingsKeyBackupTableViewSectionShowKeyBackupSetup(self)
     }
-    func settingsKeyBackup(_ viewModel: SettingsKeyBackupViewModelType, showVerifyDevice deviceId: String) {
-        self.delegate?.settingsKeyBackup(self, showVerifyDevice: deviceId)
-    }
+
     func settingsKeyBackup(_ viewModel: SettingsKeyBackupViewModelType, showKeyBackupRecover keyBackupVersion: MXKeyBackupVersion) {
         self.delegate?.settingsKeyBackup(self, showKeyBackupRecover: keyBackupVersion)
     }
+    
     func settingsKeyBackup(_ viewModel: SettingsKeyBackupViewModelType, showKeyBackupDeleteConfirm keyBackupVersion: MXKeyBackupVersion) {
         self.delegate?.settingsKeyBackup(self, showKeyBackupDeleteConfirm: keyBackupVersion)
     }

--- a/Riot/Modules/Settings/KeyBackup/SettingsKeyBackupViewAction.swift
+++ b/Riot/Modules/Settings/KeyBackup/SettingsKeyBackupViewAction.swift
@@ -19,7 +19,6 @@ import UIKit
 enum SettingsKeyBackupViewAction {
     case load
     case create
-    case verify(String)
     case restore(MXKeyBackupVersion)
     case confirmDelete(MXKeyBackupVersion)
     case delete(MXKeyBackupVersion)

--- a/Riot/Modules/Settings/KeyBackup/SettingsKeyBackupViewModel.swift
+++ b/Riot/Modules/Settings/KeyBackup/SettingsKeyBackupViewModel.swift
@@ -49,9 +49,6 @@ final class SettingsKeyBackupViewModel: SettingsKeyBackupViewModelType {
         case .create:
             viewDelegate.settingsKeyBackupViewModelShowKeyBackupSetup(self)
             break
-        case .verify(let deviceId):
-            viewDelegate.settingsKeyBackup(self, showVerifyDevice: deviceId)
-            break
         case .restore(let keyBackupVersion):
             viewDelegate.settingsKeyBackup(self, showKeyBackupRecover: keyBackupVersion)
             break

--- a/Riot/Modules/Settings/KeyBackup/SettingsKeyBackupViewModelType.swift
+++ b/Riot/Modules/Settings/KeyBackup/SettingsKeyBackupViewModelType.swift
@@ -21,7 +21,6 @@ protocol SettingsKeyBackupViewModelViewDelegate: class {
     func settingsKeyBackupViewModel(_ viewModel: SettingsKeyBackupViewModelType, didUpdateNetworkRequestViewState networkRequestViewSate: SettingsKeyBackupNetworkRequestViewState)
 
     func settingsKeyBackupViewModelShowKeyBackupSetup(_ viewModel: SettingsKeyBackupViewModelType)
-    func settingsKeyBackup(_ viewModel: SettingsKeyBackupViewModelType, showVerifyDevice deviceId:String)
     func settingsKeyBackup(_ viewModel: SettingsKeyBackupViewModelType, showKeyBackupRecover keyBackupVersion:MXKeyBackupVersion)
     func settingsKeyBackup(_ viewModel: SettingsKeyBackupViewModelType, showKeyBackupDeleteConfirm keyBackupVersion:MXKeyBackupVersion)
 }

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -4293,12 +4293,6 @@ KeyBackupRecoverCoordinatorBridgePresenterDelegate>
     [self showKeyBackupSetup];
 }
 
-- (void)settingsKeyBackup:(SettingsKeyBackupTableViewSection *)settingsKeyBackupTableViewSection showVerifyDevice:(NSString *)deviceId
-{
-    MXDeviceInfo *deviceInfo = [self.mainSession.crypto.deviceList storedDevice:self.mainSession.myUser.userId deviceId:deviceId];
-    [self showDeviceInfo:deviceInfo];
-}
-
 - (void)settingsKeyBackup:(SettingsKeyBackupTableViewSection *)settingsKeyBackupTableViewSection showKeyBackupRecover:(MXKeyBackupVersion *)keyBackupVersion
 {
     [self showKeyBackupRecover:keyBackupVersion];
@@ -4321,7 +4315,7 @@ KeyBackupRecoverCoordinatorBridgePresenterDelegate>
                                                        self->currentAlert = nil;
                                                    }]];
 
-    [currentAlert addAction:[UIAlertAction actionWithTitle:NSLocalizedStringFromTable(@"remove", @"Vector", nil)
+    [currentAlert addAction:[UIAlertAction actionWithTitle:NSLocalizedStringFromTable(@"settings_key_backup_button_delete", @"Vector", nil)
                                                      style:UIAlertActionStyleDefault
                                                    handler:^(UIAlertAction * action) {
                                                        MXStrongifyAndReturnIfNil(self);


### PR DESCRIPTION
Verify button has been removed and replaced by "Use key backup", which makes a restore, because we trust on decrypt now.

* No backup
![](https://matrix.org/_matrix/media/v1/download/matrix.org/AZEMoiUFiAnlkktsqJdWWjsD)

* Trusted backup
![](https://matrix.org/_matrix/media/v1/download/matrix.org/wUBKcGiTeizMsASXlKEiYRJU)

* Untrusted backup
![](https://matrix.org/_matrix/media/v1/download/matrix.org/qjhVIuiLlSkztsjEProFZDfj)