### PR TITLE
 Reactions: Add placeholder for reactions list under message

### DIFF
--- a/Riot/Modules/Room/CellData/RoomBubbleCellData.m
+++ b/Riot/Modules/Room/CellData/RoomBubbleCellData.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2015 OpenMarket Ltd
+ Copyright 2019 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -210,11 +211,7 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
                 currentAttributedTextMsg = [[NSMutableAttributedString alloc] initWithAttributedString:componentString];
             }
 
-            if (self.readReceipts[component.event.eventId].count)
-            {
-                // Add vertical whitespace in case of read receipts
-                [currentAttributedTextMsg appendAttributedString:[RoomBubbleCellData readReceiptVerticalWhitespace]];
-            }
+            [self addverticalWhitespaceToString:currentAttributedTextMsg forEvent:component.event.eventId];
             
             // The first non empty component has been handled.
             break;
@@ -246,11 +243,7 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
             // Append attributed text
             [currentAttributedTextMsg appendAttributedString:componentString];
             
-            if (self.readReceipts[component.event.eventId].count)
-            {
-                // Add vertical whitespace in case of read receipts
-                [currentAttributedTextMsg appendAttributedString:[RoomBubbleCellData readReceiptVerticalWhitespace]];
-            }
+            [self addverticalWhitespaceToString:currentAttributedTextMsg forEvent:component.event.eventId];
         }
     }
     
@@ -344,13 +337,9 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
                         positionY = MXKROOMBUBBLECELLDATA_TEXTVIEW_DEFAULT_VERTICAL_INSET + (cumulatedHeight - [self rawTextHeight:componentString]);
                         
                         component.position = CGPointMake(0, positionY);
-                        
-                        // Add vertical whitespace in case of read receipts.
-                        if (self.readReceipts[component.event.eventId].count)
-                        {
-                            [attributedString appendAttributedString:[RoomBubbleCellData readReceiptVerticalWhitespace]];
-                        }
-                        
+
+                        [self addverticalWhitespaceToString:attributedString forEvent:component.event.eventId];
+
                         [attributedString appendAttributedString:[MXKRoomBubbleCellDataWithAppendingMode messageSeparator]];
                     }
                     else
@@ -360,6 +349,15 @@ static NSAttributedString *readReceiptVerticalWhitespace = nil;
                 }
             }
         }
+    }
+}
+
+- (void)addverticalWhitespaceToString:(NSMutableAttributedString *)attributedString forEvent:(NSString *)eventId
+{
+    // Add vertical whitespace in case of read receipts.
+    if (self.readReceipts[eventId].count)
+    {
+        [attributedString appendAttributedString:[RoomBubbleCellData readReceiptVerticalWhitespace]];
     }
 }
 


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-ios-kit/pull/549

Need to replace TODOs once the final view is done.

There is a bug where RRs and all reactions disappears. This happens when there is a reaction and RR on the last message of the timeline.
This bug existed already on the aggregations branch (where there was RR only).

<img width="344" alt="Screenshot 2019-05-17 at 01 27 53" src="https://user-images.githubusercontent.com/8418515/57906537-a3258880-787a-11e9-9c35-d43711ca9db9.png">

