### PR TITLE
Reskin: Text in badges should be white in dark theme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Improvements:
 
 Bug fix:
  * Reskin: status bar text is no more readable on iPad (#2276).
+ * Reskin: Text in badges should be white in dark theme (#2283).
 
 Changes in 0.8.1 (2019-02-19)
 ===============================================

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
@@ -593,7 +593,7 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
     if (count)
     {
         UILabel *missedNotifAndUnreadBadgeLabel = [[UILabel alloc] init];
-        missedNotifAndUnreadBadgeLabel.textColor = ThemeService.shared.theme.backgroundColor;
+        missedNotifAndUnreadBadgeLabel.textColor = ThemeService.shared.theme.baseTextPrimaryColor;
         missedNotifAndUnreadBadgeLabel.font = [UIFont boldSystemFontOfSize:14];
         if (count > 1000)
         {

--- a/Riot/Modules/Common/Recents/Views/RecentTableViewCell.m
+++ b/Riot/Modules/Common/Recents/Views/RecentTableViewCell.m
@@ -51,7 +51,7 @@ static const CGFloat kDirectRoomBorderWidth = 3.0;
     self.roomTitle.textColor = ThemeService.shared.theme.textPrimaryColor;
     self.lastEventDescription.textColor = ThemeService.shared.theme.textSecondaryColor;
     self.lastEventDate.textColor = ThemeService.shared.theme.textSecondaryColor;
-    self.missedNotifAndUnreadBadgeLabel.textColor = ThemeService.shared.theme.backgroundColor;
+    self.missedNotifAndUnreadBadgeLabel.textColor = ThemeService.shared.theme.baseTextPrimaryColor;
     
     // Prepare direct room border
     CGColorRef directRoomBorderColor = CGColorCreateCopyWithAlpha(ThemeService.shared.theme.tintColor.CGColor, kDirectRoomBorderColorAlpha);

--- a/Riot/Modules/Communities/Views/GroupTableViewCell.m
+++ b/Riot/Modules/Communities/Views/GroupTableViewCell.m
@@ -47,7 +47,7 @@
     
     if (self.missedNotifAndUnreadBadgeLabel)
     {
-        self.missedNotifAndUnreadBadgeLabel.textColor = ThemeService.shared.theme.backgroundColor;
+        self.missedNotifAndUnreadBadgeLabel.textColor = ThemeService.shared.theme.baseTextPrimaryColor;
     }
     
     self.groupAvatar.defaultBackgroundColor = [UIColor clearColor];

--- a/Riot/Modules/Home/Views/RoomCollectionViewCell.m
+++ b/Riot/Modules/Home/Views/RoomCollectionViewCell.m
@@ -69,7 +69,7 @@ static const CGFloat kDirectRoomBorderWidth = 3.0;
     self.roomTitle.textColor = ThemeService.shared.theme.textPrimaryColor;
     self.roomTitle1.textColor = ThemeService.shared.theme.textPrimaryColor;
     self.roomTitle2.textColor = ThemeService.shared.theme.textPrimaryColor;
-    self.missedNotifAndUnreadBadgeLabel.textColor = ThemeService.shared.theme.backgroundColor;
+    self.missedNotifAndUnreadBadgeLabel.textColor = ThemeService.shared.theme.baseTextPrimaryColor;
     
     // Prepare direct room border
     CGColorRef directRoomBorderColor = CGColorCreateCopyWithAlpha(ThemeService.shared.theme.tintColor.CGColor, kDirectRoomBorderColorAlpha);

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -449,7 +449,7 @@
     self.expandedHeaderContainer.backgroundColor = ThemeService.shared.theme.baseColor;
     self.previewHeaderContainer.backgroundColor = ThemeService.shared.theme.headerBackgroundColor;
     
-    missedDiscussionsBadgeLabel.textColor = ThemeService.shared.theme.backgroundColor;
+    missedDiscussionsBadgeLabel.textColor = ThemeService.shared.theme.baseTextPrimaryColor;
     missedDiscussionsBadgeLabel.font = [UIFont boldSystemFontOfSize:14];
     missedDiscussionsBadgeLabel.backgroundColor = [UIColor clearColor];
     

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -819,6 +819,11 @@
         if (@available(iOS 10, *))
         {
             self.tabBar.items[index].badgeColor = badgeColor;
+
+            [self.tabBar.items[index] setBadgeTextAttributes:@{
+                                                               NSForegroundColorAttributeName: ThemeService.shared.theme.baseTextPrimaryColor
+                                                               }
+                                                    forState:UIControlStateNormal];
         }
     }
     else
@@ -836,6 +841,11 @@
         if (@available(iOS 10, *))
         {
             self.tabBar.items[index].badgeColor = badgeColor;
+
+            [self.tabBar.items[index] setBadgeTextAttributes:@{
+                                                               NSForegroundColorAttributeName: ThemeService.shared.theme.baseTextPrimaryColor
+                                                               }
+                                                    forState:UIControlStateNormal];
         }
     }
     else


### PR DESCRIPTION
Fixes #2283