### PR TITLE
Privacy: Email help text on registration should be updated without binding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Improvements:
  * Privacy: Make clear that device names are publicly readable (#2662).
  * Privacy: Remove the bind true flag from 3PID calls on registration (#2648).
  * Privacy: Remove the bind true flag from 3PID adds in settings (#2650).
+ * Privacy: Email help text on registration should be updated without binding (#2675).
 
 Changes in 0.9.2 (2019-08-08)
 ===============================================

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -84,10 +84,9 @@
 "auth_invalid_email" = "This doesn't look like a valid email address";
 "auth_invalid_phone" = "This doesn't look like a valid phone number";
 "auth_missing_password" = "Missing password";
-"auth_add_email_message_2" = "Set an email for account recovery. Use email to optionally be discoverable by existing contacts.";
-"auth_add_phone_message_2" = "Set a phone for account recovery. Use phone to optionally be discoverable by existing contacts.";
-"auth_add_email_phone_message_2" = "Set an email for account recovery. Use email or phone to optionally be discoverable by existing contacts.";
-"auth_add_email_and_phone_message_2" = "Set an email and a phone number for account recovery. Use email or phone to optionally be discoverable by existing contacts.";
+"auth_add_email_message_2" = "Set an email for account recovery, and later to be optionally discoverable by people who know you.";
+"auth_add_phone_message_2" = "Set a phone, and later to be optionally discoverable by people who know you.";
+"auth_add_email_phone_message_2" = "Set an email for account recovery. Use later email or phone to be optionally discoverable by people who know you.";
 "auth_missing_email" = "Missing email address";
 "auth_missing_phone" = "Missing phone number";
 "auth_missing_email_or_phone" = "Missing email address or phone number";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -84,10 +84,10 @@
 "auth_invalid_email" = "This doesn't look like a valid email address";
 "auth_invalid_phone" = "This doesn't look like a valid phone number";
 "auth_missing_password" = "Missing password";
-"auth_add_email_message" = "Add an email address to your account to let users discover you, and to reset your password.";
-"auth_add_phone_message" = "Add a phone number to your account to let users discover you.";
-"auth_add_email_phone_message" = "Add an email address and/or a phone number to your account to let users discover you. Email address will also let you reset your password.";
-"auth_add_email_and_phone_message" = "Add an email address and a phone number to your account to let users discover you. Email address will also let you reset your password.";
+"auth_add_email_message_2" = "Set an email for account recovery. Use email to optionally be discoverable by existing contacts.";
+"auth_add_phone_message_2" = "Set a phone for account recovery. Use phone to optionally be discoverable by existing contacts.";
+"auth_add_email_phone_message_2" = "Set an email for account recovery. Use email or phone to optionally be discoverable by existing contacts.";
+"auth_add_email_and_phone_message_2" = "Set an email and a phone number for account recovery. Use email or phone to optionally be discoverable by existing contacts.";
 "auth_missing_email" = "Missing email address";
 "auth_missing_phone" = "Missing phone number";
 "auth_missing_email_or_phone" = "Missing email address or phone number";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -30,23 +30,19 @@ internal enum VectorL10n {
   internal static var authAcceptPolicies: String { 
     return VectorL10n.tr("Vector", "auth_accept_policies") 
   }
-  /// Set an email and a phone number for account recovery. Use email or phone to optionally be discoverable by existing contacts.
-  internal static var authAddEmailAndPhoneMessage2: String { 
-    return VectorL10n.tr("Vector", "auth_add_email_and_phone_message_2") 
-  }
   /// Registration with email and phone number at once is not supported yet until the api exists. Only the phone number will be taken into account. You may add your email to your profile in settings.
   internal static var authAddEmailAndPhoneWarning: String { 
     return VectorL10n.tr("Vector", "auth_add_email_and_phone_warning") 
   }
-  /// Set an email for account recovery. Use email to optionally be discoverable by existing contacts.
+  /// Set an email for account recovery, and later to be optionally discoverable by people who know you.
   internal static var authAddEmailMessage2: String { 
     return VectorL10n.tr("Vector", "auth_add_email_message_2") 
   }
-  /// Set an email for account recovery. Use email or phone to optionally be discoverable by existing contacts.
+  /// Set an email for account recovery. Use later email or phone to be optionally discoverable by people who know you.
   internal static var authAddEmailPhoneMessage2: String { 
     return VectorL10n.tr("Vector", "auth_add_email_phone_message_2") 
   }
-  /// Set a phone number for account recovery. Use phone to optionally be discoverable by existing contacts.
+  /// Set a phone, and later to be optionally discoverable by people who know you.
   internal static var authAddPhoneMessage2: String { 
     return VectorL10n.tr("Vector", "auth_add_phone_message_2") 
   }

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -30,25 +30,25 @@ internal enum VectorL10n {
   internal static var authAcceptPolicies: String { 
     return VectorL10n.tr("Vector", "auth_accept_policies") 
   }
-  /// Add an email address and a phone number to your account to let users discover you. Email address will also let you reset your password.
-  internal static var authAddEmailAndPhoneMessage: String { 
-    return VectorL10n.tr("Vector", "auth_add_email_and_phone_message") 
+  /// Set an email and a phone number for account recovery. Use email or phone to optionally be discoverable by existing contacts.
+  internal static var authAddEmailAndPhoneMessage2: String { 
+    return VectorL10n.tr("Vector", "auth_add_email_and_phone_message_2") 
   }
   /// Registration with email and phone number at once is not supported yet until the api exists. Only the phone number will be taken into account. You may add your email to your profile in settings.
   internal static var authAddEmailAndPhoneWarning: String { 
     return VectorL10n.tr("Vector", "auth_add_email_and_phone_warning") 
   }
-  /// Add an email address to your account to let users discover you, and to reset your password.
-  internal static var authAddEmailMessage: String { 
-    return VectorL10n.tr("Vector", "auth_add_email_message") 
+  /// Set an email for account recovery. Use email to optionally be discoverable by existing contacts.
+  internal static var authAddEmailMessage2: String { 
+    return VectorL10n.tr("Vector", "auth_add_email_message_2") 
   }
-  /// Add an email address and/or a phone number to your account to let users discover you. Email address will also let you reset your password.
-  internal static var authAddEmailPhoneMessage: String { 
-    return VectorL10n.tr("Vector", "auth_add_email_phone_message") 
+  /// Set an email for account recovery. Use email or phone to optionally be discoverable by existing contacts.
+  internal static var authAddEmailPhoneMessage2: String { 
+    return VectorL10n.tr("Vector", "auth_add_email_phone_message_2") 
   }
-  /// Add a phone number to your account to let users discover you.
-  internal static var authAddPhoneMessage: String { 
-    return VectorL10n.tr("Vector", "auth_add_phone_message") 
+  /// Set a phone number for account recovery. Use phone to optionally be discoverable by existing contacts.
+  internal static var authAddPhoneMessage2: String { 
+    return VectorL10n.tr("Vector", "auth_add_phone_message_2") 
   }
   /// Invalid homeserver discovery response
   internal static var authAutodiscoverInvalidResponse: String { 

--- a/Riot/Modules/Authentication/Views/AuthInputsView.m
+++ b/Riot/Modules/Authentication/Views/AuthInputsView.m
@@ -1207,15 +1207,7 @@
                 self.emailTextField.returnKeyType = UIReturnKeyNext;
                 
                 self.phoneContainerTopConstraint.constant = 50;
-                
-                if (self.areAllThirdPartyIdentifiersRequired)
-                {
-                    self.messageLabel.text = NSLocalizedStringFromTable(@"auth_add_email_and_phone_message_2", @"Vector", nil);
-                }
-                else
-                {
-                    self.messageLabel.text = NSLocalizedStringFromTable(@"auth_add_email_phone_message_2", @"Vector", nil);
-                }
+                self.messageLabel.text = NSLocalizedStringFromTable(@"auth_add_email_phone_message_2", @"Vector", nil);
             }
             else
             {

--- a/Riot/Modules/Authentication/Views/AuthInputsView.m
+++ b/Riot/Modules/Authentication/Views/AuthInputsView.m
@@ -1178,7 +1178,7 @@
             self.emailContainer.hidden = NO;
             
             self.messageLabel.hidden = NO;
-            self.messageLabel.text = NSLocalizedStringFromTable(@"auth_add_email_message", @"Vector", nil);
+            self.messageLabel.text = NSLocalizedStringFromTable(@"auth_add_email_message_2", @"Vector", nil);
             
             lastViewContainer = self.emailContainer;
         }
@@ -1210,11 +1210,11 @@
                 
                 if (self.areAllThirdPartyIdentifiersRequired)
                 {
-                    self.messageLabel.text = NSLocalizedStringFromTable(@"auth_add_email_and_phone_message", @"Vector", nil);
+                    self.messageLabel.text = NSLocalizedStringFromTable(@"auth_add_email_and_phone_message_2", @"Vector", nil);
                 }
                 else
                 {
-                    self.messageLabel.text = NSLocalizedStringFromTable(@"auth_add_email_phone_message", @"Vector", nil);
+                    self.messageLabel.text = NSLocalizedStringFromTable(@"auth_add_email_phone_message_2", @"Vector", nil);
                 }
             }
             else
@@ -1222,7 +1222,7 @@
                 self.phoneContainerTopConstraint.constant = 0;
                 
                 self.messageLabel.hidden = NO;
-                self.messageLabel.text = NSLocalizedStringFromTable(@"auth_add_phone_message", @"Vector", nil);
+                self.messageLabel.text = NSLocalizedStringFromTable(@"auth_add_phone_message_2", @"Vector", nil);
             }
             
             lastViewContainer = self.phoneContainer;


### PR DESCRIPTION
Fixes #2675

We use new strings ids as the meaning changed.

![Simulator Screen Shot - iPhone 8 - 2019-08-30 at 10 12 20](https://user-images.githubusercontent.com/8418515/64005137-0a0c3c00-cb10-11e9-9156-e1fdaa050bdd.png)


