### PR TITLE
Update build instructions to make use of Bundler

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,8 @@ Before opening the Riot Xcode workspace, you need to build it with the
 CocoaPods command::
 
         $ cd Riot
-        $ pod install
+        $ bundle install
+        $ bundle exec pod install
 
 This will load all dependencies for the Riot source code, including MatrixKit 
 and MatrixSDK.  You will need an recent and updated (``pod setup``) install of


### PR DESCRIPTION
Hi, thanks for sharing this great project. 

I found a minor issue while building the project. 

Even though the project contains a Gemfile listing the dependencies, the current build instructions do not really make use of it.

I am just updating the instructions so that Cocoapods is ran on the expected version defined by Gemfile.

### Pull Request Checklist

* [ ] UI change has been tested on both light and dark themes
* [x] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [ ] Pull request includes screenshots or videos of UI changes
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Signed-off-by: David Cordero <david@corderoramirez.com>