### PR TITLE
BF: Reskin: status bar text is no more readable on iPad

### DIFF
--- a/Riot/Modules/Main/RiotSplitViewController.m
+++ b/Riot/Modules/Main/RiotSplitViewController.m
@@ -15,6 +15,8 @@
  */
 
 #import "RiotSplitViewController.h"
+#import "ThemeService.h"
+#import "Riot-Swift.h"
 
 @implementation RiotSplitViewController
 
@@ -36,8 +38,8 @@
         }
     }
     
-    // Keep the default UISplitViewController style.
-    return [super preferredStatusBarStyle];
+    // Use theme status bar style
+    return ThemeService.shared.theme.statusBarStyle;
 }
 
 - (BOOL)prefersStatusBarHidden


### PR DESCRIPTION
Fix #2276
![ipad_status_bar_light_theme](https://user-images.githubusercontent.com/2205780/53096681-fe680900-351f-11e9-94bf-21f12bc395f6.png)
![ipad_status_bar_theme_dark](https://user-images.githubusercontent.com/2205780/53096695-01fb9000-3520-11e9-8ea3-455ac864ee95.png)
