### PR TITLE
Make sure there are no ugly edge cases running Riot without an integrations manager

### DIFF
--- a/Riot.xcodeproj/project.pbxproj
+++ b/Riot.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		32242F1721E8FBE500725742 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32242F0D21E8FBA900725742 /* Theme.swift */; };
 		32242F1821E8FBF800725742 /* DefaultTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32242F0F21E8FBA900725742 /* DefaultTheme.swift */; };
 		32242F1921E8FBFB00725742 /* DarkTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32242F1021E8FBA900725742 /* DarkTheme.swift */; };
+		322C110822BBC6F80043FEAC /* WidgetManagerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322C110722BBC6F80043FEAC /* WidgetManagerConfig.swift */; };
 		3232AB1422564D9100AD6A5C /* swiftgen-config.yml in Resources */ = {isa = PBXBuildFile; fileRef = 3232AB0022564D9100AD6A5C /* swiftgen-config.yml */; };
 		3232AB1522564D9100AD6A5C /* flat-swift4-vector.stencil in Resources */ = {isa = PBXBuildFile; fileRef = 3232AB0322564D9100AD6A5C /* flat-swift4-vector.stencil */; };
 		3232AB2122564D9100AD6A5C /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 3232AB1322564D9100AD6A5C /* README.md */; };
@@ -548,6 +549,7 @@
 		32242F0F21E8FBA900725742 /* DefaultTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultTheme.swift; sourceTree = "<group>"; };
 		32242F1021E8FBA900725742 /* DarkTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DarkTheme.swift; sourceTree = "<group>"; };
 		32242F1121E8FBA900725742 /* ThemeService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThemeService.h; sourceTree = "<group>"; };
+		322C110722BBC6F80043FEAC /* WidgetManagerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetManagerConfig.swift; sourceTree = "<group>"; };
 		3232AB0022564D9100AD6A5C /* swiftgen-config.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "swiftgen-config.yml"; sourceTree = "<group>"; };
 		3232AB0322564D9100AD6A5C /* flat-swift4-vector.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "flat-swift4-vector.stencil"; sourceTree = "<group>"; };
 		3232AB1322564D9100AD6A5C /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -3042,6 +3044,7 @@
 				B1B5598420EFC3DF00210D55 /* WidgetManager.m */,
 				B1B5598120EFC3DF00210D55 /* Widget.h */,
 				B1B5598320EFC3DF00210D55 /* Widget.m */,
+				322C110722BBC6F80043FEAC /* WidgetManagerConfig.swift */,
 			);
 			path = Widgets;
 			sourceTree = "<group>";
@@ -3987,6 +3990,7 @@
 				B1B5593C20EF7BAC00210D55 /* TableViewCellWithCheckBoxes.m in Sources */,
 				32891D6B2264CBA300C82226 /* SimpleScreenTemplateViewController.swift in Sources */,
 				B1CA3A2721EF6914000D1D89 /* UIViewController.swift in Sources */,
+				322C110822BBC6F80043FEAC /* WidgetManagerConfig.swift in Sources */,
 				F0D2ADA11F6AA5FD00A7097D /* MXRoomSummary+Riot.m in Sources */,
 				B1B5596F20EFA85D00210D55 /* EncryptionInfoView.m in Sources */,
 				B1B5573820EE6C4D00210D55 /* GroupParticipantsViewController.m in Sources */,

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -635,6 +635,7 @@
 
 // Widget
 "widget_no_integrations_server_configured" = "No integrations server configured";
+"widget_integrations_server_failed_to_connect" = "Failed to connect to integrations server";
 "widget_no_power_to_manage" = "You need permission to manage widgets in this room";
 "widget_creation_failure" = "Widget creation has failed";
 "widget_sticker_picker_no_stickerpacks_alert" = "You don't currently have any stickerpacks enabled.";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -634,6 +634,7 @@
 "bug_report_send" = "Send";
 
 // Widget
