### PR TITLE
Widgets: Use scalar prod urls in Riot mobile apps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in 0.8.5 (2019-xx-xx)
 
 Improvements:
  * Push: Add more logs to track spontaneously disabling (#2348).
+ * Widgets: Use scalar prod urls in Riot mobile apps (#2349).
 
 Bug fix:
 

--- a/Riot/Assets/Riot-Defaults.plist
+++ b/Riot/Assets/Riot-Defaults.plist
@@ -25,9 +25,9 @@
 	<key>matrixApps</key>
 	<true/>
 	<key>integrationsUiUrl</key>
-	<string>https://scalar-staging.riot.im/scalar-web/</string>
+	<string>https://scalar.vector.im/</string>
 	<key>integrationsRestUrl</key>
-	<string>https://scalar-staging.riot.im/scalar/api</string>
+	<string>https://scalar.vector.im/api</string>
 	<key>integrationsWidgetsUrls</key>
 	<array>
 		<string>https://scalar-staging.riot.im/scalar/api</string>


### PR DESCRIPTION
Fixes #2349

![Simulator Screen Shot - iPhone 6s - 2019-03-27 at 15 42 36](https://user-images.githubusercontent.com/8418515/55085785-8b662b00-50a7-11e9-8317-66ec9261ee81.png)
