### PR TITLE
BF: Build: Fix build based on git tag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Changes in 0.9.2 (2019-07-)
+Changes in 0.9.2 (2019-08-08)
 ===============================================
 
 Improvements:
@@ -12,7 +12,8 @@ Improvements:
 Bug fix:
  * Crash when leaving settings due to backup section refresh animation.
  * Reactions: Do not display reactions on redacted events in timeline.
- * Fix crash for earch bar customisation in iOS13 (#2626).
+ * Fix crash for search bar customisation in iOS13 (#2626).
+ * Build: Fix build based on git tag.
 
 Changes in 0.9.1 (2019-07-17)
 ===============================================

--- a/Tools/Release/buildRelease.sh
+++ b/Tools/Release/buildRelease.sh
@@ -37,8 +37,9 @@ bundle update
 # Checkout the source to build
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR
-git clone --single-branch --branch $TAG https://github.com/vector-im/riot-ios.git
+git clone https://github.com/vector-im/riot-ios.git
 cd riot-ios
+git checkout -b $TAG $TAG
 
 
 # Develop branch special case

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -232,7 +232,7 @@ platform :ios do
         build_number = options[:build_number]
 
         if !git_branch_name.to_s.empty?
-            preprocessor_definitions["GIT_BRANCH"] = git_branch_name.sub("origin/", "")
+            preprocessor_definitions["GIT_BRANCH"] = git_branch_name.sub("origin/", "").sub("heads/", "")
         end
 
         if !build_number.to_s.empty?


### PR DESCRIPTION
It was no more possible to build using tags. The reason was the fastlane git_branch method returned nil.
Internally, this method executes `git symbolic-ref HEAD --short` which returned `fatal: ref HEAD is not a symbolic ref` in our case.

We now checks out the tag as a local branch.