### PR TITLE
Make sure the app behaves clearly for the end user when there is no IS

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -199,6 +199,7 @@
 // Contacts
 "contacts_address_book_section" = "LOCAL CONTACTS";
 "contacts_address_book_matrix_users_toggle" = "Matrix users only";
+"contacts_address_book_no_identity_server" = "No identity server configured";
 "contacts_address_book_no_contact" = "No local contacts";
 "contacts_address_book_permission_required" = "Permission required to access local contacts";
 "contacts_address_book_permission_denied" = "You didn't allow Riot to access your local contacts";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -987,4 +987,4 @@
 
 
 // Generic errors
-"error_no_identity_server" = "Add an identity server in your settings to invite by email.";
+"error_invite_3pid_with_no_identity_server" = "Add an identity server in your settings to invite by email.";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -984,3 +984,7 @@
 
 // MARK: Reaction history
 "reaction_history_title" = "Reactions";
+
+
+// Generic errors
+"error_no_identity_server" = "Add an identity server in your settings to invite by email.";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -994,6 +994,10 @@ internal enum VectorL10n {
   internal static var encryptedRoomMessageReplyToPlaceholder: String { 
     return VectorL10n.tr("Vector", "encrypted_room_message_reply_to_placeholder") 
   }
+  /// Add an identity server in your settings to invite by email.
+  internal static var errorNoIdentityServer: String { 
+    return VectorL10n.tr("Vector", "error_no_identity_server") 
+  }
   /// VoIP conference added by %@
   internal static func eventFormatterJitsiWidgetAdded(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "event_formatter_jitsi_widget_added", p1)

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -995,8 +995,8 @@ internal enum VectorL10n {
     return VectorL10n.tr("Vector", "encrypted_room_message_reply_to_placeholder") 
   }
   /// Add an identity server in your settings to invite by email.
-  internal static var errorNoIdentityServer: String { 
-    return VectorL10n.tr("Vector", "error_no_identity_server") 
+  internal static var errorInvite3pidWithNoIdentityServer: String { 
+    return VectorL10n.tr("Vector", "error_invite_3pid_with_no_identity_server") 
   }
   /// VoIP conference added by %@
   internal static func eventFormatterJitsiWidgetAdded(_ p1: String) -> String {

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -426,6 +426,10 @@ internal enum VectorL10n {
   internal static var contactsAddressBookNoContact: String { 
     return VectorL10n.tr("Vector", "contacts_address_book_no_contact") 
   }
+  /// No identity server configured
+  internal static var contactsAddressBookNoIdentityServer: String { 
+    return VectorL10n.tr("Vector", "contacts_address_book_no_identity_server") 
+  }
   /// You didn't allow Riot to access your local contacts
   internal static var contactsAddressBookPermissionDenied: String { 
     return VectorL10n.tr("Vector", "contacts_address_book_permission_denied") 

--- a/Riot/Modules/Contacts/DataSources/ContactsDataSource.m
+++ b/Riot/Modules/Contacts/DataSources/ContactsDataSource.m
@@ -622,8 +622,16 @@
             switch ([CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts])
             {
                 case CNAuthorizationStatusAuthorized:
-                    // Because there is no contacts on the device
-                    tableViewCell.textLabel.text = NSLocalizedStringFromTable(@"contacts_address_book_no_contact", @"Vector", nil);
+                    if (hideNonMatrixEnabledContacts && !self.mxSession.identityService)
+                    {
+                        // Because we cannot make lookups with no IS
+                        tableViewCell.textLabel.text = NSLocalizedStringFromTable(@"contacts_address_book_no_identity_server", @"Vector", nil);
+                    }
+                    else
+                    {
+                        // Because there is no contacts on the device
+                        tableViewCell.textLabel.text = NSLocalizedStringFromTable(@"contacts_address_book_no_contact", @"Vector", nil);
+                    }
                     break;
 
                 case CNAuthorizationStatusNotDetermined:

--- a/Riot/Modules/Room/Members/RoomParticipantsViewController.m
+++ b/Riot/Modules/Room/Members/RoomParticipantsViewController.m
@@ -1651,7 +1651,7 @@
                                                                        if ([error.domain isEqualToString:kMXRestClientErrorDomain]
                                                                            && error.code == MXRestClientErrorMissingIdentityServer)
                                                                        {
-                                                                           NSString *message = [NSBundle mxk_localizedStringForKey:@"error_no_identity_server"];
+                                                                           NSString *message = [NSBundle mxk_localizedStringForKey:@"error_invite_3pid_with_no_identity_server"];
                                                                            [[AppDelegate theDelegate] showAlertWithTitle:message message:nil];
                                                                        }
                                                                        else

--- a/Riot/Modules/Room/Members/RoomParticipantsViewController.m
+++ b/Riot/Modules/Room/Members/RoomParticipantsViewController.m
@@ -1646,8 +1646,18 @@
                                                                        [self removePendingActionMask];
                                                                        
                                                                        NSLog(@"[RoomParticipantsVC] Invite be email %@ failed", participantId);
+
                                                                        // Alert user
-                                                                       [[AppDelegate theDelegate] showErrorAsAlert:error];
+                                                                       if ([error.domain isEqualToString:kMXRestClientErrorDomain]
+                                                                           && error.code == MXRestClientErrorMissingIdentityServer)
+                                                                       {
+                                                                           NSString *message = [NSBundle mxk_localizedStringForKey:@"error_no_identity_server"];
+                                                                           [[AppDelegate theDelegate] showAlertWithTitle:message message:nil];
+                                                                       }
+                                                                       else
+                                                                       {
+                                                                           [[AppDelegate theDelegate] showErrorAsAlert:error];
+                                                                       }
                                                                    }];
                                                                }
                                                                else //if ([MXTools isMatrixUserIdentifier:participantId])

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -5008,8 +5008,16 @@
                                                                    
                                                                    NSLog(@"[RoomVC] Invite be email %@ failed", participantId);
                                                                    // Alert user
-                                                                   [[AppDelegate theDelegate] showErrorAsAlert:error];
-                                                                   
+                                                                   if ([error.domain isEqualToString:kMXRestClientErrorDomain]
+                                                                       && error.code == MXRestClientErrorMissingIdentityServer)
+                                                                   {
+                                                                       NSString *message = [NSBundle mxk_localizedStringForKey:@"error_no_identity_server"];
+                                                                       [[AppDelegate theDelegate] showAlertWithTitle:message message:nil];
+                                                                   }
+                                                                   else
+                                                                   {
+                                                                       [[AppDelegate theDelegate] showErrorAsAlert:error];
+                                                                   }
                                                                }];
                                                            }
                                                            else //if ([MXTools isMatrixUserIdentifier:participantId])

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -5011,7 +5011,7 @@
                                                                    if ([error.domain isEqualToString:kMXRestClientErrorDomain]
                                                                        && error.code == MXRestClientErrorMissingIdentityServer)
                                                                    {
-                                                                       NSString *message = [NSBundle mxk_localizedStringForKey:@"error_no_identity_server"];
+                                                                       NSString *message = [NSBundle mxk_localizedStringForKey:@"error_invite_3pid_with_no_identity_server"];
                                                                        [[AppDelegate theDelegate] showAlertWithTitle:message message:nil];
                                                                    }
                                                                    else

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -3723,6 +3723,8 @@ SettingsDiscoveryTableViewSectionDelegate, SettingsDiscoveryViewModelCoordinator
         }];
 
     } failure:^(NSError *error) {
+        [self stopActivityIndicator];
+        
         // Notify user
         NSString *myUserId = session.myUser.userId; // TODO: Hanlde multi-account
         [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];


### PR DESCRIPTION
closes #2672 

This PR implements:
- an error message when the user tries to invite by email
![Simulator Screen Shot - iPhone 7 - 2019-09-16 at 18 21 16](https://user-images.githubusercontent.com/8418515/65027523-cbadb400-d93a-11e9-9fb7-b4628814a407.png)
- a message explaining why there is no matrix users in the local contact list
<img width="352" alt="Screenshot 2019-09-17 at 11 05 15" src="https://user-images.githubusercontent.com/8418515/65027663-0c0d3200-d93b-11e9-91c4-ef705ab9fbb1.png">

Note: In settings, there was already an error message if you try to add a email to your account on an HS that still requires an IS to operate.