### PR TITLE
Device Verification: Stay in infinite waiting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes in 0.10.4 (2019-xx-xx)
 Improvements:
  * ON/OFF Cross-signing development in a Lab setting (#2855).
 
+Bug fix:
+ * Device Verification: Stay in infinite waiting (#2878).
+
 Changes in 0.10.3 (2019-12-05)
 ===============================================
 

--- a/Riot/Modules/DeviceVerification/Start/DeviceVerificationStartViewModel.swift
+++ b/Riot/Modules/DeviceVerification/Start/DeviceVerificationStartViewModel.swift
@@ -115,21 +115,22 @@ final class DeviceVerificationStartViewModel: DeviceVerificationStartViewModelTy
         guard let transaction = notification.object as? MXOutgoingSASTransaction else {
             return
         }
-        
-        self.unregisterTransactionDidStateChangeNotification()
 
         switch transaction.state {
         case MXSASTransactionStateShowSAS:
+            self.unregisterTransactionDidStateChangeNotification()
             self.coordinatorDelegate?.deviceVerificationStartViewModel(self, didCompleteWithOutgoingTransaction: transaction)
         case MXSASTransactionStateCancelled:
             guard let reason = transaction.reasonCancelCode else {
                 return
             }
+            self.unregisterTransactionDidStateChangeNotification()
             self.update(viewState: .cancelled(reason))
         case MXSASTransactionStateCancelledByMe:
             guard let reason = transaction.reasonCancelCode else {
                 return
             }
+            self.unregisterTransactionDidStateChangeNotification()
             self.update(viewState: .cancelledByMe(reason))
         default:
             break

--- a/Riot/Modules/DeviceVerification/Verify/DeviceVerificationVerifyViewModel.swift
+++ b/Riot/Modules/DeviceVerification/Verify/DeviceVerificationVerifyViewModel.swift
@@ -103,11 +103,6 @@ final class DeviceVerificationVerifyViewModel: DeviceVerificationVerifyViewModel
                 return
             }
             self.update(viewState: .error(error))
-        case MXSASTransactionStateCancelled:
-            guard let reason = transaction.reasonCancelCode else {
-                return
-            }
-            self.update(viewState: .cancelled(reason))
         case MXSASTransactionStateCancelledByMe:
             guard let reason = transaction.reasonCancelCode else {
                 return


### PR DESCRIPTION
Closes #2878

Don't stop listening to transaction updates if we receive unexpected events else you block the state machine.
