### PR TITLE
Support soft logout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+Changes in 0.9.2 (2019-07-)
+===============================================
+
+Improvements:
+ * Upgrade MatrixKit version ([v0.10.2](https://github.com/matrix-org/matrix-ios-kit/releases/tag/v0.10.2)).
+ * Soft logout: Support soft logout (#2540).
+
 Changes in 0.9.1 (2019-07-17)
 ===============================================
 

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -2770,7 +2770,10 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
         
         // Remove inApp notifications toggle change
         MXKAccount *account = notif.object;
-        [account removeObserver:self forKeyPath:@"enableInAppNotifications"];
+        if (!account.isSoftLogout)
+        {
+            [account removeObserver:self forKeyPath:@"enableInAppNotifications"];
+        }
 
         // Clear Modular data
         [[WidgetManager sharedManager] deleteDataForUser:account.mxCredentials.userId];

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -2781,6 +2781,16 @@ NSString *const kAppDelegateNetworkStatusDidChangeNotification = @"kAppDelegateN
             [self logoutWithConfirmation:NO completion:nil];
         }
     }];
+
+    // Add observer to handle soft logout
+    [[NSNotificationCenter defaultCenter] addObserverForName:kMXKAccountManagerDidSoftlogoutAccountNotification  object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+
+        MXKAccount *account = notif.object;
+        [self removeMatrixSession:account.mxSession];
+
+        // Return to authentication screen
+        [self.masterTabBarController showAuthenticationScreenAfterSoftLogout:account.mxCredentials];
+    }];
     
     [[NSNotificationCenter defaultCenter] addObserverForName:kMXSessionIgnoredUsersDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull notif) {
         

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -123,6 +123,10 @@
 "auth_softlogout_clear_data_message_1" = "Warning: Your personal data (including encryption keys) is still stored on this device.";
 "auth_softlogout_clear_data_message_2" = "Clear it if you're finished using this device, or want to sign in to another account.";
 "auth_softlogout_clear_data_button" = "Clear all data";
+"auth_softlogout_clear_data_sign_out_title" = "Are you sure?";
+"auth_softlogout_clear_data_sign_out_msg" = "Are you sure you want to clear all data currently stored on this device? Sign in again to access your account data and messages.";
+"auth_softlogout_clear_data_sign_out" = "Sign out";
+
 
 // Chat creation
 "room_creation_title" = "New Chat";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -115,6 +115,10 @@
 "auth_add_email_and_phone_warning" = "Registration with email and phone number at once is not supported yet until the api exists. Only the phone number will be taken into account. You may add your email to your profile in settings.";
 "auth_accept_policies" = "Please review and accept the policies of this homeserver:";
 "auth_autodiscover_invalid_response" = "Invalid homeserver discovery response";
+"auth_softlogout_signed_out" = "You’re signed out";
+"auth_softlogout_sign_in" = "Sign In";
+"auth_softlogout_reason" = "Your homeserver (%1$@) admin has signed you out of your account %2$@ (%3$@).";
+"auth_softlogout_recover_encryption_keys" = "Sign in to recover encryption keys stored exclusively on this device. You need them to read all of your secure messages on any device.";
 
 // Chat creation
 "room_creation_title" = "New Chat";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -119,6 +119,10 @@
 "auth_softlogout_sign_in" = "Sign In";
 "auth_softlogout_reason" = "Your homeserver (%1$@) admin has signed you out of your account %2$@ (%3$@).";
 "auth_softlogout_recover_encryption_keys" = "Sign in to recover encryption keys stored exclusively on this device. You need them to read all of your secure messages on any device.";
+"auth_softlogout_clear_data" = "Clear personal data";
+"auth_softlogout_clear_data_message_1" = "Warning: Your personal data (including encryption keys) is still stored on this device.";
+"auth_softlogout_clear_data_message_2" = "Clear it if you're finished using this device, or want to sign in to another account.";
+"auth_softlogout_clear_data_button" = "Clear all data";
 
 // Chat creation
 "room_creation_title" = "New Chat";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -242,6 +242,18 @@ internal enum VectorL10n {
   internal static var authSoftlogoutClearDataMessage2: String { 
     return VectorL10n.tr("Vector", "auth_softlogout_clear_data_message_2") 
   }
+  /// Sign out
+  internal static var authSoftlogoutClearDataSignOut: String { 
+    return VectorL10n.tr("Vector", "auth_softlogout_clear_data_sign_out") 
+  }
+  /// Are you sure you want to clear all data currently stored on this device? Sign in again to access your account data and messages.
+  internal static var authSoftlogoutClearDataSignOutMsg: String { 
+    return VectorL10n.tr("Vector", "auth_softlogout_clear_data_sign_out_msg") 
+  }
+  /// Are you sure?
+  internal static var authSoftlogoutClearDataSignOutTitle: String { 
+    return VectorL10n.tr("Vector", "auth_softlogout_clear_data_sign_out_title") 
+  }
   /// Your homeserver (%1$@) admin has signed you out of your account %2$@ (%3$@).
   internal static func authSoftlogoutReason(_ p1: String, _ p2: String, _ p3: String) -> String {
     return VectorL10n.tr("Vector", "auth_softlogout_reason", p1, p2, p3)

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -226,6 +226,22 @@ internal enum VectorL10n {
   internal static var authSkip: String { 
     return VectorL10n.tr("Vector", "auth_skip") 
   }
+  /// Your homeserver (%1$@) admin has signed you out of your account %2$@ (%3$@).
+  internal static func authSoftlogoutReason(_ p1: String, _ p2: String, _ p3: String) -> String {
+    return VectorL10n.tr("Vector", "auth_softlogout_reason", p1, p2, p3)
+  }
+  /// Sign in to recover encryption keys stored exclusively on this device. You need them to read all of your secure messages on any device.
+  internal static var authSoftlogoutRecoverEncryptionKeys: String { 
+    return VectorL10n.tr("Vector", "auth_softlogout_recover_encryption_keys") 
+  }
+  /// Sign In
+  internal static var authSoftlogoutSignIn: String { 
+    return VectorL10n.tr("Vector", "auth_softlogout_sign_in") 
+  }
+  /// You’re signed out
+  internal static var authSoftlogoutSignedOut: String { 
+    return VectorL10n.tr("Vector", "auth_softlogout_signed_out") 
+  }
   /// Submit
   internal static var authSubmit: String { 
     return VectorL10n.tr("Vector", "auth_submit") 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -226,6 +226,22 @@ internal enum VectorL10n {
   internal static var authSkip: String { 
     return VectorL10n.tr("Vector", "auth_skip") 
   }
+  /// Clear personal data
+  internal static var authSoftlogoutClearData: String { 
+    return VectorL10n.tr("Vector", "auth_softlogout_clear_data") 
+  }
+  /// Clear all data
+  internal static var authSoftlogoutClearDataButton: String { 
+    return VectorL10n.tr("Vector", "auth_softlogout_clear_data_button") 
+  }
+  /// Warning: Your personal data (including encryption keys) is still stored on this device.
+  internal static var authSoftlogoutClearDataMessage1: String { 
+    return VectorL10n.tr("Vector", "auth_softlogout_clear_data_message_1") 
+  }
+  /// Clear it if you're finished using this device, or want to sign in to another account.
+  internal static var authSoftlogoutClearDataMessage2: String { 
+    return VectorL10n.tr("Vector", "auth_softlogout_clear_data_message_2") 
+  }
   /// Your homeserver (%1$@) admin has signed you out of your account %2$@ (%3$@).
   internal static func authSoftlogoutReason(_ p1: String, _ p2: String, _ p3: String) -> String {
     return VectorL10n.tr("Vector", "auth_softlogout_reason", p1, p2, p3)

--- a/Riot/Modules/Authentication/AuthenticationViewController.h
+++ b/Riot/Modules/Authentication/AuthenticationViewController.h
@@ -41,5 +41,9 @@
 @property (weak, nonatomic) IBOutlet UIView *homeServerSeparator;
 @property (weak, nonatomic) IBOutlet UIView *identityServerSeparator;
 
+@property (weak, nonatomic) IBOutlet UIView *softLogoutClearDataContainer;
+@property (weak, nonatomic) IBOutlet UILabel *softLogoutClearDataLabel;
+@property (weak, nonatomic) IBOutlet UIButton *softLogoutClearDataButton;
+
 @end
 

--- a/Riot/Modules/Authentication/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/AuthenticationViewController.m
@@ -300,6 +300,7 @@
     }
     
     [self updateForgotPwdButtonVisibility];
+    [self updateSoftLogoutClearDataContainerVisibility];
 }
 
 - (void)setAuthInputsView:(MXKAuthInputsView *)authInputsView
@@ -416,10 +417,10 @@
     self.rightBarButtonItem.title = nil;
     self.mainNavigationItem.title = NSLocalizedStringFromTable(@"auth_softlogout_signed_out", @"Vector", nil);
 
-    [self showLogoutClearDataContainer];
+    [self showSoftLogoutClearDataContainer];
 }
 
-- (void)showLogoutClearDataContainer
+- (void)showSoftLogoutClearDataContainer
 {
     NSMutableAttributedString *message = [[NSMutableAttributedString alloc] initWithString:NSLocalizedStringFromTable(@"auth_softlogout_clear_data", @"Vector", nil)
                                                                                 attributes:@{
@@ -440,6 +441,19 @@
 
     self.softLogoutClearDataContainer.hidden = NO;
     [self refreshContentViewHeightConstraint];
+}
+
+- (void)updateSoftLogoutClearDataContainerVisibility
+{
+    // Do not display it in case of forget password flow
+    if (self.softLogoutCredentials && self.authType == MXKAuthenticationTypeLogin)
+    {
+        self.softLogoutClearDataContainer.hidden = NO;
+    }
+    else
+    {
+        self.softLogoutClearDataContainer.hidden = YES;
+    }
 }
 
 - (void)showClearDataAfterSoftLogoutConfirmation
@@ -490,6 +504,7 @@
 
     // Hide "Forgot password" and "Log in" buttons in case of SSO
     [self updateForgotPwdButtonVisibility];
+    [self updateSoftLogoutClearDataContainerVisibility];
 
     AuthInputsView *authInputsview;
     if ([self.authInputsView isKindOfClass:AuthInputsView.class])
@@ -626,6 +641,8 @@
     {
         [super onButtonPressed:sender];
     }
+
+    [self updateSoftLogoutClearDataContainerVisibility];
 }
 
 - (void)onFailureDuringAuthRequest:(NSError *)error

--- a/Riot/Modules/Authentication/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/AuthenticationViewController.m
@@ -1,7 +1,8 @@
 /*
  Copyright 2015 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
- 
+ Copyright 2019 New Vector Ltd
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -366,7 +367,7 @@
         // The right bar button is used to switch the authentication type.
         if (self.authType == MXKAuthenticationTypeLogin)
         {
-            if (!authInputsview.isSingleSignOnRequired)
+            if (!authInputsview.isSingleSignOnRequired && !self.softLogoutCredentials)
             {
                 self.rightBarButtonItem.title = NSLocalizedStringFromTable(@"auth_register", @"Vector", nil);
             }
@@ -400,8 +401,11 @@
     [super setSoftLogoutCredentials:softLogoutCredentials];
 
     // Customise the screen for soft logout
-    // TODO
     self.customServersTickButton.hidden = YES;
+    self.rightBarButtonItem.title = nil;
+    self.mainNavigationItem.title = NSLocalizedStringFromTable(@"auth_softlogout_signed_out", @"Vector", nil);
+
+    // TODO: Clear all data button
 }
 
 

--- a/Riot/Modules/Authentication/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/AuthenticationViewController.m
@@ -395,6 +395,16 @@
     }
 }
 
+- (void)setSoftLogoutCredentials:(MXCredentials *)softLogoutCredentials
+{
+    [super setSoftLogoutCredentials:softLogoutCredentials];
+
+    // Customise the screen for soft logout
+    // TODO
+    self.customServersTickButton.hidden = YES;
+}
+
+
 - (void)handleAuthenticationSession:(MXAuthenticationSession *)authSession
 {
     [super handleAuthenticationSession:authSession];

--- a/Riot/Modules/Authentication/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/AuthenticationViewController.m
@@ -108,6 +108,14 @@
     [self.customServersTickButton setImage:[UIImage imageNamed:@"selection_untick"] forState:UIControlStateHighlighted];
     
     [self hideCustomServers:YES];
+
+    // Soft logout section
+    self.softLogoutClearDataButton.layer.cornerRadius = 5;
+    self.softLogoutClearDataButton.clipsToBounds = YES;
+    [self.softLogoutClearDataButton setTitle:NSLocalizedStringFromTable(@"auth_softlogout_clear_data_button", @"Vector", nil) forState:UIControlStateNormal];
+    [self.softLogoutClearDataButton setTitle:NSLocalizedStringFromTable(@"auth_softlogout_clear_data_button", @"Vector", nil) forState:UIControlStateHighlighted];
+    self.softLogoutClearDataButton.enabled = YES;
+    self.softLogoutClearDataContainer.hidden = YES;
     
     // The view controller dismiss itself on successful login.
     self.delegate = self;
@@ -195,7 +203,10 @@
     self.identityServerLabel.textColor = ThemeService.shared.theme.textSecondaryColor;
 
     self.activityIndicator.backgroundColor = ThemeService.shared.theme.overlayBackgroundColor;
-    
+
+    self.softLogoutClearDataLabel.textColor = ThemeService.shared.theme.textPrimaryColor;
+    self.softLogoutClearDataButton.backgroundColor = ThemeService.shared.theme.warningColor;
+
     [self.authInputsView customizeViewRendering];
     
     [self setNeedsStatusBarAppearanceUpdate];
@@ -405,7 +416,30 @@
     self.rightBarButtonItem.title = nil;
     self.mainNavigationItem.title = NSLocalizedStringFromTable(@"auth_softlogout_signed_out", @"Vector", nil);
 
-    // TODO: Clear all data button
+    [self showLogoutClearDataContainer];
+}
+
+- (void)showLogoutClearDataContainer
+{
+    NSMutableAttributedString *message = [[NSMutableAttributedString alloc] initWithString:NSLocalizedStringFromTable(@"auth_softlogout_clear_data", @"Vector", nil)
+                                                                                attributes:@{
+                                                                                             NSFontAttributeName: [UIFont boldSystemFontOfSize:14]
+                                                                                             }];
+
+    [message appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n\n"]];
+
+    NSString *string = [NSString stringWithFormat:@"%@\n\n%@",
+                        NSLocalizedStringFromTable(@"auth_softlogout_clear_data_message_1", @"Vector", nil),
+                        NSLocalizedStringFromTable(@"auth_softlogout_clear_data_message_2", @"Vector", nil)];
+    
+    [message appendAttributedString:[[NSAttributedString alloc] initWithString:string
+                                                                    attributes:@{
+                                                                                 NSFontAttributeName: [UIFont systemFontOfSize:14]
+                                                                                 }]];
+    self.softLogoutClearDataLabel.attributedText = message;
+
+    self.softLogoutClearDataContainer.hidden = NO;
+    [self refreshContentViewHeightConstraint];
 }
 
 
@@ -724,7 +758,13 @@
             }
         }
     }
-    
+
+    if (!self.softLogoutClearDataContainer.isHidden)
+    {
+        // The soft logout clear data section adds more height
+        constant += self.softLogoutClearDataContainer.frame.size.height;
+    }
+
     self.contentViewHeightConstraint.constant = constant;
 }
 

--- a/Riot/Modules/Authentication/AuthenticationViewController.m
+++ b/Riot/Modules/Authentication/AuthenticationViewController.m
@@ -633,7 +633,7 @@
     // Homeserver migration: When the default homeserver url is different from matrix.org,
     // the login (or forgot pwd) process with an existing matrix.org accounts will then fail.
     // Patch: Falling back to matrix.org HS so we don't break everyone's logins
-    if ([self.homeServerTextField.text isEqualToString:self.defaultHomeServerUrl] && ![self.defaultHomeServerUrl isEqualToString:@"https://matrix.org"])
+    if ([self.homeServerTextField.text isEqualToString:self.defaultHomeServerUrl] && ![self.defaultHomeServerUrl isEqualToString:@"https://matrix.org"] && !self.softLogoutCredentials)
     {
         MXError *mxError = [[MXError alloc] initWithNSError:error];
         

--- a/Riot/Modules/Authentication/AuthenticationViewController.xib
+++ b/Riot/Modules/Authentication/AuthenticationViewController.xib
@@ -378,6 +378,9 @@ Clear it if you're finished using this device, or want to sign in to another acc
                                                     <state key="normal" title="Clear all data">
                                                         <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </state>
+                                                    <connections>
+                                                        <action selector="onButtonPressed:" destination="-1" eventType="touchUpInside" id="c0b-DK-MIg"/>
+                                                    </connections>
                                                 </button>
                                             </subviews>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Riot/Modules/Authentication/AuthenticationViewController.xib
+++ b/Riot/Modules/Authentication/AuthenticationViewController.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -42,6 +42,9 @@
                 <outlet property="rightBarButtonItem" destination="Kwt-KN-aVL" id="Y3F-wA-tf8"/>
                 <outlet property="serverOptionsContainer" destination="FIn-2w-e6H" id="Z0e-NN-3LY"/>
                 <outlet property="skipButton" destination="wEJ-AF-rdH" id="smu-MS-2IY"/>
+                <outlet property="softLogoutClearDataButton" destination="ZRO-C2-hH1" id="PDa-aM-Hso"/>
+                <outlet property="softLogoutClearDataContainer" destination="vX2-5Y-rQc" id="mgK-41-cnX"/>
+                <outlet property="softLogoutClearDataLabel" destination="QYL-Lo-tmH" id="ks9-5X-xfs"/>
                 <outlet property="submitButton" destination="k3J-Eg-itz" id="fiZ-wK-6YM"/>
                 <outlet property="submitButtonMinLeadingConstraint" destination="bEB-EO-b14" id="Iz5-ks-nSX"/>
                 <outlet property="view" destination="5rn-KE-plm" id="bFJ-yJ-vc0"/>
@@ -345,17 +348,63 @@
                                                 <constraint firstAttribute="trailing" secondItem="6yx-o1-vbD" secondAttribute="trailing" constant="19" id="rWk-Mp-KPS"/>
                                             </constraints>
                                         </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vX2-5Y-rQc">
+                                            <rect key="frame" x="0.0" y="96" width="375" height="170"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QYL-Lo-tmH">
+                                                    <rect key="frame" x="10" y="0.0" width="355" height="121"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="100" id="jFf-id-CJn"/>
+                                                    </constraints>
+                                                    <string key="text">Clear personal data
+
+Warning: Your personal data (including encryption keys) is still stored on this device.
+
+Clear it if you're finished using this device, or want to sign in to another account.</string>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <string key="userLabel">Clear personal data  Warning: Your personal data (including encryption keys) is still stored on this device.  Clear it if you're finished using this device, or want to sign in to another account.</string>
+                                                </label>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZRO-C2-hH1">
+                                                    <rect key="frame" x="245" y="129" width="119" height="30"/>
+                                                    <color key="backgroundColor" red="0.4624713659286499" green="0.81734329462051392" blue="0.47220504283905029" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="30" id="WjZ-Bh-No3"/>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="dvm-Bz-pT0"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                                    <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="10" maxY="0.0"/>
+                                                    <state key="normal" title="Clear all data">
+                                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </state>
+                                                </button>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstItem="ZRO-C2-hH1" firstAttribute="top" secondItem="QYL-Lo-tmH" secondAttribute="bottom" constant="8" id="29j-dP-GC6"/>
+                                                <constraint firstItem="QYL-Lo-tmH" firstAttribute="leading" secondItem="vX2-5Y-rQc" secondAttribute="leading" constant="10" id="3Qr-IT-GDa"/>
+                                                <constraint firstAttribute="trailing" secondItem="ZRO-C2-hH1" secondAttribute="trailing" constant="11" id="Cj8-Kx-8vu"/>
+                                                <constraint firstAttribute="trailing" secondItem="QYL-Lo-tmH" secondAttribute="trailing" constant="10" id="JoV-ju-IhL"/>
+                                                <constraint firstItem="QYL-Lo-tmH" firstAttribute="top" secondItem="vX2-5Y-rQc" secondAttribute="top" id="Xjs-ZO-7fl"/>
+                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="170" id="oUw-Jb-GkG"/>
+                                                <constraint firstAttribute="bottom" secondItem="ZRO-C2-hH1" secondAttribute="bottom" constant="11" id="q0c-yG-I0n"/>
+                                            </constraints>
+                                        </view>
                                     </subviews>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <accessibility key="accessibilityConfiguration" identifier="AuthenticationVCOptionsContainer"/>
                                     <constraints>
                                         <constraint firstItem="FIn-2w-e6H" firstAttribute="leading" secondItem="Gg0-TE-OGb" secondAttribute="leading" id="3G8-Tb-KaN"/>
                                         <constraint firstItem="wEJ-AF-rdH" firstAttribute="width" secondItem="k3J-Eg-itz" secondAttribute="width" id="7sB-YJ-eX4"/>
+                                        <constraint firstAttribute="trailing" secondItem="vX2-5Y-rQc" secondAttribute="trailing" id="DPh-Jx-WP1"/>
                                         <constraint firstItem="wEJ-AF-rdH" firstAttribute="centerY" secondItem="k3J-Eg-itz" secondAttribute="centerY" id="Vze-EI-oXj"/>
                                         <constraint firstAttribute="trailing" secondItem="k3J-Eg-itz" secondAttribute="trailing" constant="11" id="ZyA-Tq-Sfq"/>
                                         <constraint firstItem="k3J-Eg-itz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Gg0-TE-OGb" secondAttribute="leading" constant="150" id="bEB-EO-b14"/>
+                                        <constraint firstItem="vX2-5Y-rQc" firstAttribute="top" secondItem="k3J-Eg-itz" secondAttribute="bottom" constant="33" id="db7-2y-vPZ"/>
                                         <constraint firstItem="AJ2-lJ-NUq" firstAttribute="centerY" secondItem="k3J-Eg-itz" secondAttribute="centerY" id="dcE-Vs-7Rt"/>
                                         <constraint firstAttribute="trailing" secondItem="FIn-2w-e6H" secondAttribute="trailing" id="kFj-6g-v3H"/>
+                                        <constraint firstItem="vX2-5Y-rQc" firstAttribute="leading" secondItem="Gg0-TE-OGb" secondAttribute="leading" id="kYN-Lj-zYP"/>
                                         <constraint firstAttribute="height" constant="300" id="lXv-gM-CjN"/>
                                         <constraint firstItem="k3J-Eg-itz" firstAttribute="top" secondItem="Gg0-TE-OGb" secondAttribute="top" constant="33" id="mor-t9-7Ke"/>
                                         <constraint firstItem="FIn-2w-e6H" firstAttribute="top" secondItem="k3J-Eg-itz" secondAttribute="bottom" constant="5" id="oTS-5o-MMW"/>

--- a/Riot/Modules/Authentication/Views/AuthInputsView.m
+++ b/Riot/Modules/Authentication/Views/AuthInputsView.m
@@ -973,6 +973,7 @@
     [fileStore asyncUsersWithUserIds:@[softLogoutCredentials.userId] success:^(NSArray<MXUser *> * _Nonnull users) {
 
         MXUser *myUser = users.firstObject;
+        [fileStore close];
 
         [self displaySoftLogoutMessageWithUserDisplayname:myUser.displayname andKeyBackupNeeded:keyBackupNeeded];
 

--- a/Riot/Modules/Authentication/Views/AuthInputsView.m
+++ b/Riot/Modules/Authentication/Views/AuthInputsView.m
@@ -1,6 +1,7 @@
 /*
  Copyright 2016 OpenMarket Ltd
  Copyright 2017 Vector Creations Ltd
+ Copyright 2019 New Vector Ltd
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -955,6 +956,58 @@
 {
     softLogoutCredentials = credentials;
     self.userLoginTextField.text = softLogoutCredentials.userId;
+    self.userLoginContainer.hidden = YES;
+    self.phoneContainer.hidden = YES;
+
+    [self displaySoftLogoutMessage];
+}
+
+- (void)displaySoftLogoutMessage
+{
+    // Take some shortcuts and make some assumptions (Riot uses MXFileStore) to
+    // retrieve my user display name as quick as possible
+    MXFileStore *fileStore = [[MXFileStore alloc] initWithCredentials:softLogoutCredentials];
+    [fileStore asyncUsersWithUserIds:@[softLogoutCredentials.userId] success:^(NSArray<MXUser *> * _Nonnull users) {
+
+        MXUser *myUser = users.firstObject;
+        [self displaySoftLogoutMessageWithUserDisplayname:myUser.displayname];
+
+    } failure:^(NSError * _Nonnull error) {
+        NSLog(@"[AuthInputsView] displaySoftLogoutMessage: Cannot load displayname. Error: %@", error);
+        [self displaySoftLogoutMessageWithUserDisplayname:nil];
+    }];
+}
+
+- (void)displaySoftLogoutMessageWithUserDisplayname:(NSString*)userDisplayname
+{
+    // Use messageLabel for this message
+    self.messageLabelTopConstraint.constant = 8;
+    self.messageLabel.textColor = ThemeService.shared.theme.textPrimaryColor;
+    self.messageLabel.hidden = NO;
+
+    NSMutableAttributedString *message = [[NSMutableAttributedString alloc] initWithString:NSLocalizedStringFromTable(@"auth_softlogout_sign_in", @"Vector", nil)
+                                                                    attributes:@{
+                                                                                 NSFontAttributeName: [UIFont boldSystemFontOfSize:14]
+                                                                                 }];
+
+    [message appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n\n"]];
+
+    NSString *string = [NSString stringWithFormat:NSLocalizedStringFromTable(@"auth_softlogout_reason", @"Vector", nil),
+                        softLogoutCredentials.homeServerName, userDisplayname, softLogoutCredentials.userId];
+    [message appendAttributedString:[[NSAttributedString alloc] initWithString:string
+                                                                    attributes:@{
+                                                                                 NSFontAttributeName: [UIFont systemFontOfSize:14]
+                                                                                 }]];
+
+    // TODO: Do not display this message if no e2e keys
+    [message appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n\n"]];
+    string = NSLocalizedStringFromTable(@"auth_softlogout_recover_encryption_keys", @"Vector", nil);
+    [message appendAttributedString:[[NSAttributedString alloc] initWithString:string
+                                                                    attributes:@{
+                                                                                 NSFontAttributeName: [UIFont systemFontOfSize:14]
+                                                                                 }]];
+
+    self.messageLabel.attributedText = message;
 }
 
 - (BOOL)areAllRequiredFieldsSet

--- a/Riot/Modules/Authentication/Views/AuthInputsView.m
+++ b/Riot/Modules/Authentication/Views/AuthInputsView.m
@@ -54,6 +54,7 @@
 @end
 
 @implementation AuthInputsView
+@synthesize softLogoutCredentials;
 
 + (UINib *)nib
 {
@@ -487,6 +488,15 @@
                         }
                     }
                 }
+
+                // For soft logout, pass the device_id currently used
+                if (parameters && self.softLogoutCredentials)
+                {
+                    NSMutableDictionary *parametersWithDeviceId = [parameters mutableCopy];
+                    parametersWithDeviceId[@"device_id"] = self.softLogoutCredentials.deviceId;
+                    parameters = parametersWithDeviceId;
+                }
+
             }
             else if (type == MXKAuthenticationTypeRegister)
             {
@@ -725,7 +735,12 @@
                 {
                     // Note: this use case was not tested yet.
                     parameters = @{
-                                   @"auth": @{@"session":currentSession.session, @"username": self.userLoginTextField.text, @"password": self.passWordTextField.text, @"type": kMXLoginFlowTypePassword}
+                                   @"auth": @{
+                                           @"session":currentSession.session,
+                                           @"username": self.userLoginTextField.text,
+                                           @"password": self.passWordTextField.text,
+                                           @"type": kMXLoginFlowTypePassword
+                                           }
                                    };
                 }
                 else if ([self isFlowSupported:kMXLoginFlowTypeTerms] && ![self isFlowCompleted:kMXLoginFlowTypeTerms])
@@ -934,6 +949,12 @@
     [self hideInputsContainer];
     
     return YES;
+}
+
+- (void)setSoftLogoutCredentials:(MXCredentials *)credentials
+{
+    softLogoutCredentials = credentials;
+    self.userLoginTextField.text = softLogoutCredentials.userId;
 }
 
 - (BOOL)areAllRequiredFieldsSet

--- a/Riot/Modules/TabBar/MasterTabBarController.h
+++ b/Riot/Modules/TabBar/MasterTabBarController.h
@@ -64,6 +64,13 @@
 - (void)showAuthenticationScreenWithRegistrationParameters:(NSDictionary*)parameters;
 
 /**
+ Display the authentication screen in order to login back a soft logout session.
+
+ @param softLogoutCredentials the credentials of the soft logout session.
+ */
+- (void)showAuthenticationScreenAfterSoftLogout:(MXCredentials*)softLogoutCredentials;
+
+/**
  Open the room with the provided identifier in a specific matrix session.
  
  @param roomId the room identifier.

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -39,6 +39,7 @@
     
     // Observer that checks when the Authentification view controller has gone.
     id authViewControllerObserver;
+    id authViewRemovedAccountObserver;
     
     // The parameters to pass to the Authentification view controller.
     NSDictionary *authViewControllerRegistrationParameters;
@@ -230,6 +231,11 @@
     {
         [[NSNotificationCenter defaultCenter] removeObserver:authViewControllerObserver];
         authViewControllerObserver = nil;
+    }
+    if (authViewRemovedAccountObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:authViewRemovedAccountObserver];
+        authViewRemovedAccountObserver = nil;
     }
     
     if (kThemeServiceDidChangeThemeNotificationObserver)
@@ -663,6 +669,15 @@
                 
                 [[NSNotificationCenter defaultCenter] removeObserver:authViewControllerObserver];
                 authViewControllerObserver = nil;
+            }];
+
+            authViewRemovedAccountObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXKAccountManagerDidRemoveAccountNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+
+                // The user has cleared data for their soft logged out account
+                _authViewController = nil;
+
+                [[NSNotificationCenter defaultCenter] removeObserver:authViewRemovedAccountObserver];
+                authViewRemovedAccountObserver = nil;
             }];
             
             // Forward parameters if any


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-ios-kit/pull/584
Part of #2540

It does:
- [x] Show the login page on `MXSessionStateSoftLogout` without loosing user data
- [x] Implement the login UX (https://zpl.io/a89QL5x). This is likely to be an adapted version to match the current auth UI.
- [x] Detect if all keys are backed up and use the right UX ^
- [x] "Clear all data" button

![Simulator Screen Shot - iPhone X - 2019-07-23 at 17 52 19](https://user-images.githubusercontent.com/8418515/61726892-aead9800-ad72-11e9-98d8-2e59797f6769.png)
