### PR TITLE
Key backup: avoid to refresh the home room list on every backup state change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,12 @@
 Changes in 0.8.1 (2019-02-)
 ===============================================
 
+Improvements:
+ * Key backup: avoid to refresh the home room list on every backup state change (#2265).
+
 Bug fix:
- * Fix text color in room preview (PR #2261)
- * Fix navigation bar background after accepting an invite (PR #2261)
+ * Fix text color in room preview (PR #2261).
+ * Fix navigation bar background after accepting an invite (PR #2261).
 
 Changes in 0.8.0 (2019-02-15)
 ===============================================

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
@@ -165,10 +165,13 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
 
 - (void)keyBackupStateDidChangeNotification:(NSNotification*)notification
 {
-    [self forceRefresh];
+    if ([self updateKeyBackupBanner])
+    {
+        [self forceRefresh];
+    }
 }
 
-- (void)updateKeyBackupBanner
+- (BOOL)updateKeyBackupBanner
 {
     KeyBackupBanner keyBackupBanner = KeyBackupBannerNone;
     
@@ -207,8 +210,12 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
                 break;
         }
     }
-    
+
+    BOOL updated = (self.keyBackupBanner != keyBackupBanner);
+
     self.keyBackupBanner = keyBackupBanner;
+
+    return updated;
 }
 
 - (void)hideKeyBackupBanner:(KeyBackupBanner)keyBackupBanner
@@ -1227,6 +1234,8 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
 
 - (void)refreshRoomsSections
 {
+    NSDate *startDate = [NSDate date];
+
     [invitesCellDataArray removeAllObjects];
     [favoriteCellDataArray removeAllObjects];
     [peopleCellDataArray removeAllObjects];
@@ -1239,8 +1248,6 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
     _missedGroupDiscussionsCount = _missedHighlightGroupDiscussionsCount = 0;
     
     keyBackupBannerSection = directorySection = favoritesSection = peopleSection = conversationSection = lowPrioritySection = serverNoticeSection = invitesSection = -1;
-    
-    [self updateKeyBackupBanner];
     
     if (displayedRecentsDataSourceArray.count > 0)
     {
@@ -1485,6 +1492,8 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
             }];
         }
     }
+
+    NSLog(@"[RecentsDataSource] refreshRoomsSections: Done in %.0fms", [[NSDate date] timeIntervalSinceDate:startDate] * 1000);
 }
 
 - (void)dataSource:(MXKDataSource*)dataSource didCellChange:(id)changes


### PR DESCRIPTION
A possible mitigation for #2265.
