### PR TITLE
BF: Edits: editing an unsent msg gets cancelled if the original msg s…

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -287,6 +287,7 @@
     
     // Listen to the event sent state changes
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(eventDidChangeSentState:) name:kMXEventDidChangeSentStateNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(eventDidChangeIdentifier:) name:kMXEventDidChangeIdentifierNotification object:nil];
 }
 
 - (void)viewDidLoad
@@ -1221,6 +1222,7 @@
     missedDiscussionsBadgeLabel = nil;
     
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXEventDidChangeSentStateNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXEventDidChangeIdentifierNotification object:nil];
     
     [super destroy];
 }
@@ -4561,6 +4563,18 @@
         
         [currentAlert mxk_setAccessibilityIdentifier:@"RoomVCUnknownDevicesAlert"];
         [self presentViewController:currentAlert animated:YES completion:nil];
+    }
+}
+
+- (void)eventDidChangeIdentifier:(NSNotification *)notif
+{
+    MXEvent *event = notif.object;
+    NSString *previousId = notif.userInfo[kMXEventIdentifierKey];
+
+    if ([customizedRoomDataSource.selectedEventId isEqualToString:previousId])
+    {
+        NSLog(@"[RoomVC] eventDidChangeIdentifier: Update selectedEventId");
+        customizedRoomDataSource.selectedEventId = event.eventId;
     }
 }
 


### PR DESCRIPTION
…end completes during the edit

When the send completes, the id of the event changes from a local event id to the final event id. We need to track this change for the selected event.

Fixes #2495.
