### PR TITLE
Reskin: HomeVC: Use notices colors for badges background in section headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Improvements:
 Bug fix:
  * Reskin: status bar text is no more readable on iPad (#2276).
  * Reskin: Text in badges should be white in dark theme (#2283).
+ * Reskin: HomeVC: use notices colors for badges background in section headers (#2292).
  * Crash in Settings in 0.8.1 (#2295).
 
 Changes in 0.8.1 (2019-02-19)

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
@@ -584,10 +584,12 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
     {
         sectionArray = serverNoticeCellDataArray;
     }
-    
+
+    BOOL highlight = NO;
     for (id<MXKRecentCellDataStoring> cellData in sectionArray)
     {
         count += cellData.notificationCount;
+        highlight |= (cellData.highlightCount > 0);
     }
     
     if (count)
@@ -611,7 +613,7 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
         
         missedNotifAndUnreadBadgeBgView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, bgViewWidth, 20)];
         [missedNotifAndUnreadBadgeBgView.layer setCornerRadius:10];
-        missedNotifAndUnreadBadgeBgView.backgroundColor = ThemeService.shared.theme.headerTextSecondaryColor;
+        missedNotifAndUnreadBadgeBgView.backgroundColor = highlight ? ThemeService.shared.theme.noticeColor : ThemeService.shared.theme.noticeSecondaryColor;
         
         [missedNotifAndUnreadBadgeBgView addSubview:missedNotifAndUnreadBadgeLabel];
         missedNotifAndUnreadBadgeLabel.center = missedNotifAndUnreadBadgeBgView.center;


### PR DESCRIPTION
Part of #2292.

![simulator screen shot - iphone 6s plus - 2019-03-01 at 07 36 33](https://user-images.githubusercontent.com/8418515/53623354-c3876480-3bf4-11e9-8a62-fc38d8befc97.png)
