### PR TITLE
BF: +N read receipt text is invisible on dark theme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Improvements:
 Bug fix:
  * Share extension: Fix a crash when receive a memory warning (PR #2352).
  * Upgraded rooms show up in the share extension twice (#2293).
+ * +N read receipt text is invisible on dark theme (#2294).
 
 Changes in 0.8.4 (2019-03-21)
 ===============================================

--- a/Riot/Modules/Room/DataSources/RoomDataSource.m
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.m
@@ -314,6 +314,8 @@
                             // Set the container tag to be able to retrieve read receipts container from component index (see component selection in MXKRoomBubbleTableViewCell (Vector) category).
                             avatarsContainer.tag = index;
                             
+                            avatarsContainer.moreLabelTextColor = ThemeService.shared.theme.textPrimaryColor;
+                            
                             [avatarsContainer refreshReceiptSenders:roomMembers withPlaceHolders:placeholders andAlignment:ReadReceiptAlignmentRight];
                             avatarsContainer.readReceipts = receipts;
                             UITapGestureRecognizer *tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:cell action:@selector(onReceiptContainerTap:)];


### PR DESCRIPTION
Fix #2294, requires matrix-org/matrix-ios-kit/pull/539

![image](https://user-images.githubusercontent.com/2205780/55871071-338cf100-5b8a-11e9-8a67-137df51bf57d.png)


