### PR TITLE
Clarify key backup details when backup exists but is not trusted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Improvements:
  * Notifications: Added titles to notifications on iOS 10+, thanks to @fridtjof (PR #2347).
  * iOS 12 Notification: Group them by room (#2337 and PR #2347 thanks to @fridtjof).
  * Notifications: When navigate to a room, remove associated delivered notifications (#2337).
+ * Key backup: Adjust wording for untrusted backup to match Riot Web.
 
 Bug fix:
  * Share extension: Fix a crash when receive a memory warning (PR #2352).

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -431,11 +431,11 @@
 "settings_key_backup_info" = "Encrypted messages are secured with end-to-end encryption. Only you and the recipient(s) have the keys to read these messages.";
 "settings_key_backup_info_checking" = "Checking...";
 "settings_key_backup_info_none" = "Your keys are not being backed up from this device.";
-"settings_key_backup_info_signout_warning" = "Back up your keys before signing out to avoid losing them.";
+"settings_key_backup_info_signout_warning" = "Connect this device to key backup before signing out to avoid losing any keys that may only be on this device.";
 "settings_key_backup_info_version" = "Key Backup Version: %@";
 "settings_key_backup_info_algorithm" = "Algorithm: %@";
 "settings_key_backup_info_valid" = "This device is backing up your keys.";
-"settings_key_backup_info_not_valid" = "This device is not backing up your keys.";
+"settings_key_backup_info_not_valid" = "This device is not backing up your keys, but you do have an existing backup you can restore from and add to going forward.";
 "settings_key_backup_info_progress" = "Backing up %@ keys...";
 "settings_key_backup_info_progress_done" = "All keys backed up";
 
@@ -449,7 +449,7 @@
 "settings_key_backup_button_create" = "Start using Key Backup";
 "settings_key_backup_button_restore" = "Restore from Backup";
 "settings_key_backup_button_delete" = "Delete Backup";
-"settings_key_backup_button_use" = "Use key backup";
+"settings_key_backup_button_connect" = "Connect this device to Key Backup";
 "settings_key_backup_delete_confirmation_prompt_title" = "Delete Backup";
 "settings_key_backup_delete_confirmation_prompt_msg" = "Are you sure? You will lose your encrypted messages if your keys are not backed up properly.";
 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -2006,6 +2006,10 @@ internal enum VectorL10n {
   internal static var settingsKeyBackup: String { 
     return VectorL10n.tr("Vector", "settings_key_backup") 
   }
+  /// Connect this device to Key Backup
+  internal static var settingsKeyBackupButtonConnect: String { 
+    return VectorL10n.tr("Vector", "settings_key_backup_button_connect") 
+  }
   /// Start using Key Backup
   internal static var settingsKeyBackupButtonCreate: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_button_create") 
@@ -2017,10 +2021,6 @@ internal enum VectorL10n {
   /// Restore from Backup
   internal static var settingsKeyBackupButtonRestore: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_button_restore") 
-  }
-  /// Use key backup
-  internal static var settingsKeyBackupButtonUse: String { 
-    return VectorL10n.tr("Vector", "settings_key_backup_button_use") 
   }
   /// Are you sure? You will lose your encrypted messages if your keys are not backed up properly.
   internal static var settingsKeyBackupDeleteConfirmationPromptMsg: String { 
@@ -2046,7 +2046,7 @@ internal enum VectorL10n {
   internal static var settingsKeyBackupInfoNone: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_info_none") 
   }
-  /// This device is not backing up your keys.
+  /// This device is not backing up your keys, but you do have an existing backup you can restore from and add to going forward.
   internal static var settingsKeyBackupInfoNotValid: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_info_not_valid") 
   }
@@ -2058,7 +2058,7 @@ internal enum VectorL10n {
   internal static var settingsKeyBackupInfoProgressDone: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_info_progress_done") 
   }
-  /// Back up your keys before signing out to avoid losing them.
+  /// Connect this device to key backup before signing out to avoid losing any keys that may only be on this device.
   internal static var settingsKeyBackupInfoSignoutWarning: String { 
     return VectorL10n.tr("Vector", "settings_key_backup_info_signout_warning") 
   }

--- a/Riot/Modules/Settings/KeyBackup/SettingsKeyBackupTableViewSection.swift
+++ b/Riot/Modules/Settings/KeyBackup/SettingsKeyBackupTableViewSection.swift
@@ -331,7 +331,7 @@ import UIKit
             cell = infoCell
 
         case 3:
-            cell = self.buttonCellForRestore(keyBackupVersion: keyBackupVersion, atRow: row, title: VectorL10n.settingsKeyBackupButtonUse)
+            cell = self.buttonCellForRestore(keyBackupVersion: keyBackupVersion, atRow: row, title: VectorL10n.settingsKeyBackupButtonConnect)
 
         case 4:
             cell = self.buttonCellForDelete(keyBackupVersion: keyBackupVersion, atRow: row)


### PR DESCRIPTION
This ports the wording changes from Riot Web
https://github.com/matrix-org/matrix-react-sdk/pull/2917.

"Use key backup" as button text feels like it's telling me I haven't set it up
at all. This changes to "Connect this device ..." which seems more reassuring
and applies for both the "add to backup" and "restore from backup" use cases.

This also updates the backup status text for the case where a backup exists, but
it's not being used by the current device so that it's much more clear that you
have a backup at least.

![Untitled](https://user-images.githubusercontent.com/279572/56361239-c22eed00-61de-11e9-8738-f60e16a4150a.png)

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] UI change has been tested on both light and dark themes
* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [x] Pull request includes screenshots or videos of UI changes
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