+"widget_no_integrations_server_configured" = "No integrations server configured";
 "widget_no_power_to_manage" = "You need permission to manage widgets in this room";
 "widget_creation_failure" = "Widget creation has failed";
 "widget_sticker_picker_no_stickerpacks_alert" = "You don't currently have any stickerpacks enabled.";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -2834,6 +2834,10 @@ internal enum VectorL10n {
   internal static var widgetIntegrationUnableToCreate: String { 
     return VectorL10n.tr("Vector", "widget_integration_unable_to_create") 
   }
+  /// Failed to connect to integrations server
+  internal static var widgetIntegrationsServerFailedToConnect: String { 
+    return VectorL10n.tr("Vector", "widget_integrations_server_failed_to_connect") 
+  }
   /// No integrations server configured
   internal static var widgetNoIntegrationsServerConfigured: String { 
     return VectorL10n.tr("Vector", "widget_no_integrations_server_configured") 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -2834,6 +2834,10 @@ internal enum VectorL10n {
   internal static var widgetIntegrationUnableToCreate: String { 
     return VectorL10n.tr("Vector", "widget_integration_unable_to_create") 
   }
+  /// No integrations server configured
+  internal static var widgetNoIntegrationsServerConfigured: String { 
+    return VectorL10n.tr("Vector", "widget_no_integrations_server_configured") 
+  }
   /// You need permission to manage widgets in this room
   internal static var widgetNoPowerToManage: String { 
     return VectorL10n.tr("Vector", "widget_no_power_to_manage") 

--- a/Riot/Managers/Widgets/Widget.m
+++ b/Riot/Managers/Widgets/Widget.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2017 Vector Creations Ltd
+ Copyright 2019 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -100,7 +101,7 @@
                                                     _widgetId]];
 
     // Check if their scalar token must added
-    if ([WidgetManager isScalarUrl:widgetUrl])
+    if ([[WidgetManager sharedManager] isScalarUrl:widgetUrl forUser:userId])
     {
         return [[WidgetManager sharedManager] getScalarTokenForMXSession:_mxSession validate:NO success:^(NSString *scalarToken) {
             // Add the user scalar token

--- a/Riot/Managers/Widgets/WidgetManager.h
+++ b/Riot/Managers/Widgets/WidgetManager.h
@@ -55,7 +55,8 @@ typedef enum : NSUInteger
 {
     WidgetManagerErrorCodeNotEnoughPower,
     WidgetManagerErrorCodeCreationFailed,
-    WidgetManagerErrorCodeNoIntegrationsServerConfigured
+    WidgetManagerErrorCodeNoIntegrationsServerConfigured,
+    WidgetManagerErrorCodeFailedToConnectToIntegrationsServer
 }
 WidgetManagerErrorCode;
 

--- a/Riot/Managers/Widgets/WidgetManager.h
+++ b/Riot/Managers/Widgets/WidgetManager.h
@@ -54,7 +54,8 @@ FOUNDATION_EXPORT NSString *const WidgetManagerErrorDomain;
 typedef enum : NSUInteger
 {
     WidgetManagerErrorCodeNotEnoughPower,
-    WidgetManagerErrorCodeCreationFailed
+    WidgetManagerErrorCodeCreationFailed,
+    WidgetManagerErrorCodeNoIntegrationsServerConfigured
 }
 WidgetManagerErrorCode;
 

--- a/Riot/Managers/Widgets/WidgetManager.h
+++ b/Riot/Managers/Widgets/WidgetManager.h
@@ -1,5 +1,6 @@
 /*
  Copyright 2017 Vector Creations Ltd
+ Copyright 2019 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -19,6 +20,8 @@
 #import <MatrixSDK/MatrixSDK.h>
 
 #import "Widget.h"
+
+@class WidgetManagerConfig;
 
 /**
  The type of matrix event used for matrix widgets.
@@ -181,6 +184,30 @@ WidgetManagerErrorCode;
 #pragma mark - Modular interface
 
 /**
+ Get the integration manager configuration for a user.
+
+ @param userId the user id.
+ @return the integration manager configuration.
+ */
+- (WidgetManagerConfig*)configForUser:(NSString*)userId;
+
+/**
+ Store the integration manager configuration for a user.
+
+ @param the integration manager configuration.
+ @param userId the user id.
+ */
+- (void)setConfig:(WidgetManagerConfig*)config forUser:(NSString*)userId;
+
+/**
+ Check if the user has URLs for an integration manager configured.
+
+ @param userId the user id.
+ @return YES if they have URLs for an integration manager.
+ */
+- (BOOL)hasIntegrationManagerForUser:(NSString*)userId;
+
+/**
  Make sure there is a scalar token for the given Matrix session.
  
  If no token was gotten and stored before, the operation will make http requests
@@ -201,8 +228,9 @@ WidgetManagerErrorCode;
  Returns true if specified url is a scalar URL, typically https://scalar.vector.im/api
 
  @param urlString the URL to check.
+ @param userId the user id.
  @return YES if specified URL is a scalar URL.
  */
-+ (BOOL)isScalarUrl:(NSString*)urlString;
+- (BOOL)isScalarUrl:(NSString*)urlString forUser:(NSString*)userId;
 
 @end

--- a/Riot/Managers/Widgets/WidgetManager.m
+++ b/Riot/Managers/Widgets/WidgetManager.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2017 Vector Creations Ltd
+ Copyright 2019 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -15,6 +16,8 @@
  */
 
 #import "WidgetManager.h"
+
+#import "Riot-Swift.h"
 
 #import <MatrixKit/MatrixKit.h>
 
@@ -46,7 +49,7 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
         NSMutableDictionary<NSString*, void (^)(NSError *error)>*> *failureBlockForWidgetCreation;
 
     // User id -> scalar token
-    NSMutableDictionary<NSString*, NSString*> *scalarTokens;
+    NSMutableDictionary<NSString*, WidgetManagerConfig*> *configs;
 }
 
 @end
@@ -74,12 +77,7 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
         successBlockForWidgetCreation = [NSMutableDictionary dictionary];
         failureBlockForWidgetCreation = [NSMutableDictionary dictionary];
 
-        [self load];
-
-        if (!scalarTokens)
-        {
-            scalarTokens = [NSMutableDictionary dictionary];
-        }
+        [self loadConfigs];
     }
     return self;
 }
@@ -261,6 +259,15 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
                                      success:(void (^)(Widget *jitsiWidget))success
                                      failure:(void (^)(NSError *error))failure
 {
+    NSString *userId = room.mxSession.myUser.userId;
+    WidgetManagerConfig *config = [self configForUser:userId];
+    if (!config.hasUrls)
+    {
+        NSLog(@"[WidgetManager] createJitsiWidgetInRoom: Error: no Integrations Manager API URL for user %@", userId);
+        failure(nil);
+        return nil;
+    }
+
     // Build data for a jitsi widget
     NSString *widgetId = [NSString stringWithFormat:@"%@_%@_%@", kWidgetTypeJitsi, room.mxSession.myUser.userId, @((uint64_t)([[NSDate date] timeIntervalSince1970] * 1000))];
 
@@ -274,8 +281,7 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
     // TODO: This url should come from modular API
     // Note: this url can be used as is inside a web container (like iframe for Riot-web)
     // Riot-iOS does not directly use it but extracts params from it (see `[JitsiViewController openWidget:withVideo:]`)
-    NSString *modularRestUrl = [[NSUserDefaults standardUserDefaults] objectForKey:@"integrationsRestUrl"];
-    NSString *url = [NSString stringWithFormat:@"%@/widgets/jitsi.html?confId=%@&isAudioConf=%@&displayName=$matrix_display_name&avatarUrl=$matrix_avatar_url&email=$matrix_user_id@", modularRestUrl, confId, video ? @"false" : @"true"];
+    NSString *url = [NSString stringWithFormat:@"%@/widgets/jitsi.html?confId=%@&isAudioConf=%@&displayName=$matrix_display_name&avatarUrl=$matrix_avatar_url&email=$matrix_user_id@", config.apiUrl, confId, video ? @"false" : @"true"];
 
     return [self createWidget:widgetId
                   withContent:@{
@@ -435,11 +441,29 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
 
 - (void)deleteDataForUser:(NSString *)userId
 {
-    [scalarTokens removeObjectForKey:userId];
-    [self save];
+    [configs removeObjectForKey:userId];
+    [self saveConfigs];
 }
 
 #pragma mark - Modular interface
+
+- (WidgetManagerConfig*)configForUser:(NSString*)userId
+{
+    // Return a default config by default
+    return configs[userId] ? configs[userId] : [WidgetManagerConfig new];
+}
+
+- (BOOL)hasIntegrationManagerForUser:(NSString*)userId
+{
+    return [self configForUser:userId].hasUrls;
+}
+
+- (void)setConfig:(WidgetManagerConfig*)config forUser:(NSString*)userId
+{
+    configs[userId] = config;
+    [self saveConfigs];
+}
+
 
 - (MXHTTPOperation *)getScalarTokenForMXSession:(MXSession*)mxSession
                                        validate:(BOOL)validate
@@ -487,15 +511,22 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
                                     failure:(void (^)(NSError *error))failure
 {
     MXHTTPOperation *operation;
+    NSString *userId = mxSession.myUser.userId;
+
+    WidgetManagerConfig *config = [self configForUser:userId];
+    if (!config.hasUrls)
+    {
+        NSLog(@"[WidgetManager] registerForScalarToken: Error: no Integrations Manager API URL for user %@", mxSession.myUser.userId);
+        failure(nil);
+        return nil;
+    }
 
     MXWeakify(self);
     operation = [mxSession.matrixRestClient openIdToken:^(MXOpenIdToken *tokenObject) {
         MXStrongifyAndReturnIfNil(self);
 
         // Exchange the token for a scalar token
-        NSString *modularRestUrl = [[NSUserDefaults standardUserDefaults] objectForKey:@"integrationsRestUrl"];
-
-        MXHTTPClient *httpClient = [[MXHTTPClient alloc] initWithBaseURL:modularRestUrl andOnUnrecognizedCertificateBlock:nil];
+        MXHTTPClient *httpClient = [[MXHTTPClient alloc] initWithBaseURL:config.apiUrl andOnUnrecognizedCertificateBlock:nil];
 
         MXHTTPOperation *operation2 =
         [httpClient requestWithMethod:@"POST"
@@ -506,9 +537,10 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
 
              NSString *scalarToken;
              MXJSONModelSetString(scalarToken, JSONResponse[@"scalar_token"])
-             self->scalarTokens[mxSession.myUser.userId] = scalarToken;
+             config.scalarToken = scalarToken;
 
-             [self save];
+             self->configs[userId] = config;
+             [self saveConfigs];
 
              if (success)
              {
@@ -542,8 +574,17 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
                                 complete:(void (^)(BOOL valid))complete
                                  failure:(void (^)(NSError *error))failure
 {
-    NSString *modularRestUrl = [[NSUserDefaults standardUserDefaults] objectForKey:@"integrationsRestUrl"];
-    MXHTTPClient *httpClient = [[MXHTTPClient alloc] initWithBaseURL:modularRestUrl andOnUnrecognizedCertificateBlock:nil];
+    NSString *userId = mxSession.myUser.userId;
+
+    WidgetManagerConfig *config = [self configForUser:userId];
+    if (!config.hasUrls)
+    {
+        NSLog(@"[WidgetManager] validateScalarToken: Error: no Integrations Manager API URL for user %@", mxSession.myUser.userId);
+        failure(nil);
+        return nil;
+    }
+
+    MXHTTPClient *httpClient = [[MXHTTPClient alloc] initWithBaseURL:config.apiUrl andOnUnrecognizedCertificateBlock:nil];
 
     return [httpClient requestWithMethod:@"GET"
                                     path:[NSString stringWithFormat:@"account?v=1.1&scalar_token=%@", scalarToken]
@@ -579,14 +620,19 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
                                  }];
 }
 
-+ (BOOL)isScalarUrl:(NSString *)urlString
+- (BOOL)isScalarUrl:(NSString *)urlString forUser:(NSString*)userId
 {
     BOOL isScalarUrl = NO;
 
+    // TODO: Do we need to add `integrationsWidgetsUrls` to `WidgetManagerConfig`?
     NSArray<NSString*> *scalarUrlStrings = [[NSUserDefaults standardUserDefaults] objectForKey:@"integrationsWidgetsUrls"];
     if (scalarUrlStrings.count == 0)
     {
-        scalarUrlStrings = @[[[NSUserDefaults standardUserDefaults] objectForKey:@"integrationsRestUrl"]];
+        NSString *apiUrl = [self configForUser:userId].apiUrl;
+        if (apiUrl)
+        {
+            scalarUrlStrings = @[apiUrl];
+        }
     }
 
     for (NSString *scalarUrlString in scalarUrlStrings)
@@ -605,20 +651,53 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
 
 - (NSString *)scalarTokenForMXSession:(MXSession *)mxSession
 {
-    return scalarTokens[mxSession.myUser.userId];
+    return configs[mxSession.myUser.userId].scalarToken;
 }
 
-- (void)load
-{
-    NSUserDefaults *userDefaults = [MXKAppSettings standardAppSettings].sharedUserDefaults;
-    scalarTokens = [NSMutableDictionary dictionaryWithDictionary:[userDefaults objectForKey:@"scalarTokens"]];
-}
-
-- (void)save
+- (void)loadConfigs
 {
     NSUserDefaults *userDefaults = [MXKAppSettings standardAppSettings].sharedUserDefaults;
 
-    [userDefaults setObject:scalarTokens forKey:@"scalarTokens"];
+    NSDictionary<NSString*, NSString*> *scalarTokens = [userDefaults objectForKey:@"scalarTokens"];
+    if (scalarTokens)
+    {
+        // Manage migration to WidgetManagerConfig
+        configs = [NSMutableDictionary dictionary];
+        for (NSString *userId in scalarTokens)
+        {
+            NSString *scalarToken = scalarTokens[userId];
+
+            NSLog(@"[WidgetManager] migrate scalarTokens to integrationManagerConfigs for %@", userId);
+
+            WidgetManagerConfig *config = [WidgetManagerConfig new];
+            config.scalarToken = scalarToken;
+
+            configs[userId] = config;
+        }
+
+        [self saveConfigs];
+        [userDefaults removeObjectForKey:@"scalarTokens"];
+    }
+    else
+    {
+        NSData *configsData = [userDefaults objectForKey:@"integrationManagerConfigs"];
+        if (configsData)
+        {
+            configs = [NSMutableDictionary dictionaryWithDictionary:[NSKeyedUnarchiver unarchiveObjectWithData:configsData]];
+        }
+
+        if (!configs)
+        {
+            configs = [NSMutableDictionary dictionary];
+        }
+    }
+}
+
+- (void)saveConfigs
+{
+    NSUserDefaults *userDefaults = [MXKAppSettings standardAppSettings].sharedUserDefaults;
+    [userDefaults setObject:[NSKeyedArchiver archivedDataWithRootObject:configs]
+                     forKey:@"integrationManagerConfigs"];
 }
 
 @end

--- a/Riot/Managers/Widgets/WidgetManager.m
+++ b/Riot/Managers/Widgets/WidgetManager.m
@@ -548,10 +548,17 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
              }
 
          } failure:^(NSError *error) {
-             NSLog(@"[WidgetManager] registerForScalarToken. Error in modular/register request");
+             NSLog(@"[WidgetManager] registerForScalarToken: Failed to register. Error: %@", error);
 
              if (failure)
              {
+                 // Specialise the error
+                 NSError *error = [NSError errorWithDomain:WidgetManagerErrorDomain
+                                                      code:WidgetManagerErrorCodeFailedToConnectToIntegrationsServer
+                                                  userInfo:@{
+                                                             NSLocalizedDescriptionKey: NSLocalizedStringFromTable(@"widget_integrations_server_failed_to_connect", @"Vector", nil)
+                                                             }];
+
                  failure(error);
              }
          }];

--- a/Riot/Managers/Widgets/WidgetManager.m
+++ b/Riot/Managers/Widgets/WidgetManager.m
@@ -264,7 +264,7 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
     if (!config.hasUrls)
     {
         NSLog(@"[WidgetManager] createJitsiWidgetInRoom: Error: no Integrations Manager API URL for user %@", userId);
-        failure(nil);
+        failure(self.errorForNonConfiguredIntegrationManager);
         return nil;
     }
 
@@ -517,7 +517,7 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
     if (!config.hasUrls)
     {
         NSLog(@"[WidgetManager] registerForScalarToken: Error: no Integrations Manager API URL for user %@", mxSession.myUser.userId);
-        failure(nil);
+        failure(self.errorForNonConfiguredIntegrationManager);
         return nil;
     }
 
@@ -580,7 +580,7 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
     if (!config.hasUrls)
     {
         NSLog(@"[WidgetManager] validateScalarToken: Error: no Integrations Manager API URL for user %@", mxSession.myUser.userId);
-        failure(nil);
+        failure(self.errorForNonConfiguredIntegrationManager);
         return nil;
     }
 
@@ -698,6 +698,16 @@ NSString *const WidgetManagerErrorDomain = @"WidgetManagerErrorDomain";
     NSUserDefaults *userDefaults = [MXKAppSettings standardAppSettings].sharedUserDefaults;
     [userDefaults setObject:[NSKeyedArchiver archivedDataWithRootObject:configs]
                      forKey:@"integrationManagerConfigs"];
+}
+
+
+#pragma mark - Errors
+
+- (NSError*)errorForNonConfiguredIntegrationManager
+{
+    return [NSError errorWithDomain:WidgetManagerErrorDomain
+                               code:WidgetManagerErrorCodeNoIntegrationsServerConfigured
+                           userInfo:@{NSLocalizedDescriptionKey: NSLocalizedStringFromTable(@"widget_no_integrations_server_configured", @"Vector", nil)}];
 }
 
 @end

--- a/Riot/Managers/Widgets/WidgetManagerConfig.swift
+++ b/Riot/Managers/Widgets/WidgetManagerConfig.swift
@@ -1,0 +1,77 @@
+/*
+ Copyright 2019 New Vector Ltd
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+/// Configuration for an integration manager.
+/// By default, it uses URLs defined in the app settings but they can be overidden.
+@objcMembers
+class WidgetManagerConfig: NSObject, NSCoding {
+
+    /// The URL for the REST api
+    let apiUrl: NSString?
+    /// The URL of the integration manager interface
+    let uiUrl: NSString?
+    /// The token if the user has been authenticated
+    var scalarToken: NSString?
+
+    var hasUrls: Bool {
+        if apiUrl != nil && uiUrl != nil {
+            return true
+        } else {
+            return false
+        }
+    }
+
+    init(apiUrl: NSString?, uiUrl: NSString?) {
+        self.apiUrl = apiUrl
+        self.uiUrl = uiUrl
+
+        super.init()
+    }
+
+    override convenience init () {
+        // Use app settings as default
+        let apiUrl = UserDefaults.standard.object(forKey: "integrationsRestUrl") as? NSString
+        let uiUrl = UserDefaults.standard.object(forKey: "integrationsUiUrl") as? NSString
+
+        self.init(apiUrl: apiUrl, uiUrl: uiUrl)
+    }
+
+
+    /// MARK: - NSCoding
+
+    enum CodingKeys: String {
+        case apiUrl = "apiUrl"
+        case uiUrl = "uiUrl"
+        case scalarToken = "scalarToken"
+    }
+
+    func encode(with aCoder: NSCoder) {
+        aCoder.encode(self.apiUrl, forKey: CodingKeys.apiUrl.rawValue)
+        aCoder.encode(self.uiUrl, forKey: CodingKeys.uiUrl.rawValue)
+        aCoder.encode(self.scalarToken, forKey: CodingKeys.scalarToken.rawValue)
+    }
+
+    convenience required init?(coder aDecoder: NSCoder) {
+        let apiUrl = aDecoder.decodeObject(forKey: CodingKeys.apiUrl.rawValue) as? NSString
+        let uiUrl = aDecoder.decodeObject(forKey: CodingKeys.uiUrl.rawValue) as? NSString
+        let scalarToken = aDecoder.decodeObject(forKey: CodingKeys.scalarToken.rawValue) as? NSString
+
+        self.init(apiUrl: apiUrl, uiUrl: uiUrl)
+        self.scalarToken = scalarToken
+    }
+}

--- a/Riot/Modules/Integrations/IntegrationManagerViewController.m
+++ b/Riot/Modules/Integrations/IntegrationManagerViewController.m
@@ -18,6 +18,8 @@
 #import "IntegrationManagerViewController.h"
 
 #import "WidgetManager.h"
+
+#import "AppDelegate.h"
 #import "Riot-Swift.h"
 
 NSString *const kIntegrationManagerMainScreen = nil;
@@ -87,8 +89,14 @@ NSString *const kIntegrationManagerAddIntegrationScreen = @"add_integ";
         } failure:^(NSError *error) {
             MXStrongifyAndReturnIfNil(self);
 
+            NSLog(@"[IntegraionManagerVS] Cannot open due to missing scalar token. Error: %@", error);
+
             self->operation = nil;
             [self stopActivityIndicator];
+
+            [self withdrawViewControllerAnimated:YES completion:^{
+                [[AppDelegate theDelegate] showErrorAsAlert:error];
+            }];
         }];
     }
 }

--- a/Riot/Modules/Integrations/IntegrationManagerViewController.m
+++ b/Riot/Modules/Integrations/IntegrationManagerViewController.m
@@ -1,5 +1,6 @@
 /*
  Copyright 2017 Vector Creations Ltd
+ Copyright 2019 New Vector Ltd
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -17,6 +18,7 @@
 #import "IntegrationManagerViewController.h"
 
 #import "WidgetManager.h"
+#import "Riot-Swift.h"
 
 NSString *const kIntegrationManagerMainScreen = nil;
 NSString *const kIntegrationManagerAddIntegrationScreen = @"add_integ";
@@ -100,10 +102,12 @@ NSString *const kIntegrationManagerAddIntegrationScreen = @"add_integ";
 {
     NSMutableString *url;
 
+    NSString *integrationsUiUrl = [[WidgetManager sharedManager] configForUser:mxSession.myUser.userId].uiUrl;
+
     if (scalarToken)
     {
         url = [NSMutableString stringWithFormat:@"%@?scalar_token=%@&room_id=%@",
-               [[NSUserDefaults standardUserDefaults] objectForKey:@"integrationsUiUrl"],
+               integrationsUiUrl,
                [MXTools encodeURIComponent:scalarToken],
                [MXTools encodeURIComponent:roomId]
                ];

--- a/Riot/Modules/Integrations/Widgets/WidgetViewController.m
+++ b/Riot/Modules/Integrations/Widgets/WidgetViewController.m
@@ -190,7 +190,7 @@ NSString *const kJavascriptSendResponseToPostMessageAPI = @"riotIOS.sendResponse
             NSLog(@"[WidgetVC] decidePolicyForNavigationResponse: statusCode: %@", @(response.statusCode));
         }
 
-        if (response.statusCode == 403 && [WidgetManager isScalarUrl:self.URL])
+        if (response.statusCode == 403 && [[WidgetManager sharedManager] isScalarUrl:self.URL forUser:self.widget.mxSession.myUser.userId])
         {
             [self fixScalarToken];
         }


### PR DESCRIPTION
Closes #2518 .

This PR displays errors instead of trying to hide things.

3 things in the PR:
- Make code support use of an integration manager other than modular/scalar. (It supports multi-account)
- Display a specific error in case of unset IM server
![Simulator Screen Shot - iPhone 7 - 2019-06-21 at 15 48 47](https://user-images.githubusercontent.com/8418515/59927150-1bfc9f00-943c-11e9-9a0d-16ca47987796.png)
- Display a specific error in case of connection issue with the IM server
![Simulator Screen Shot - iPhone 7 - 2019-06-21 at 15 01 20](https://user-images.githubusercontent.com/8418515/59926829-6f222200-943b-11e9-92fa-87a93a4269bc.png)

