### PR TITLE
BF: Edits history: Original event is missing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Changes in 0.9.1 (2019-07-)
+===============================================
+
+Improvements:
+
+Bug fix:
+ * Edits history: Original event is missing (#2585).
+
 Changes in 0.9.0 (2019-07-16)
 ===============================================
 


### PR DESCRIPTION
Close #2585

The original event is not an edit event. It must be processed a bit differently.