### PR TITLE
RoomVC: Use accent color (green) for the ongoing conference call banner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Improvements:
  * Add app store description as app string resource to make them available for translation on weblate (#2201).
  * Update deprecated contact availability checks (#2222).
  * RoomVC: Remove the beta warning modal when enabling e2e in a room (#2239).
+ * RoomVC: Use accent color (green) for the ongoing conference call banner.
  * Fastlane: Update to Xcode 10.1 (#2202).
  * Use SwiftLint to enforce Swift style and conventions (PR #2300).
  * Fix SWIFT_VERSION configuration in post install hook of Podfile (PR #2302).

--- a/Riot/Modules/Room/Views/Activities/RoomActivitiesView.m
+++ b/Riot/Modules/Room/Views/Activities/RoomActivitiesView.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2019 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -261,15 +262,15 @@
     // Display the string in white on pink red
     NSRange wholeString = NSMakeRange(0, onGoingConferenceCallAttibutedString.length);
     [onGoingConferenceCallAttibutedString addAttribute:NSForegroundColorAttributeName value:ThemeService.shared.theme.backgroundColor range:wholeString];
-    [onGoingConferenceCallAttibutedString addAttribute:NSBackgroundColorAttributeName value:ThemeService.shared.theme.warningColor range:wholeString];
+    [onGoingConferenceCallAttibutedString addAttribute:NSBackgroundColorAttributeName value:ThemeService.shared.theme.tintColor range:wholeString];
     [onGoingConferenceCallAttibutedString addAttribute:NSFontAttributeName value:[UIFont systemFontOfSize:15] range:wholeString];
 
     self.messageTextView.attributedText = onGoingConferenceCallAttibutedString;
     self.messageTextView.tintColor = ThemeService.shared.theme.backgroundColor;
     self.messageTextView.hidden = NO;
 
-    self.backgroundColor = ThemeService.shared.theme.warningColor;
-    self.messageTextView.backgroundColor = ThemeService.shared.theme.warningColor;
+    self.backgroundColor = ThemeService.shared.theme.tintColor;
+    self.messageTextView.backgroundColor = ThemeService.shared.theme.tintColor;
 
     // Hide the separator to display correctly the red pink conf call banner
     self.separatorView.hidden = YES;


### PR DESCRIPTION
![simulator screen shot - iphone 6s plus - 2019-03-06 at 18 58 03](https://user-images.githubusercontent.com/8418515/53947371-ebc80500-40c5-11e9-8680-253350d20ff3.png)
