### PR TITLE
Add and prioritize the new "_matrix/integrations/v1" widget urls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in 0.9.3 (2019-08-)
 
 Improvements:
  * Prompt to accept integration manager policies on use (#2600).
+ * Widgets: Whitelist {MSC1961](https://github.com/matrix-org/matrix-doc/pull/1961) widget urls
 
 Changes in 0.9.2 (2019-08-08)
 ===============================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changes in 0.9.3 (2019-08-)
 
 Improvements:
  * Prompt to accept integration manager policies on use (#2600).
- * Widgets: Whitelist {MSC1961](https://github.com/matrix-org/matrix-doc/pull/1961) widget urls
+ * Widgets: Whitelist [MSC1961](https://github.com/matrix-org/matrix-doc/pull/1961) widget urls
 
 Changes in 0.9.2 (2019-08-08)
 ===============================================

--- a/Riot/Assets/Riot-Defaults.plist
+++ b/Riot/Assets/Riot-Defaults.plist
@@ -32,9 +32,11 @@
 	<string>https://jitsi.riot.im</string>
 	<key>integrationsWidgetsUrls</key>
 	<array>
-		<string>https://scalar-staging.riot.im/scalar/api</string>
-		<string>https://scalar-staging.vector.im/api</string>
+		<string>https://scalar.vector.im/_matrix/integrations/v1</string>
 		<string>https://scalar.vector.im/api</string>
+		<string>https://scalar-staging.vector.im/_matrix/integrations/v1</string>
+		<string>https://scalar-staging.vector.im/api</string>
+		<string>https://scalar-staging.riot.im/scalar/api</string>
 	</array>
 	<key>piwik</key>
 	<dict>


### PR DESCRIPTION
As per MSC1961, add to the whitelisted integrations_widget_urls
the new paths. This allows us to switch Scalar over to use the
new path as default.

Note, the legacy "scalar-staging.riot.im" is these days just a redirect
to scalar-staging.vector.im, so there is no addition for that. It still
needs Riot side whitelisting though for existing widgets.

Refs: https://github.com/matrix-org/matrix-doc/pull/1961

