### PR TITLE
Reaction Menu: UX polish

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -5112,6 +5112,9 @@
         
         [self hideContextualMenuAnimated:YES cancelEventSelection:NO completion:nil];
         [self selectEventWithId:eventId inputToolBarSendMode:RoomInputToolbarViewSendModeReply showTimestamp:NO];
+
+        // And display the keyboard
+        [self.inputToolbarView becomeFirstResponder];
     };
     
     // Edit action
@@ -5121,6 +5124,9 @@
         MXStrongifyAndReturnIfNil(self);
         [self hideContextualMenuAnimated:YES cancelEventSelection:NO completion:nil];
         [self editEventContentWithId:eventId];
+
+        // And display the keyboard
+        [self.inputToolbarView becomeFirstResponder];
     };
     
     editMenuItem.isEnabled = [self.roomDataSource canEditEventWithId:eventId];

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -5270,6 +5270,8 @@
         
         [self.errorPresenter presentErrorFromViewController:self forError:error animated:YES handler:nil];
     }];
+
+    [self hideContextualMenuAnimated:YES];
 }
 
 - (void)reactionsMenuViewModel:(ReactionsMenuViewModel *)viewModel didRemoveReaction:(NSString *)reaction forEventId:(NSString *)eventId
@@ -5283,6 +5285,8 @@
         
         [self.errorPresenter presentErrorFromViewController:self forError:error animated:YES handler:nil];
     }];
+
+    [self hideContextualMenuAnimated:YES];
 }
 
 @end


### PR DESCRIPTION
2 changes in this PR

- Leave the menu once the user tapped a reaction
- Display the keyboard once the users tap on reply or edit