### PR TITLE
ContactsDataSource: Do not use [MXKContactManager updateMatrixIDsForA…

### DIFF
--- a/Riot/Modules/Contacts/DataSources/ContactsDataSource.m
+++ b/Riot/Modules/Contacts/DataSources/ContactsDataSource.m
@@ -86,13 +86,6 @@
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onContactManagerDidUpdate:) name:kMXKContactManagerDidUpdateMatrixContactsNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onContactManagerDidUpdate:) name:kMXKContactManagerDidUpdateLocalContactsNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onContactManagerDidUpdate:) name:kMXKContactManagerDidUpdateLocalContactMatrixIDsNotification object:nil];
-        
-        // Refresh the matrix identifiers for all the local contacts.
-        if ([CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts] != CNAuthorizationStatusNotDetermined)
-        {
-            // Refresh the matrix identifiers for all the local contacts.
-            [[MXKContactManager sharedManager] updateMatrixIDsForAllLocalContacts];
-        }
     }
     return self;
 }


### PR DESCRIPTION
…llLocalContacts]

MXKContactManager does it already when a new session is added.
