### PR TITLE
Edits: Support edits in e2e rooms

### DIFF
--- a/Riot/Modules/Room/Views/BubbleCells/Encryption/RoomEncryptedDataBubbleCell.m
+++ b/Riot/Modules/Room/Views/BubbleCells/Encryption/RoomEncryptedDataBubbleCell.m
@@ -29,7 +29,8 @@ NSString *const kRoomEncryptedDataBubbleCellTapOnEncryptionIcon = @"kRoomEncrypt
     {
         encryptionIcon = @"e2e_unencrypted";
         
-        if (event.isLocalEvent)
+        if (event.isLocalEvent
+            || event.contentHasBeenEdited)    // Local echo for an edit is clear but uses a true event id, the one of the edited event 
         {
             // Patch: Display the verified icon by default on pending outgoing messages in the encrypted rooms when the encryption is enabled
             MXRoom *room = [session roomWithRoomId:event.roomId];


### PR DESCRIPTION
Fixes vector-im/riot-ios#2449

Requires https://github.com/matrix-org/matrix-ios-kit/pull/571 & https://github.com/matrix-org/matrix-ios-sdk/pull/679

This is compatible with the current implementation in Riot-Web but this code may change with the update of MSC1849.
Note that synapse does not support aggregation in e2e rooms yet. That means the app may not display edited content when opening a permalink.
