### PR TITLE
Pasteboard: Fix a crash when passing a nil object to UIPasteboard

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in 0.10.1 (2019-XX-XX)
 
 Bug fix:
  * Room cell: The states of direct chat and favorite buttons are reversed in the menu (#2788).
+ * Pasteboard: Fix a crash when passing a nil object to UIPasteboard.
 
 Changes in 0.10.0 (2019-10-11)
 ===============================================

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -2683,7 +2683,7 @@
                                                                }
                                                                else
                                                                {
-                                                                   NSLog(@"[RoomViewController] Contextual menu permalink action failed. Permalink is nil.");
+                                                                   NSLog(@"[RoomViewController] Contextual menu permalink action failed. Permalink is nil room id/event id: %@/%@", selectedEvent.roomId, selectedEvent.eventId);
                                                                }
                                                            }
                                                            
@@ -5290,7 +5290,7 @@
             }
             else
             {
-                NSLog(@"[RoomViewController] Contextual menu copy failed. Text is nil.");
+                NSLog(@"[RoomViewController] Contextual menu copy failed. Text is nil for room id/event id: %@/%@", selectedComponent.event.roomId, selectedComponent.event.eventId);
             }
             
             [self hideContextualMenuAnimated:YES];

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -2677,8 +2677,14 @@
                                                                // Create a matrix.to permalink that is common to all matrix clients
                                                                NSString *permalink = [MXTools permalinkToEvent:selectedEvent.eventId inRoom:selectedEvent.roomId];
                                                                
-                                                               // Create a room matrix.to permalink
-                                                               [[UIPasteboard generalPasteboard] setString:permalink];
+                                                               if (permalink)
+                                                               {
+                                                                   [[UIPasteboard generalPasteboard] setString:permalink];
+                                                               }
+                                                               else
+                                                               {
+                                                                   NSLog(@"[RoomViewController] Contextual menu permalink action failed. Permalink is nil.");
+                                                               }
                                                            }
                                                            
                                                        }]];
@@ -5278,7 +5284,14 @@
             }
             NSString *textMessage = selectedComponent.textMessage;
             
-            [UIPasteboard generalPasteboard].string = textMessage;
+            if (textMessage)
+            {
+                [UIPasteboard generalPasteboard].string = textMessage;
+            }
+            else
+            {
+                NSLog(@"[RoomViewController] Contextual menu copy failed. Text is nil.");
+            }
             
             [self hideContextualMenuAnimated:YES];
         }

--- a/Riot/Modules/Room/Settings/RoomSettingsViewController.m
+++ b/Riot/Modules/Room/Settings/RoomSettingsViewController.m
@@ -674,7 +674,16 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
                                                                typeof(self) self = weakSelf;
                                                                self->currentAlert = nil;
                                                                
-                                                               [[UIPasteboard generalPasteboard] setString:roomIdLabel.text];
+                                                               NSString *roomdId = roomIdLabel.text;
+                                                               
+                                                               if (roomdId)
+                                                               {
+                                                                   [[UIPasteboard generalPasteboard] setString:roomdId];
+                                                               }
+                                                               else
+                                                               {
+                                                                   NSLog(@"[RoomSettingsViewController] Copy room id failed. Room id is nil");
+                                                               }
                                                            }
                                                            
                                                        }]];
@@ -773,7 +782,16 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
                                                                typeof(self) self = weakSelf;
                                                                self->currentAlert = nil;
                                                                
-                                                               [[UIPasteboard generalPasteboard] setString:roomAliasLabel.text];
+                                                               NSString *roomAlias = roomAliasLabel.text;
+                                                               
+                                                               if (roomAlias)
+                                                               {
+                                                                   [[UIPasteboard generalPasteboard] setString:roomAlias];
+                                                               }
+                                                               else
+                                                               {
+                                                                   NSLog(@"[RoomSettingsViewController] Copy room address failed. Room address is nil");
+                                                               }
                                                            }
                                                            
                                                        }]];
@@ -788,7 +806,17 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
                                                                self->currentAlert = nil;
                                                                
                                                                // Create a matrix.to permalink to the room
-                                                               [[UIPasteboard generalPasteboard] setString:[MXTools permalinkToRoom:roomAliasLabel.text]];
+                                                               
+                                                               NSString *permalink = [MXTools permalinkToRoom:roomAliasLabel.text];
+                                                               
+                                                               if (permalink)
+                                                               {
+                                                                   [[UIPasteboard generalPasteboard] setString:permalink];
+                                                               }
+                                                               else
+                                                               {
+                                                                   NSLog(@"[RoomSettingsViewController] Copy room URL failed. Room URL is nil");
+                                                               }
                                                            }
                                                            
                                                        }]];


### PR DESCRIPTION
Passing nil to `-[UIPasteboard setString:]` causes a crash whereas `string` property is nullable (See Radar issue https://openradar.appspot.com/36063433).