### PR TITLE
Key backup: Fix crash when switching tabs if there is a banner on the home tab

### DIFF
--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
@@ -126,7 +126,8 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
     {
         [self unregisterKeyBackupStateDidChangeNotification];
     }
-    
+
+    [self updateKeyBackupBanner];
     [self forceRefresh];
 }
 


### PR DESCRIPTION
This is a regression made in #2265 (Key backup: avoid to refresh the home room list on every backup state change).

On other tabs than `self.keyBackupBanner` must be reset to `KeyBackupBannerNone` so that there is no banner section.
