### PR TITLE
Privacy: Make NSContactsUsageDescription more generic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Improvements:
  * Privacy: Allow password reset when no IS (#2658).
  * Privacy: Allow email registration when no IS (#2657).
  * Privacy: Settings: Add a Discovery section (#2606).
+ * Privacy: Make NSContactsUsageDescription more generic and mention that 3pids are now uploaded hashed (#2521).
 
 Changes in 0.9.2 (2019-08-08)
 ===============================================

--- a/Riot/Assets/en.lproj/InfoPlist.strings
+++ b/Riot/Assets/en.lproj/InfoPlist.strings
@@ -18,6 +18,6 @@
 "NSCameraUsageDescription" = "The camera is used to take photos and videos, make video calls.";
 "NSPhotoLibraryUsageDescription" = "The photo library is used to send photos and videos.";
 "NSMicrophoneUsageDescription" = "The microphone is used to take videos, make calls.";
-"NSContactsUsageDescription" = "In order to show you which of your contacts are already using Riot or Matrix, we can send the email addresses and phone numbers in your address book to your Matrix identity server. New Vector does not store this data or use it for any other purpose. For more information please see the privacy policy page in application settings.";
+"NSContactsUsageDescription" = "To discover contacts already using Matrix, Riot can send email addresses and phone numbers in your address book to your chosen Matrix identity server. Where supported, personal data is hashed before sending - please check your identity server's privacy policy for more details.";
 "NSCalendarsUsageDescription" = "See your scheduled meetings in the app.";
 


### PR DESCRIPTION
and mention that 3pids are now uploaded hashed.

Closes #2521.

<img width="269" alt="Screenshot 2019-09-11 at 17 56 34" src="https://user-images.githubusercontent.com/8418515/64713954-130cee00-d4be-11e9-9b80-32f00a701b15.png">
