### PR TITLE
Privacy: Make IS terms wording clearer when we fallback to vector.im

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Improvements:
  * Privacy: Settings: Add a Discovery section (#2606).
  * Privacy: Make NSContactsUsageDescription more generic and mention that 3pids are now uploaded hashed (#2521).
  * Privacy: Settings: Add IDENTITY SERVER section (#2604).
+ * Privacy: Make IS terms wording clearer when we fallback to vector.im (#2760).
 
 Bug fix:
  * Theme: Make button theming work (#2734).

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -4823,6 +4823,8 @@ NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey = @"AppDe
 
 - (void)handleIdentityServiceTermsNotSignedNotification:(NSNotification*)notification
 {
+    NSLog(@"[AppDelegate] IS Terms: handleIdentityServiceTermsNotSignedNotification.");
+
     NSString *baseURL;
     NSString *accessToken;
     
@@ -4859,6 +4861,24 @@ NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey = @"AppDe
 {
     [coordinatorBridgePresenter dismissWithAnimated:YES completion:^{
         
+    }];
+    self.serviceTermsModalCoordinatorBridgePresenter = nil;
+}
+
+- (void)serviceTermsModalCoordinatorBridgePresenterDelegateDidDecline:(ServiceTermsModalCoordinatorBridgePresenter *)coordinatorBridgePresenter session:(MXSession *)session
+{
+    NSLog(@"[AppDelegate] IS Terms: User has declined the use of the default IS.");
+
+    // The user does not want to use the proposed IS.
+    // Disable IS feature on user's account
+    [session setIdentityServer:nil andAccessToken:nil];
+    [session setAccountDataIdentityServer:nil success:^{
+    } failure:^(NSError *error) {
+        NSLog(@"[AppDelegate] IS Terms: Error: %@", error);
+    }];
+
+    [coordinatorBridgePresenter dismissWithAnimated:YES completion:^{
+
     }];
     self.serviceTermsModalCoordinatorBridgePresenter = nil;
 }

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -4844,6 +4844,7 @@ NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey = @"AppDe
     ServiceTermsModalCoordinatorBridgePresenter *serviceTermsModalCoordinatorBridgePresenter = [[ServiceTermsModalCoordinatorBridgePresenter alloc] initWithSession:mxSession
                                                                                                                                                             baseUrl:baseURL
                                                                                                                                                         serviceType:MXServiceTypeIdentityService
+                                                                                                                                                       outOfContext:YES
                                                                                                                                                         accessToken:accessToken];
     
     serviceTermsModalCoordinatorBridgePresenter.delegate = self;

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -784,10 +784,18 @@
 
 // Service terms
 "service_terms_modal_title" = "Terms Of Service";
-"service_terms_modal_message" = "To continue you need to accept the Terms of this service (%@).";
+"service_terms_modal_message" = "To continue you need to accept the terms of this service (%@).";
 "service_terms_modal_accept_button" = "Accept";
-"service_terms_modal_description_for_identity_server" = "Be discoverable by others";
+"service_terms_modal_decline_button" = "Decline";
+
+"service_terms_modal_description_for_identity_server_1" = "Find others by phone or email";
+"service_terms_modal_description_for_identity_server_2" = "Be found by phone or email";
 "service_terms_modal_description_for_integration_manager" = "Use Bots, bridges, widgets and sticker packs";
+
+// Service terms - Variant for identity server when displayed out of a context
+"service_terms_modal_title_identity_server" = "Contact discovery";
+"service_terms_modal_message_identity_server" = "Accept the terms of the identity server (%@) to discover contacts.";
+
 
 // Deactivate account
 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -2518,21 +2518,37 @@ internal enum VectorL10n {
   internal static var serviceTermsModalAcceptButton: String { 
     return VectorL10n.tr("Vector", "service_terms_modal_accept_button") 
   }
-  /// Be discoverable by others
-  internal static var serviceTermsModalDescriptionForIdentityServer: String { 
-    return VectorL10n.tr("Vector", "service_terms_modal_description_for_identity_server") 
+  /// Decline
+  internal static var serviceTermsModalDeclineButton: String { 
+    return VectorL10n.tr("Vector", "service_terms_modal_decline_button") 
+  }
+  /// Find others by phone or email
+  internal static var serviceTermsModalDescriptionForIdentityServer1: String { 
+    return VectorL10n.tr("Vector", "service_terms_modal_description_for_identity_server_1") 
+  }
+  /// Be found by phone or email
+  internal static var serviceTermsModalDescriptionForIdentityServer2: String { 
+    return VectorL10n.tr("Vector", "service_terms_modal_description_for_identity_server_2") 
   }
   /// Use Bots, bridges, widgets and sticker packs
   internal static var serviceTermsModalDescriptionForIntegrationManager: String { 
     return VectorL10n.tr("Vector", "service_terms_modal_description_for_integration_manager") 
   }
-  /// To continue you need to accept the Terms of this service (%@).
+  /// To continue you need to accept the terms of this service (%@).
   internal static func serviceTermsModalMessage(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "service_terms_modal_message", p1)
+  }
+  /// Accept the terms of the identity server (%@) to discover contacts.
+  internal static func serviceTermsModalMessageIdentityServer(_ p1: String) -> String {
+    return VectorL10n.tr("Vector", "service_terms_modal_message_identity_server", p1)
   }
   /// Terms Of Service
   internal static var serviceTermsModalTitle: String { 
     return VectorL10n.tr("Vector", "service_terms_modal_title") 
+  }
+  /// Contact discovery
+  internal static var serviceTermsModalTitleIdentityServer: String { 
+    return VectorL10n.tr("Vector", "service_terms_modal_title_identity_server") 
   }
   /// Add email address
   internal static var settingsAddEmailAddress: String { 

--- a/Riot/Modules/Integrations/IntegrationManagerViewController.m
+++ b/Riot/Modules/Integrations/IntegrationManagerViewController.m
@@ -707,6 +707,7 @@ NSString *const kIntegrationManagerAddIntegrationScreen = @"add_integ";
 
     ServiceTermsModalCoordinatorBridgePresenter *serviceTermsModalCoordinatorBridgePresenter = [[ServiceTermsModalCoordinatorBridgePresenter alloc] initWithSession:mxSession baseUrl:config.baseUrl
                                                                                                                                                         serviceType:MXServiceTypeIntegrationManager
+                                                                                                                                                       outOfContext:NO
                                                                                                                                                         accessToken:config.scalarToken];
 
     serviceTermsModalCoordinatorBridgePresenter.delegate = self;

--- a/Riot/Modules/Integrations/Widgets/WidgetViewController.m
+++ b/Riot/Modules/Integrations/Widgets/WidgetViewController.m
@@ -406,7 +406,9 @@ NSString *const kJavascriptSendResponseToPostMessageAPI = @"riotIOS.sendResponse
     NSLog(@"[WidgetVC] presentTerms for %@", config.baseUrl);
 
     ServiceTermsModalCoordinatorBridgePresenter *serviceTermsModalCoordinatorBridgePresenter = [[ServiceTermsModalCoordinatorBridgePresenter alloc] initWithSession:widget.mxSession baseUrl:config.baseUrl
-                                                                                                                                                       serviceType:MXServiceTypeIntegrationManager                                                                                                                                            accessToken:config.scalarToken];
+                                                                                                                                                       serviceType:MXServiceTypeIntegrationManager
+                                                                                                                                                       outOfContext:NO
+                                                                                                                                                        accessToken:config.scalarToken];
     serviceTermsModalCoordinatorBridgePresenter.delegate = self;
 
     [serviceTermsModalCoordinatorBridgePresenter presentFrom:self animated:YES];

--- a/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenCoordinator.swift
+++ b/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenCoordinator.swift
@@ -66,7 +66,11 @@ extension ServiceTermsModalScreenCoordinator: ServiceTermsModalScreenViewModelCo
     func serviceTermsModalScreenViewModel(_ coordinator: ServiceTermsModalScreenViewModelType, displayPolicy policy: MXLoginPolicyData) {
         self.delegate?.serviceTermsModalScreenCoordinator(self, displayPolicy: policy)
     }
-    
+
+    func serviceTermsModalScreenViewModelDidDecline(_ viewModel: ServiceTermsModalScreenViewModelType) {
+        self.delegate?.serviceTermsModalScreenCoordinatorDidDecline(self)
+    }
+
     func serviceTermsModalScreenViewModelDidCancel(_ viewModel: ServiceTermsModalScreenViewModelType) {
         self.delegate?.serviceTermsModalScreenCoordinatorDidCancel(self)
     }

--- a/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenCoordinator.swift
+++ b/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenCoordinator.swift
@@ -37,9 +37,9 @@ final class ServiceTermsModalScreenCoordinator: ServiceTermsModalScreenCoordinat
     
     // MARK: - Setup
     
-    init(serviceTerms: MXServiceTerms) {
+    init(serviceTerms: MXServiceTerms, outOfContext: Bool = false) {
         
-        let serviceTermsModalScreenViewModel = ServiceTermsModalScreenViewModel(serviceTerms: serviceTerms)
+        let serviceTermsModalScreenViewModel = ServiceTermsModalScreenViewModel(serviceTerms: serviceTerms, outOfContext: outOfContext)
         let serviceTermsModalScreenViewController = ServiceTermsModalScreenViewController.instantiate(with: serviceTermsModalScreenViewModel)
         self.serviceTermsModalScreenViewModel = serviceTermsModalScreenViewModel
         self.serviceTermsModalScreenViewController = serviceTermsModalScreenViewController

--- a/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenCoordinatorType.swift
+++ b/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenCoordinatorType.swift
@@ -21,6 +21,7 @@ import Foundation
 protocol ServiceTermsModalScreenCoordinatorDelegate: class {
     func serviceTermsModalScreenCoordinatorDidAccept(_ coordinator: ServiceTermsModalScreenCoordinatorType)
     func serviceTermsModalScreenCoordinator(_ coordinator: ServiceTermsModalScreenCoordinatorType, displayPolicy policy: MXLoginPolicyData)
+    func serviceTermsModalScreenCoordinatorDidDecline(_ coordinator: ServiceTermsModalScreenCoordinatorType)
     func serviceTermsModalScreenCoordinatorDidCancel(_ coordinator: ServiceTermsModalScreenCoordinatorType)
 }
 

--- a/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewAction.swift
+++ b/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewAction.swift
@@ -23,5 +23,6 @@ enum ServiceTermsModalScreenViewAction {
     case load
     case display(MXLoginPolicyData)
     case accept
+    case decline
     case cancel
 }

--- a/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewController.storyboard
+++ b/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewController.storyboard
@@ -37,32 +37,46 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="swq-xw-ItG">
-                                                        <rect key="frame" x="20" y="128" width="374" height="652"/>
+                                                        <rect key="frame" x="20" y="128" width="374" height="600"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </tableView>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DOt-5E-FjF">
-                                                        <rect key="frame" x="20" y="788" width="374" height="44"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="44" id="d2a-Dw-Pu5"/>
-                                                        </constraints>
-                                                        <state key="normal" title="Accept"/>
-                                                        <connections>
-                                                            <action selector="acceptButtonAction:" destination="V8j-Lb-PgC" eventType="touchUpInside" id="uvI-tt-Nfj"/>
-                                                        </connections>
-                                                    </button>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dcx-ju-f0Q">
+                                                        <rect key="frame" x="20" y="736" width="374" height="96"/>
+                                                        <subviews>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DOt-5E-FjF">
+                                                                <rect key="frame" x="0.0" y="0.0" width="374" height="44"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="44" id="d2a-Dw-Pu5"/>
+                                                                </constraints>
+                                                                <state key="normal" title="Accept"/>
+                                                                <connections>
+                                                                    <action selector="acceptButtonAction:" destination="V8j-Lb-PgC" eventType="touchUpInside" id="uvI-tt-Nfj"/>
+                                                                </connections>
+                                                            </button>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QHr-gh-dAD">
+                                                                <rect key="frame" x="0.0" y="52" width="374" height="44"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="44" id="y6d-Vg-5PP"/>
+                                                                </constraints>
+                                                                <state key="normal" title="Decline">
+                                                                    <color key="titleColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                                </state>
+                                                            </button>
+                                                        </subviews>
+                                                    </stackView>
                                                 </subviews>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstItem="bxI-mu-qng" firstAttribute="leading" secondItem="voD-3Q-ryt" secondAttribute="leading" constant="20" symbolic="YES" id="1K2-u8-QsL"/>
-                                                    <constraint firstAttribute="bottom" secondItem="DOt-5E-FjF" secondAttribute="bottom" constant="20" symbolic="YES" id="2Vt-c1-fPz"/>
                                                     <constraint firstAttribute="trailing" secondItem="bxI-mu-qng" secondAttribute="trailing" constant="20" symbolic="YES" id="41D-TP-69f"/>
-                                                    <constraint firstItem="DOt-5E-FjF" firstAttribute="leading" secondItem="voD-3Q-ryt" secondAttribute="leading" constant="20" symbolic="YES" id="43V-Ya-vks"/>
                                                     <constraint firstItem="swq-xw-ItG" firstAttribute="top" secondItem="bxI-mu-qng" secondAttribute="bottom" constant="8" symbolic="YES" id="9Gg-Xb-o2W"/>
-                                                    <constraint firstItem="DOt-5E-FjF" firstAttribute="top" secondItem="swq-xw-ItG" secondAttribute="bottom" constant="8" symbolic="YES" id="K8z-wm-8yT"/>
                                                     <constraint firstItem="bxI-mu-qng" firstAttribute="top" secondItem="voD-3Q-ryt" secondAttribute="top" constant="20" symbolic="YES" id="W1m-x0-TyS"/>
+                                                    <constraint firstItem="dcx-ju-f0Q" firstAttribute="leading" secondItem="voD-3Q-ryt" secondAttribute="leading" constant="20" symbolic="YES" id="Wcx-d6-M14"/>
                                                     <constraint firstAttribute="trailing" secondItem="swq-xw-ItG" secondAttribute="trailing" constant="20" symbolic="YES" id="Y5v-Gg-xkM"/>
+                                                    <constraint firstAttribute="bottom" secondItem="dcx-ju-f0Q" secondAttribute="bottom" constant="20" symbolic="YES" id="cpa-Lq-Mvs"/>
+                                                    <constraint firstAttribute="trailing" secondItem="dcx-ju-f0Q" secondAttribute="trailing" constant="20" symbolic="YES" id="eGO-kM-neh"/>
                                                     <constraint firstAttribute="width" priority="750" constant="500" id="glD-Sz-73O"/>
-                                                    <constraint firstAttribute="trailing" secondItem="DOt-5E-FjF" secondAttribute="trailing" constant="20" symbolic="YES" id="lpw-9u-VDG"/>
+                                                    <constraint firstItem="dcx-ju-f0Q" firstAttribute="top" secondItem="swq-xw-ItG" secondAttribute="bottom" constant="8" symbolic="YES" id="zYm-2k-kvi"/>
                                                     <constraint firstItem="swq-xw-ItG" firstAttribute="leading" secondItem="voD-3Q-ryt" secondAttribute="leading" constant="20" symbolic="YES" id="ze1-Iw-v9U"/>
                                                 </constraints>
                                             </view>
@@ -98,6 +112,7 @@
                     </view>
                     <connections>
                         <outlet property="acceptButton" destination="DOt-5E-FjF" id="ktw-U4-efQ"/>
+                        <outlet property="declineButton" destination="QHr-gh-dAD" id="QOS-rE-4SP"/>
                         <outlet property="messageLabel" destination="bxI-mu-qng" id="pbX-aZ-inC"/>
                         <outlet property="scrollView" destination="9U2-KL-ZVA" id="ojG-2y-X7b"/>
                         <outlet property="tableView" destination="swq-xw-ItG" id="Fwb-Sc-bec"/>

--- a/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewController.storyboard
+++ b/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewController.storyboard
@@ -61,6 +61,9 @@
                                                                 <state key="normal" title="Decline">
                                                                     <color key="titleColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                                 </state>
+                                                                <connections>
+                                                                    <action selector="declineButtonAction:" destination="V8j-Lb-PgC" eventType="touchUpInside" id="MTU-9k-8yo"/>
+                                                                </connections>
                                                             </button>
                                                         </subviews>
                                                     </stackView>

--- a/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewController.swift
+++ b/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewController.swift
@@ -211,6 +211,10 @@ final class ServiceTermsModalScreenViewController: UIViewController {
         self.viewModel.process(viewAction: .accept)
     }
 
+    @IBAction private func declineButtonAction(_ sender: Any) {
+        self.viewModel.process(viewAction: .decline)
+    }
+    
     private func cancelButtonAction() {
         self.viewModel.process(viewAction: .cancel)
     }

--- a/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewController.swift
+++ b/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewController.swift
@@ -31,7 +31,8 @@ final class ServiceTermsModalScreenViewController: UIViewController {
     @IBOutlet private weak var messageLabel: UILabel!
     @IBOutlet private weak var tableView: UITableView!
     @IBOutlet private weak var acceptButton: UIButton!
-    
+    @IBOutlet private weak var declineButton: UIButton!
+
     // MARK: Private
 
     private var viewModel: ServiceTermsModalScreenViewModelType!
@@ -94,6 +95,9 @@ final class ServiceTermsModalScreenViewController: UIViewController {
         self.acceptButton.backgroundColor = theme.backgroundColor
         theme.applyStyle(onButton: self.acceptButton)
 
+        theme.applyStyle(onButton: self.declineButton)
+        self.declineButton.setTitleColor(self.theme.warningColor, for: .normal)
+
         self.refreshViews()
     }
     
@@ -120,6 +124,17 @@ final class ServiceTermsModalScreenViewController: UIViewController {
         self.acceptButton.setTitle(VectorL10n.serviceTermsModalAcceptButton, for: .normal)
         self.acceptButton.setTitle(VectorL10n.serviceTermsModalAcceptButton, for: .highlighted)
         self.refreshAcceptButton()
+
+        if self.viewModel.outOfContext
+            && self.viewModel.serviceType == MXServiceTypeIdentityService {
+            self.title = VectorL10n.serviceTermsModalTitleIdentityServer
+            self.messageLabel.text = VectorL10n.serviceTermsModalMessageIdentityServer(self.viewModel.serviceUrl)
+
+            self.declineButton.setTitle(VectorL10n.serviceTermsModalDeclineButton, for: .normal)
+            self.declineButton.setTitle(VectorL10n.serviceTermsModalDeclineButton, for: .highlighted)
+        } else {
+            self.declineButton.isHidden = true
+        }
     }
 
     private func setupTableView() {
@@ -269,7 +284,9 @@ extension ServiceTermsModalScreenViewController: UITableViewDataSource {
         var labelDetail: String = ""
         switch self.viewModel.serviceType {
         case MXServiceTypeIdentityService:
-            labelDetail = VectorL10n.serviceTermsModalDescriptionForIdentityServer
+            labelDetail = VectorL10n.serviceTermsModalDescriptionForIdentityServer1
+                + "\n"
+                + VectorL10n.serviceTermsModalDescriptionForIdentityServer2
         case MXServiceTypeIntegrationManager:
             labelDetail = VectorL10n.serviceTermsModalDescriptionForIntegrationManager
         default: break
@@ -280,7 +297,6 @@ extension ServiceTermsModalScreenViewController: UITableViewDataSource {
         label.append(NSAttributedString(string: "\n"))
         label.append(NSAttributedString(string: labelDetail,
                                         attributes: [.foregroundColor: theme.textSecondaryColor]))
-
         return label
     }
 }

--- a/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewModel.swift
+++ b/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewModel.swift
@@ -61,6 +61,8 @@ final class ServiceTermsModalScreenViewModel: ServiceTermsModalScreenViewModelTy
             self.coordinatorDelegate?.serviceTermsModalScreenViewModel(self, displayPolicy: policy)
         case .accept:
             self.acceptTerms()
+        case .decline:
+            self.coordinatorDelegate?.serviceTermsModalScreenViewModelDidDecline(self)
         case .cancel:
             self.coordinatorDelegate?.serviceTermsModalScreenViewModelDidCancel(self)
         }

--- a/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewModel.swift
+++ b/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewModel.swift
@@ -19,9 +19,10 @@
 import Foundation
 
 final class ServiceTermsModalScreenViewModel: ServiceTermsModalScreenViewModelType {
-    
+
     // MARK: - Properties
-    
+    let outOfContext: Bool
+
     // MARK: Private
 
     private let serviceTerms: MXServiceTerms
@@ -42,8 +43,9 @@ final class ServiceTermsModalScreenViewModel: ServiceTermsModalScreenViewModelTy
     
     // MARK: - Setup
     
-    init(serviceTerms: MXServiceTerms) {
+    init(serviceTerms: MXServiceTerms, outOfContext: Bool) {
         self.serviceTerms = serviceTerms
+        self.outOfContext = outOfContext
     }
     
     deinit {

--- a/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewModelType.swift
+++ b/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewModelType.swift
@@ -25,6 +25,7 @@ protocol ServiceTermsModalScreenViewModelViewDelegate: class {
 protocol ServiceTermsModalScreenViewModelCoordinatorDelegate: class {
     func serviceTermsModalScreenViewModel(_ coordinator: ServiceTermsModalScreenViewModelType, displayPolicy policy: MXLoginPolicyData)
     func serviceTermsModalScreenViewModelDidAccept(_ viewModel: ServiceTermsModalScreenViewModelType)
+    func serviceTermsModalScreenViewModelDidDecline(_ viewModel: ServiceTermsModalScreenViewModelType)
     func serviceTermsModalScreenViewModelDidCancel(_ viewModel: ServiceTermsModalScreenViewModelType)
 }
 

--- a/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewModelType.swift
+++ b/Riot/Modules/ServiceTerms/Modal/Modal/ServiceTermsModalScreenViewModelType.swift
@@ -33,6 +33,9 @@ protocol ServiceTermsModalScreenViewModelType {
 
     var serviceUrl: String { get }
     var serviceType: MXServiceType { get }
+    /// If true, terms are displayed out of a context of a flow (like a background 3pids lookup)
+    /// In this case, the wording needs to provide more information about the intent
+    var outOfContext: Bool { get }
     var policies: [MXLoginPolicyData]? { get set }
     var alreadyAcceptedPoliciesUrls: [String] { get set }
         

--- a/Riot/Modules/ServiceTerms/Modal/ServiceTermsModalCoordinator.swift
+++ b/Riot/Modules/ServiceTerms/Modal/ServiceTermsModalCoordinator.swift
@@ -100,6 +100,10 @@ extension ServiceTermsModalCoordinator: ServiceTermsModalScreenCoordinatorDelega
         self.showPolicy(policy: policy)
     }
 
+    func serviceTermsModalScreenCoordinatorDidDecline(_ coordinator: ServiceTermsModalScreenCoordinatorType) {
+        self.delegate?.serviceTermsModalCoordinatorDidDecline(self)
+    }
+
     func serviceTermsModalScreenCoordinatorDidCancel(_ coordinator: ServiceTermsModalScreenCoordinatorType) {
         self.delegate?.serviceTermsModalCoordinatorDidCancel(self)
     }

--- a/Riot/Modules/ServiceTerms/Modal/ServiceTermsModalCoordinator.swift
+++ b/Riot/Modules/ServiceTerms/Modal/ServiceTermsModalCoordinator.swift
@@ -28,6 +28,7 @@ final class ServiceTermsModalCoordinator: ServiceTermsModalCoordinatorType {
     private let navigationRouter: NavigationRouterType
     private let session: MXSession
     private let serviceTerms: MXServiceTerms
+    private let outOfContext: Bool
     
     // MARK: Public
 
@@ -37,10 +38,11 @@ final class ServiceTermsModalCoordinator: ServiceTermsModalCoordinatorType {
     weak var delegate: ServiceTermsModalCoordinatorDelegate?
     
     // MARK: - Setup
-    init(session: MXSession, baseUrl: String, serviceType: MXServiceType, accessToken: String) {
+    init(session: MXSession, baseUrl: String, serviceType: MXServiceType, outOfContext: Bool, accessToken: String) {
         self.navigationRouter = NavigationRouter(navigationController: RiotNavigationController())
         self.session = session
         self.serviceTerms = MXServiceTerms(baseUrl: baseUrl, serviceType: serviceType, matrixSession: session, accessToken: accessToken)
+        self.outOfContext = outOfContext
     }
     
     // MARK: - Public methods
@@ -62,7 +64,7 @@ final class ServiceTermsModalCoordinator: ServiceTermsModalCoordinatorType {
     // MARK: - Private methods
 
     private func createServiceTermsModalLoadTermsScreenCoordinator() -> ServiceTermsModalScreenCoordinator {
-        let coordinator = ServiceTermsModalScreenCoordinator(serviceTerms: self.serviceTerms)
+        let coordinator = ServiceTermsModalScreenCoordinator(serviceTerms: self.serviceTerms, outOfContext: self.outOfContext)
         coordinator.delegate = self
         return coordinator
     }

--- a/Riot/Modules/ServiceTerms/Modal/ServiceTermsModalCoordinatorBridgePresenter.swift
+++ b/Riot/Modules/ServiceTerms/Modal/ServiceTermsModalCoordinatorBridgePresenter.swift
@@ -35,6 +35,7 @@ final class ServiceTermsModalCoordinatorBridgePresenter: NSObject {
     private let session: MXSession
     private let baseUrl: String
     private let serviceType: MXServiceType
+    private let outOfContext: Bool
     private let accessToken: String
     private var coordinator: ServiceTermsModalCoordinator?
     
@@ -48,10 +49,11 @@ final class ServiceTermsModalCoordinatorBridgePresenter: NSObject {
     
     // MARK: - Setup
     
-    init(session: MXSession, baseUrl: String, serviceType: MXServiceType, accessToken: String) {
+    init(session: MXSession, baseUrl: String, serviceType: MXServiceType, outOfContext: Bool = false, accessToken: String) {
         self.session = session
         self.baseUrl = baseUrl
         self.serviceType = serviceType
+        self.outOfContext = outOfContext
         self.accessToken = accessToken
         super.init()
     }
@@ -64,7 +66,7 @@ final class ServiceTermsModalCoordinatorBridgePresenter: NSObject {
     // }
     
     func present(from viewController: UIViewController, animated: Bool) {
-        let serviceTermsModalCoordinator = ServiceTermsModalCoordinator(session: self.session, baseUrl: self.baseUrl, serviceType: self.serviceType, accessToken: accessToken)
+        let serviceTermsModalCoordinator = ServiceTermsModalCoordinator(session: self.session, baseUrl: self.baseUrl, serviceType: self.serviceType, outOfContext: self.outOfContext, accessToken: accessToken)
         serviceTermsModalCoordinator.delegate = self
         viewController.present(serviceTermsModalCoordinator.toPresentable(), animated: animated, completion: nil)
         serviceTermsModalCoordinator.start()

--- a/Riot/Modules/ServiceTerms/Modal/ServiceTermsModalCoordinatorBridgePresenter.swift
+++ b/Riot/Modules/ServiceTerms/Modal/ServiceTermsModalCoordinatorBridgePresenter.swift
@@ -20,6 +20,7 @@ import Foundation
 
 @objc protocol ServiceTermsModalCoordinatorBridgePresenterDelegate {
     func serviceTermsModalCoordinatorBridgePresenterDelegateDidAccept(_ coordinatorBridgePresenter: ServiceTermsModalCoordinatorBridgePresenter)
+    func serviceTermsModalCoordinatorBridgePresenterDelegateDidDecline(_ coordinatorBridgePresenter: ServiceTermsModalCoordinatorBridgePresenter, session: MXSession)
     func serviceTermsModalCoordinatorBridgePresenterDelegateDidCancel(_ coordinatorBridgePresenter: ServiceTermsModalCoordinatorBridgePresenter)
 }
 
@@ -97,6 +98,10 @@ extension ServiceTermsModalCoordinatorBridgePresenter: ServiceTermsModalCoordina
 
     func serviceTermsModalCoordinatorDidAccept(_ coordinator: ServiceTermsModalCoordinatorType) {
         self.delegate?.serviceTermsModalCoordinatorBridgePresenterDelegateDidAccept(self)
+    }
+
+    func serviceTermsModalCoordinatorDidDecline(_ coordinator: ServiceTermsModalCoordinatorType) {
+        self.delegate?.serviceTermsModalCoordinatorBridgePresenterDelegateDidDecline(self, session: self.session)
     }
 
     func serviceTermsModalCoordinatorDidCancel(_ coordinator: ServiceTermsModalCoordinatorType) {

--- a/Riot/Modules/ServiceTerms/Modal/ServiceTermsModalCoordinatorType.swift
+++ b/Riot/Modules/ServiceTerms/Modal/ServiceTermsModalCoordinatorType.swift
@@ -20,6 +20,7 @@ import Foundation
 
 protocol ServiceTermsModalCoordinatorDelegate: class {
     func serviceTermsModalCoordinatorDidAccept(_ coordinator: ServiceTermsModalCoordinatorType)
+    func serviceTermsModalCoordinatorDidDecline(_ coordinator: ServiceTermsModalCoordinatorType)
     func serviceTermsModalCoordinatorDidCancel(_ coordinator: ServiceTermsModalCoordinatorType)
 }
 

--- a/Riot/Modules/Settings/IdentityServer/SettingsIdentityServerViewController.swift
+++ b/Riot/Modules/Settings/IdentityServer/SettingsIdentityServerViewController.swift
@@ -387,6 +387,10 @@ extension SettingsIdentityServerViewController: ServiceTermsModalCoordinatorBrid
         self.hideTerms(accepted: true)
     }
 
+    func serviceTermsModalCoordinatorBridgePresenterDelegateDidDecline(_ coordinatorBridgePresenter: ServiceTermsModalCoordinatorBridgePresenter, session: MXSession) {
+        self.hideTerms(accepted: false)
+    }
+
     func serviceTermsModalCoordinatorBridgePresenterDelegateDidCancel(_ coordinatorBridgePresenter: ServiceTermsModalCoordinatorBridgePresenter) {
          self.hideTerms(accepted: false)
     }


### PR DESCRIPTION
Fixes #2760 .

The terms screen has now a variant when we have a "terms not signed" error from nowhere (like a background lookup).

![Simulator Screen Shot - iPhone 7 - 2019-10-10 at 09 11 35](https://user-images.githubusercontent.com/8418515/66559502-c4528280-eb55-11e9-903c-51285275d98b.png)

