### PR TITLE
BF: Tab bar icons are not centered vertically on iOS 13

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Bug fix:
  * RoomVC: Fix crash occurring when tap on an unsent media with retrieved event equal to nil.
  * Emoji Picker: Background color is not white (#2630).
  * Device Verification: Selecting 'start verification' from a keyshare request wedges you in an entirely blank verification screen (#2504).
+ * Tab bar icons are not centered vertically on iOS 13 (#2802).
 
 Changes in 0.10.0 (2019-10-11)
 ===============================================

--- a/Riot/Modules/TabBar/MasterTabBarController.m
+++ b/Riot/Modules/TabBar/MasterTabBarController.m
@@ -97,7 +97,16 @@
     // Adjust the display of the icons in the tabbar.
     for (UITabBarItem *tabBarItem in self.tabBar.items)
     {
-        tabBarItem.imageInsets = UIEdgeInsetsMake(5, 0, -5, 0);
+        if (@available(iOS 13.0, *))
+        {
+            // Fix iOS 13 misalignment tab bar images. Some titles are nil and other empty strings. Nil title behaves as if a non-empty title was set.
+            // Note: However no need to modify imageInsets property on iOS 13.
+            tabBarItem.title = @"";            
+        }
+        else
+        {
+            tabBarItem.imageInsets = UIEdgeInsetsMake(5, 0, -5, 0);
+        }
     }
     
     childViewControllers = [NSMutableArray array];


### PR DESCRIPTION
Fix #2802

![image](https://user-images.githubusercontent.com/2205780/68307572-c69ff200-00ab-11ea-9f7d-79552685835b.png)
