### PR TITLE
 Fix for #2327: keep temporary video file until upload

### DIFF
--- a/Riot/Modules/MediaPicker/MediaPickerViewController.m
+++ b/Riot/Modules/MediaPicker/MediaPickerViewController.m
@@ -1581,8 +1581,7 @@ static void *RecordingContext = &RecordingContext;
             [self.delegate mediaPickerController:self didSelectVideo:outputFileURL];
         }
         
-        // Remove the temporary file
-        [[NSFileManager defaultManager] removeItemAtURL:outputFileURL error:nil];
+        // Do not remove the file, as it will be used asynchronously; and overwritten at next upload.
         
     }];
     


### PR DESCRIPTION
Fix for #2327: keep temporary video file until upload
This leaves a temp file behind, but isn't a problem as the same file name is used for all uploads - it will be overwritten by the next upload
Signed-off-by: Sylvain Morisse <Sylvain@watcha.fr>

I have not added an entry in CHANGES.rst since its seems not to include minor bug fixes ?

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] UI change has been tested on both light and dark themes
* [x] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [ ] Pull request includes screenshots or videos of UI changes
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
