### PR TITLE
BF: Do not display key backup UI if the user has no e2e rooms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Bug fix:
  * Reskin: HomeVC: use notices colors for badges background in section headers (#2292).
  * Crash in Settings in 0.8.1 (#2295).
  * Quickly tapping on a URL in a message highlights the message rather than opening the URL (#728).
+ * Do not display key backup UI if the user has no e2e rooms (#2304).
 
 Changes in 0.8.1 (2019-02-19)
 ===============================================

--- a/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
+++ b/Riot/Modules/Common/Recents/DataSources/RecentsDataSource.m
@@ -175,8 +175,8 @@ NSString *const kRecentsDataSourceTapOnDirectoryServerChange = @"kRecentsDataSou
 - (BOOL)updateKeyBackupBanner
 {
     KeyBackupBanner keyBackupBanner = KeyBackupBannerNone;
-    
-    if (self.recentsDataSourceMode == RecentsDataSourceModeHome)
+        
+    if (self.recentsDataSourceMode == RecentsDataSourceModeHome && self.mxSession.crypto.backup.hasKeysToBackup)
     {
         KeyBackupBannerPreferences *keyBackupBannersPreferences = KeyBackupBannerPreferences.shared;
         

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -2711,12 +2711,13 @@ SignOutAlertPresenterDelegate>
 {
     self.signOutButton = (UIButton*)sender;
     
-    MXKeyBackupState backupState = self.mainSession.crypto.backup.state;
-    [self.signOutAlertPresenter
-     presentFor:backupState
-     from:self
-     sourceView:self.signOutButton
-     animated:YES];
+    MXKeyBackup *keyBackup = self.mainSession.crypto.backup;
+    
+    [self.signOutAlertPresenter presentFor:keyBackup.state
+                      areThereKeysToBackup:keyBackup.hasKeysToBackup
+                                      from:self
+                                sourceView:self.signOutButton
+                                  animated:YES];
 }
 
 - (void)onRemove3PID:(NSIndexPath*)path

--- a/Riot/Modules/Settings/SignOut/SignOutAlertPresenter.swift
+++ b/Riot/Modules/Settings/SignOut/SignOutAlertPresenter.swift
@@ -37,9 +37,19 @@ final class SignOutAlertPresenter: NSObject {
     
     // MARK: - Public
     
-    func present(for keyBackupState: MXKeyBackupState, from viewController: UIViewController, sourceView: UIView?, animated: Bool) {
+    func present(for keyBackupState: MXKeyBackupState,
+                 areThereKeysToBackup: Bool,
+                 from viewController: UIViewController,
+                 sourceView: UIView?,
+                 animated: Bool) {
         self.sourceView = sourceView
         self.presentingViewController = viewController
+        
+        guard areThereKeysToBackup else {
+            // If there is no keys to backup do not mention key backup and present same alert as if we had an existing backup.
+            self.presentExistingBackupAlert(animated: animated)
+            return
+        }
                 
         switch keyBackupState {
         case MXKeyBackupStateUnknown, MXKeyBackupStateDisabled, MXKeyBackupStateCheckingBackUpOnHomeserver:


### PR DESCRIPTION
Fix #2304 