### PR TITLE
BF: 0.8.0: Tabs at the top of Room Details are hard to see in dark theme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes in 0.8.1 (2019-02-)
 Bug fix:
  * Fix text color in room preview (PR #2261)
  * Fix navigation bar background after accepting an invite (PR #2261)
+ * Tabs at the top of Room Details are hard to see in dark theme (#2260).
 
 Changes in 0.8.0 (2019-02-15)
 ===============================================

--- a/Riot/Modules/Common/SegmentedViewController/SegmentedViewController.m
+++ b/Riot/Modules/Common/SegmentedViewController/SegmentedViewController.m
@@ -127,6 +127,24 @@
     return viewControllers;
 }
 
+- (void)setSectionHeaderTintColor:(UIColor *)sectionHeaderTintColor
+{
+    if (_sectionHeaderTintColor != sectionHeaderTintColor)
+    {
+        _sectionHeaderTintColor = sectionHeaderTintColor;
+        
+        if (selectedMarkerView)
+        {
+            selectedMarkerView.backgroundColor = sectionHeaderTintColor;
+        }
+        
+        for (UILabel *label in sectionLabels)
+        {
+            label.textColor = sectionHeaderTintColor;
+        }
+    }
+}
+
 #pragma mark -
 
 - (void)finalizeInit


### PR DESCRIPTION
Fix #2260
![room_details_dark_theme](https://user-images.githubusercontent.com/2205780/52958527-8ae5c080-3394-11e9-89dc-587b0705c759.png)
