### PR TITLE
Add notification titles and group them properly on iOS 10+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@ Changes in 0.8.5 (2019-xx-xx)
 ===============================================
 
 Improvements:
+ * Added titles to notifications on iOS 10+ (#2347).
+ * Implemented notification grouping (#2347).
 
 Bug fix:
 

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -1934,21 +1934,26 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             NSString *sdp = event.content[@"offer"][@"sdp"];
             BOOL isVideoCall = [sdp rangeOfString:@"m=video"].location != NSNotFound;
 
-            if (!isVideoCall)
-                notificationBody = [NSString stringWithFormat:NSLocalizedString(@"VOICE_CALL_FROM_USER", nil), eventSenderName];
-            else
-                notificationBody = [NSString stringWithFormat:NSLocalizedString(@"VIDEO_CALL_FROM_USER", nil), eventSenderName];
+            notificationTitle = eventSenderName;
 
-            threadIdentifier = nil; // call notifications should probably stand out from normal messages
+            if (!isVideoCall)
+                notificationBody = NSLocalizedString(@"VOICE_CALL", nil);
+            else
+                notificationBody = NSLocalizedString(@"VIDEO_CALL", nil);
+
+            // call notifications should stand out from normal messages, so we don't stack them
+            threadIdentifier = nil;
         }
         else if (event.eventType == MXEventTypeRoomMember)
         {
             NSString *roomDisplayName = room.summary.displayname;
 
+            notificationTitle = roomDisplayName;
+
             if (roomDisplayName.length && ![roomDisplayName isEqualToString:eventSenderName])
-                notificationBody = [NSString stringWithFormat:NSLocalizedString(@"USER_INVITE_TO_NAMED_ROOM", nil), eventSenderName, roomDisplayName];
+                notificationBody = [NSString stringWithFormat:NSLocalizedString(@"INVITE_BY_USER_TO_ROOM", nil), eventSenderName];
             else
-                notificationBody = [NSString stringWithFormat:NSLocalizedString(@"USER_INVITE_TO_CHAT", nil), eventSenderName];
+                notificationBody = NSLocalizedString(@"INVITE_TO_CHAT", nil);
         }
         else if (event.eventType == MXEventTypeSticker)
         {

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -1894,13 +1894,8 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                     notificationBody = messageContent;
                 else if ([msgType isEqualToString:@"m.emote"])
                 {
-                    notificationTitle = nil;
-                    // TODO: how should this look? /me style messages don't look right with a title
-                    //   maybe like this:
-                    //   title = roomDisplayName
-                    //   body = * eventSenderName messageContent
-
-                    notificationBody = [NSString stringWithFormat:NSLocalizedString(@"ACTION_FROM_USER_IN_ROOM", nil), roomDisplayName, eventSenderName, messageContent];
+                    notificationTitle = roomDisplayName;
+                    notificationBody = [NSString stringWithFormat:NSLocalizedString(@"ACTION_FROM_USER", nil), eventSenderName, messageContent];
                 }
                 else if ([msgType isEqualToString:@"m.image"])
                     notificationBody = NSLocalizedString(@"IMAGE_TEXT_WITH_TITLE", nil);
@@ -1915,12 +1910,8 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
                     notificationBody = messageContent;
                 else if ([msgType isEqualToString:@"m.emote"])
                 {
-                    notificationTitle = nil;
-                    // TODO: how should this look? /me style messages look weird with a title
-                    //   maybe like this:
-                    //   title = eventSenderName
-                    //   body = * messageContent
-                    notificationBody = [NSString stringWithFormat:NSLocalizedString(@"ACTION_FROM_USER", nil), eventSenderName, messageContent];
+                    notificationTitle = eventSenderName;
+                    notificationBody = [NSString stringWithFormat:NSLocalizedString(@"ACTION", nil), messageContent];
                 }
                 else if ([msgType isEqualToString:@"m.image"])
                     notificationBody = NSLocalizedString(@"IMAGE_TEXT_WITH_TITLE", nil);

--- a/Riot/Assets/en.lproj/Localizable.strings
+++ b/Riot/Assets/en.lproj/Localizable.strings
@@ -39,6 +39,9 @@
 /* New action message from a specific person in a named room. */
 "ACTION_FROM_USER_IN_ROOM" = "%@: * %@ %@";
 
+/* New action message, sender is specified in notification title */
+"ACTION" = "* %@";
+
 /** Image Messages **/
 
 /* New action message from a specific person, not referencing a room. */
@@ -93,8 +96,10 @@
 /* A user has invited you to a named room */
 "USER_INVITE_TO_NAMED_ROOM" = "%@ has invited you to %@";
 
+/* Same as USER_INVITE_TO_CHAT but the username is already displayed in the notification title */
 "INVITE_TO_CHAT" = "You were invited to chat";
 
+/* Same as USER_INVITE_TO_NAMED_ROOM but the room name is already displayed in the notification title */
 "INVITE_BY_USER_TO_ROOM" = "You were invited by %@";
 
 /** Calls **/

--- a/Riot/Assets/en.lproj/Localizable.strings
+++ b/Riot/Assets/en.lproj/Localizable.strings
@@ -22,6 +22,9 @@
 /* New message from a specific person in a named room */
 "MSG_FROM_USER_IN_ROOM" = "%@ posted in %@";
 
+/* New message when a notification title is used */
+"MSG_TEXT_WITH_TITLE" = "Encrypted message";
+
 /** Single, unencrypted messages (where we can include the content */
 
 /* New message from a specific person, not referencing a room. Content included. */
@@ -44,11 +47,17 @@
 /* New action message from a specific person in a named room. */
 "IMAGE_FROM_USER_IN_ROOM" = "%@ posted a picture %@ in %@";
 
+/* New action message, but the sender (and room) are already in the notification title */
+"IMAGE_TEXT_WITH_TITLE" = "📷 Picture";
+
 /* A single unread message in a room */
 "SINGLE_UNREAD_IN_ROOM" = "You received a message in %@";
 
 /* A single unread message */
 "SINGLE_UNREAD" = "You received a message";
+
+/* Sticker, but with the sender (and room) already in the title */
+"STICKER_TEXT_WITH_TITLE" = "Sticker";
 
 /** Coalesced messages **/
 
@@ -103,3 +112,5 @@
 
 /* Incoming named video conference invite from a specific person */
 "VIDEO_CONF_NAMED_FROM_USER" = "Video group call from %@: '%@'";
+
+"MSG_FROM_USER_IN_ROOM_TITLE" = "%@ in %@";

--- a/Riot/Assets/en.lproj/Localizable.strings
+++ b/Riot/Assets/en.lproj/Localizable.strings
@@ -23,7 +23,7 @@
 "MSG_FROM_USER_IN_ROOM" = "%@ posted in %@";
 
 /* New message when a notification title is used */
-"MSG_TEXT_WITH_TITLE" = "Encrypted message";
+"MSG_TEXT_WITH_TITLE" = "Message";
 
 /** Single, unencrypted messages (where we can include the content */
 
@@ -57,7 +57,7 @@
 "SINGLE_UNREAD" = "You received a message";
 
 /* Sticker, but with the sender (and room) already in the title */
-"STICKER_TEXT_WITH_TITLE" = "Sticker";
+"STICKER_TEXT_WITH_TITLE" = "💟 Sticker";
 
 /** Coalesced messages **/
 
@@ -93,13 +93,21 @@
 /* A user has invited you to a named room */
 "USER_INVITE_TO_NAMED_ROOM" = "%@ has invited you to %@";
 
+"INVITE_TO_CHAT" = "You were invited to chat";
+
+"INVITE_BY_USER_TO_ROOM" = "You were invited by %@";
+
 /** Calls **/
 
 /* Incoming one-to-one voice call */
 "VOICE_CALL_FROM_USER" = "Call from %@";
 
+"VOICE_CALL" = "📞 Call";
+
 /* Incoming one-to-one video call */
 "VIDEO_CALL_FROM_USER" = "Video call from %@";
+
+"VIDEO_CALL" = "📹 Video call";
 
 /* Incoming unnamed voice conference invite from a specific person */
 "VOICE_CONF_FROM_USER" = "Group call from %@";


### PR DESCRIPTION
As with #2207, I can't test this myself.

This is based on riot_2337 instead of develop, because required code was only merged into that branch (see #2207)

This closes #2208 and #2337 

Signed-off-by: Fridtjof Mund 2780577+fridtjof@users.noreply.github.com