### PR TITLE
Settings/Bind: Ask the user to validate the email again if they have …

### DIFF
--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -994,16 +994,14 @@ internal enum VectorL10n {
   internal static var encryptedRoomMessageReplyToPlaceholder: String { 
     return VectorL10n.tr("Vector", "encrypted_room_message_reply_to_placeholder") 
   }
-
   /// Add an identity server in your settings to invite by email.
   internal static var errorInvite3pidWithNoIdentityServer: String { 
     return VectorL10n.tr("Vector", "error_invite_3pid_with_no_identity_server") 
-
+  }
   /// It looks like you’re trying to connect to another homeserver. Do you want to sign out?
   internal static var errorUserAlreadyLoggedIn: String { 
-    return VectorL10n.tr("Vector", "error_user_already_logged_in")
+    return VectorL10n.tr("Vector", "error_user_already_logged_in") 
   }
-    
   /// VoIP conference added by %@
   internal static func eventFormatterJitsiWidgetAdded(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "event_formatter_jitsi_widget_added", p1)
@@ -2284,9 +2282,9 @@ internal enum VectorL10n {
   internal static var roomParticipantsRemovePromptTitle: String { 
     return VectorL10n.tr("Vector", "room_participants_remove_prompt_title") 
   }
-  /// Remove third-party invite is not supported yet until the api exists
-  internal static var roomParticipantsRemoveThirdPartyInviteMsg: String { 
-    return VectorL10n.tr("Vector", "room_participants_remove_third_party_invite_msg") 
+  /// Are you sure you want to revoke this invite?
+  internal static var roomParticipantsRemoveThirdPartyInvitePromptMsg: String { 
+    return VectorL10n.tr("Vector", "room_participants_remove_third_party_invite_prompt_msg") 
   }
   /// No identity server is configured so you cannot start a chat with a contact using an email.
   internal static var roomParticipantsStartNewChatErrorUsingUserEmailWithoutIdentityServer: String { 

--- a/Riot/Modules/Settings/Discovery/ThreePidDetails/SettingsDiscoveryThreePidDetailsViewModel.swift
+++ b/Riot/Modules/Settings/Discovery/ThreePidDetails/SettingsDiscoveryThreePidDetailsViewModel.swift
@@ -190,7 +190,9 @@ final class SettingsDiscoveryThreePidDetailsViewModel: SettingsDiscoveryThreePid
 
                 self.checkThreePidDiscoverability()
             case .failure(let error):
-                if let mxError = MXError(nsError: error), mxError.errcode == kMXErrCodeStringThreePIDAuthFailed {
+                if let mxError = MXError(nsError: error),
+                    (mxError.errcode == kMXErrCodeStringThreePIDAuthFailed
+                        || mxError.errcode == kMXErrCodeStringUnknown) {
                     self.update(viewState: .loaded(displayMode: .pendingThreePidVerification))
                 } else {
                     if threePidAddSession.medium == kMX3PIDMediumEmail {


### PR DESCRIPTION
…not validated it yet

instead of displaying an error dialog.
This bug happened only with the new HS add and bind APIs (MSC2290) flow because new IS API returns only `M_UNKNOWN`.

Before:
![Simulator Screen Shot - iPhone 8 - 2019-10-04 at 14 12 29](https://user-images.githubusercontent.com/8418515/66206665-050f4f00-e6b1-11e9-8961-a46348c5a1ee.png)


After:
![Simulator Screen Shot - iPhone 8 - 2019-10-04 at 13 41 45](https://user-images.githubusercontent.com/8418515/66206482-8d412480-e6b0-11e9-9ee0-eb3838c83ce1.png)