### PR TITLE
RoomVC: Update encryption decoration with shields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+Changes in 0.10.5 (2020-xx-xx)
+===============================================
+
+Improvements:
+ * ON/OFF Cross-signing development in a Lab setting (#2855).
+ * RoomVC: Update encryption decoration with shields (#2934, #2930, #2906).
+
 Changes in 0.10.4 (2019-12-11)
 ===============================================
 

--- a/Riot/Modules/Room/DataSources/RoomDataSource.h
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.h
@@ -20,6 +20,18 @@
 #import "WidgetManager.h"
 
 /**
+ RoomEncryptionTrustLevel represents the room members trust level in an encrypted room.
+ */
+typedef NS_ENUM(NSUInteger, RoomEncryptionTrustLevel) {
+    RoomEncryptionTrustLevelTrusted,
+    RoomEncryptionTrustLevelWarning,
+    RoomEncryptionTrustLevelNormal,
+    RoomEncryptionTrustLevelUnknown
+};
+
+@protocol RoomDataSourceDelegate;
+
+/**
  The data source for `RoomViewController` in Vector.
  */
 @interface RoomDataSource : MXKRoomDataSource
@@ -38,6 +50,11 @@
  Tell whether timestamp should be displayed on event selection. Default is YES.
  */
 @property(nonatomic) BOOL showBubbleDateTimeOnSelection;
+
+/**
+ Current room members trust level for an encrypted room.
+ */
+@property(nonatomic, readonly) RoomEncryptionTrustLevel encryptionTrustLevel;
 
 /**
  Check if there is an active jitsi widget in the room and return it.
@@ -83,5 +100,11 @@
 - (void)declineVerificationRequestForEventId:(NSString*)eventId
                                      success:(void(^)(void))success
                                      failure:(void(^)(NSError*))failure;
+
+@end
+
+@protocol RoomDataSourceDelegate <MXKDataSourceDelegate>
+
+- (void)roomDataSource:(RoomDataSource*)roomDataSource didUpdateEncryptionTrustLevel:(RoomEncryptionTrustLevel)roomEncryptionTrustLevel;
 
 @end

--- a/Riot/Modules/Room/DataSources/RoomDataSource.m
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.m
@@ -44,6 +44,10 @@
 // Timer used to debounce cells refresh
 @property (nonatomic, strong) NSTimer *refreshCellsTimer;
 
+@property (nonatomic, readonly) id<RoomDataSourceDelegate> roomDataSourceDelegate;
+
+@property(nonatomic, readwrite) RoomEncryptionTrustLevel encryptionTrustLevel;
+
 @end
 
 @implementation RoomDataSource
@@ -83,6 +87,9 @@
         
         [self registerKeyVerificationRequestNotification];
         [self registerDeviceVerificationTransactionNotification];
+        [self registerTrustLevelDidChangeNotifications];
+        
+        self.encryptionTrustLevel = RoomEncryptionTrustLevelUnknown;
     }
     return self;
 }
@@ -105,6 +112,21 @@
             NSLog(@"[MXKRoomDataSource] finalizeRoomDataSource: Cannot retrieve all room members");
         }];
     }
+    
+    if (self.room.summary.isEncrypted)
+    {
+        [self fetchEncryptionTrustedLevel];
+    }
+}
+
+- (id<RoomDataSourceDelegate>)roomDataSourceDelegate
+{
+    if (!self.delegate || ![self.delegate conformsToProtocol:@protocol(RoomDataSourceDelegate)])
+    {
+        return nil;
+    }
+    
+    return ((id<RoomDataSourceDelegate>)(self.delegate));
 }
 
 - (void)updateEventFormatter
@@ -165,6 +187,88 @@
         roomBubbleCellData = (RoomBubbleCellData*)cellData;
         [roomBubbleCellData setNeedsUpdateAdditionalContentHeight];
     }
+}
+
+#pragma mark Encryption trust level
+
+- (void)registerTrustLevelDidChangeNotifications
+{
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(deviceInfoTrustLevelDidChange:) name:MXDeviceInfoTrustLevelDidChangeNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(crossSigningInfoTrustLevelDidChange:) name:MXCrossSigningInfoTrustLevelDidChangeNotification object:nil];
+}
+
+- (void)deviceInfoTrustLevelDidChange:(NSNotification*)notification
+{
+    MXDeviceInfo *deviceInfo = notification.object;
+    
+    NSString *userId = deviceInfo.userId;
+    
+    if (userId)
+    {
+        [self encryptionTrustLevelDidChangeRelatedToUserId:userId];
+    }
+}
+
+- (void)crossSigningInfoTrustLevelDidChange:(NSNotification*)notification
+{
+    MXCrossSigningInfo *crossSigningInfo = notification.object;
+    
+    NSString *userId = crossSigningInfo.userId;
+    
+    if (userId)
+    {
+        [self encryptionTrustLevelDidChangeRelatedToUserId:userId];
+    }
+}
+
+- (void)fetchEncryptionTrustedLevel
+{
+    [self encryptionTrustLevelDidChangeRelatedToUserId:self.mxSession.myUser.userId];
+}
+
+- (void)encryptionTrustLevelDidChangeRelatedToUserId:(NSString*)userId
+{
+    if (!self.room.summary.isEncrypted)
+    {
+        return;
+    }
+    
+    [self.room members:^(MXRoomMembers *roomMembers) {
+        MXRoomMember *roomMember = [roomMembers memberWithUserId:userId];
+        
+        // If user belongs to the room refresh the trust level
+        if (roomMember)
+        {
+            [self.room trustedMembersProgressWithSuccess:^(NSProgress *trustedMembersProgress) {
+                
+                RoomEncryptionTrustLevel roomEncryptionTrustLevel;
+                
+                double trustedMembersPercentage = trustedMembersProgress.fractionCompleted;
+                
+                if (trustedMembersPercentage >= 1.0)
+                {
+                    roomEncryptionTrustLevel = RoomEncryptionTrustLevelTrusted;
+                }
+                else if (trustedMembersPercentage == 0.0)
+                {
+                    roomEncryptionTrustLevel = RoomEncryptionTrustLevelNormal;
+                }
+                else
+                {
+                    roomEncryptionTrustLevel = RoomEncryptionTrustLevelWarning;
+                }
+                
+                self.encryptionTrustLevel = roomEncryptionTrustLevel;
+                [self.roomDataSourceDelegate roomDataSource:self didUpdateEncryptionTrustLevel:roomEncryptionTrustLevel];
+                
+            } failure:^(NSError *error) {
+                NSLog(@"[RoomDataSource] trustLevelDidChangeRelatedToUserId fails to retrieve room members trusted progress");
+            }];
+        }
+        
+    } failure:^(NSError *error) {
+        NSLog(@"[RoomDataSource] trustLevelDidChangeRelatedToUserId fails to retrieve room members");
+    }];
 }
 
 #pragma  mark -

--- a/Riot/Modules/Room/DataSources/RoomDataSource.m
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.m
@@ -239,7 +239,7 @@
         // If user belongs to the room refresh the trust level
         if (roomMember)
         {            
-            [self.room trustLevelSummaryWithSuccess:^(MXUsersTrustLevelSummary *usersTrustLevelSummary) {
+            [self.room membersTrustLevelSummaryWithSuccess:^(MXUsersTrustLevelSummary *usersTrustLevelSummary) {
                 
                 RoomEncryptionTrustLevel roomEncryptionTrustLevel;
                 

--- a/Riot/Modules/Room/DataSources/RoomDataSource.m
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.m
@@ -238,18 +238,18 @@
         
         // If user belongs to the room refresh the trust level
         if (roomMember)
-        {
-            [self.room trustedMembersProgressWithSuccess:^(NSProgress *trustedMembersProgress) {
+        {            
+            [self.room trustLevelSummaryWithSuccess:^(MXUsersTrustLevelSummary *usersTrustLevelSummary) {
                 
                 RoomEncryptionTrustLevel roomEncryptionTrustLevel;
                 
-                double trustedMembersPercentage = trustedMembersProgress.fractionCompleted;
+                double trustedDevicesPercentage = usersTrustLevelSummary.trustedDevicesProgress.fractionCompleted;
                 
-                if (trustedMembersPercentage >= 1.0)
+                if (trustedDevicesPercentage >= 1.0)
                 {
                     roomEncryptionTrustLevel = RoomEncryptionTrustLevelTrusted;
                 }
-                else if (trustedMembersPercentage == 0.0)
+                else if (trustedDevicesPercentage == 0.0)
                 {
                     roomEncryptionTrustLevel = RoomEncryptionTrustLevelNormal;
                 }

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -1647,6 +1647,9 @@
             case RoomEncryptionTrustLevelTrusted:
                 encryptionIconName = @"encryption_trusted";
                 break;
+            case RoomEncryptionTrustLevelUnknown:
+                encryptionIconName = @"encryption_normal";
+                break;
             default:
                 break;
         }

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -125,7 +125,8 @@
 
 @interface RoomViewController () <UISearchBarDelegate, UIGestureRecognizerDelegate, UIScrollViewAccessibilityDelegate, RoomTitleViewTapGestureDelegate, RoomParticipantsViewControllerDelegate, MXKRoomMemberDetailsViewControllerDelegate, ContactsTableViewControllerDelegate, MXServerNoticesDelegate, RoomContextualMenuViewControllerDelegate,
     ReactionsMenuViewModelCoordinatorDelegate, EditHistoryCoordinatorBridgePresenterDelegate, MXKDocumentPickerPresenterDelegate, EmojiPickerCoordinatorBridgePresenterDelegate,
-    ReactionHistoryCoordinatorBridgePresenterDelegate, CameraPresenterDelegate, MediaPickerCoordinatorBridgePresenterDelegate>
+    ReactionHistoryCoordinatorBridgePresenterDelegate, CameraPresenterDelegate, MediaPickerCoordinatorBridgePresenterDelegate,
+    RoomDataSourceDelegate>
 {
     // The expanded header
     ExpandedRoomTitleView *expandedHeader;
@@ -1421,6 +1422,11 @@
     return NO;
 }
 
+- (BOOL)isEncryptionEnabled
+{
+    return self.roomDataSource.room.summary.isEncrypted && self.mainSession.crypto != nil;
+}
+
 - (void)refreshRoomTitle
 {
     if (rightBarButtonItems && !self.navigationItem.rightBarButtonItems)
@@ -1541,12 +1547,8 @@
             roomInputToolbarView.supportCallOption &= ([[AppDelegate theDelegate] callStatusBarWindow] == nil);
         }
         
-        // Check whether the encryption is enabled in the room
-        if (self.roomDataSource.room.summary.isEncrypted)
-        {
-            // Encrypt the user's messages as soon as the user supports the encryption?
-            roomInputToolbarView.isEncryptionEnabled = (self.mainSession.crypto != nil);
-        }
+        // Update encryption decoration if needed
+        [self updateEncryptionDecorationForRoomInputToolbar:roomInputToolbarView];
     }
     else if (self.inputToolbarView && [self.inputToolbarView isKindOfClass:DisabledRoomInputToolbarView.class])
     {
@@ -1624,6 +1626,61 @@
     [UIView setAnimationsEnabled:NO];
     [self roomInputToolbarView:self.inputToolbarView heightDidChanged:height completion:nil];
     [UIView setAnimationsEnabled:YES];
+}
+
+- (UIImage*)roomEncryptionBadgeImage
+{
+    NSString *encryptionIconName;
+    UIImage *encryptionIcon;
+    
+    if (self.isEncryptionEnabled)
+    {
+        RoomEncryptionTrustLevel roomEncryptionTrustLevel = ((RoomDataSource*)self.roomDataSource).encryptionTrustLevel;
+        
+        switch (roomEncryptionTrustLevel) {
+            case RoomEncryptionTrustLevelWarning:
+                encryptionIconName = @"encryption_warning";
+                break;
+            case RoomEncryptionTrustLevelNormal:
+                encryptionIconName = @"encryption_normal";
+                break;
+            case RoomEncryptionTrustLevelTrusted:
+                encryptionIconName = @"encryption_trusted";
+                break;
+            default:
+                break;
+        }
+    }
+    
+    if (encryptionIconName)
+    {
+        encryptionIcon = [UIImage imageNamed:encryptionIconName];
+    }
+    
+    return encryptionIcon;
+}
+
+- (void)updateInputToolbarEncryptionDecoration
+{
+    if (self.inputToolbarView && [self.inputToolbarView isKindOfClass:RoomInputToolbarView.class])
+    {
+        RoomInputToolbarView *roomInputToolbarView = (RoomInputToolbarView*)self.inputToolbarView;
+        [self updateEncryptionDecorationForRoomInputToolbar:roomInputToolbarView];
+    }
+}
+
+- (void)updateExpandedHeaderEncryptionDecoration
+{
+    if (self->expandedHeader)
+    {
+        self->expandedHeader.roomAvatarBadgeImageView.image = self.roomEncryptionBadgeImage;
+    }
+}
+
+- (void)updateEncryptionDecorationForRoomInputToolbar:(RoomInputToolbarView*)roomInputToolbarView
+{
+    roomInputToolbarView.isEncryptionEnabled = self.isEncryptionEnabled;
+    roomInputToolbarView.encryptedRoomIcon.image = self.roomEncryptionBadgeImage;
 }
 
 - (void)handleLongPressFromCell:(id<MXKCellRendering>)cell withTappedEvent:(MXEvent*)event
@@ -1725,8 +1782,11 @@
             // Note the avatar title view does not define tap gesture.
             
             expandedHeader.roomAvatar.alpha = 0.0;
+            expandedHeader.roomAvatarBadgeImageView.alpha = 0.0;
             
             shadowImage = [[UIImage alloc] init];
+            
+            [self updateExpandedHeaderEncryptionDecoration];
             
             // Dismiss the keyboard when header is expanded.
             [self.inputToolbarView dismissKeyboard];
@@ -1758,7 +1818,8 @@
                              self.bubblesTableViewTopConstraint.constant = (isVisible ? self.expandedHeaderContainerHeightConstraint.constant - self.bubblesTableView.mxk_adjustedContentInset.top : 0);
                              self.jumpToLastUnreadBannerContainerTopConstraint.constant = (isVisible ? self.expandedHeaderContainerHeightConstraint.constant : self.bubblesTableView.mxk_adjustedContentInset.top);
                              
-                             expandedHeader.roomAvatar.alpha = 1;
+                             self->expandedHeader.roomAvatar.alpha = 1;
+                             self->expandedHeader.roomAvatarBadgeImageView.alpha = 1;
                              
                              // Force to render the view
                              [self forceLayoutRefresh];
@@ -3191,6 +3252,14 @@
     }
     
     return roomInputToolbarView;
+}
+
+#pragma mark - RoomDataSourceDelegate
+
+- (void)roomDataSource:(RoomDataSource *)roomDataSource didUpdateEncryptionTrustLevel:(RoomEncryptionTrustLevel)roomEncryptionTrustLevel
+{
+    [self updateInputToolbarEncryptionDecoration];
+    [self updateExpandedHeaderEncryptionDecoration];
 }
 
 #pragma mark - Segues

--- a/Riot/Modules/Room/Views/BubbleCells/Encryption/RoomEncryptedDataBubbleCell.m
+++ b/Riot/Modules/Room/Views/BubbleCells/Encryption/RoomEncryptedDataBubbleCell.m
@@ -23,60 +23,55 @@ NSString *const kRoomEncryptedDataBubbleCellTapOnEncryptionIcon = @"kRoomEncrypt
 
 + (UIImage*)encryptionIconForEvent:(MXEvent*)event andSession:(MXSession*)session
 {
-    NSString *encryptionIcon;
+    MXRoom *room = [session roomWithRoomId:event.roomId];
+    BOOL isRoomEncrypted = room.summary.isEncrypted && session.crypto;
+    
+    if (!isRoomEncrypted)
+    {
+        return nil;
+    }
+    
+    NSString *encryptionIconName;
+    UIImage* encryptionIcon;
     
     if (!event.isEncrypted)
     {
-        encryptionIcon = @"e2e_unencrypted";
-        
         if (event.isLocalEvent
-            || event.contentHasBeenEdited)    // Local echo for an edit is clear but uses a true event id, the one of the edited event 
+            || event.contentHasBeenEdited)    // Local echo for an edit is clear but uses a true event id, the one of the edited event
         {
             // Patch: Display the verified icon by default on pending outgoing messages in the encrypted rooms when the encryption is enabled
-            MXRoom *room = [session roomWithRoomId:event.roomId];
-            if (room.summary.isEncrypted && session.crypto)
-            {
-                // The outgoing message are encrypted by default
-                encryptionIcon = @"e2e_verified";
-            }
+            // The outgoing message are encrypted by default
+            encryptionIconName = nil;
+        }
+        else
+        {
+            encryptionIconName = @"encryption_warning";
         }
     }
     else if (event.decryptionError)
     {
-        encryptionIcon = @"e2e_blocked";
+        encryptionIconName = @"encryption_warning";
     }
     else
     {
         MXDeviceInfo *deviceInfo = [session.crypto eventDeviceInfo:event];
         
-        if (deviceInfo)
+        if (deviceInfo.trustLevel.isVerified)
         {
-            switch (deviceInfo.trustLevel.localVerificationStatus)
-            {
-                case MXDeviceUnknown:
-                case MXDeviceUnverified:
-                {
-                    encryptionIcon = @"e2e_warning";
-                    break;
-                }
-                case MXDeviceVerified:
-                {
-                    encryptionIcon = @"e2e_verified";
-                    break;
-                }
-                default:
-                    break;
-            }
+            encryptionIconName = nil;
+        }
+        else
+        {
+            encryptionIconName = @"encryption_warning";
         }
     }
     
-    if (!encryptionIcon)
+    if (encryptionIconName)
     {
-        // Use the warning icon by default
-        encryptionIcon = @"e2e_warning";
+         encryptionIcon = [UIImage imageNamed:encryptionIconName];
     }
     
-    return [UIImage imageNamed:encryptionIcon];
+    return encryptionIcon;
 }
 
 + (void)addEncryptionStatusFromBubbleData:(MXKRoomBubbleCellData *)bubbleData inContainerView:(UIView *)containerView
@@ -104,19 +99,23 @@ NSString *const kRoomEncryptedDataBubbleCellTapOnEncryptionIcon = @"kRoomEncrypt
         }
     
         UIImage *icon = [RoomEncryptedDataBubbleCell encryptionIconForEvent:component.event andSession:bubbleData.mxSession];
-        UIImageView *encryptStatusImageView = [[UIImageView alloc] initWithImage:icon];
         
-        CGRect frame = encryptStatusImageView.frame;
-        frame.origin.y = component.position.y + 3;
-        encryptStatusImageView.frame = frame;
-        
-        CGPoint center = encryptStatusImageView.center;
-        center.x = containerView.frame.size.width / 2;
-        encryptStatusImageView.center = center;
-        
-        encryptStatusImageView.tag = componentIndex;
-        
-        [containerView addSubview:encryptStatusImageView];
+        if (icon)
+        {
+            UIImageView *encryptStatusImageView = [[UIImageView alloc] initWithImage:icon];
+            
+            CGRect frame = encryptStatusImageView.frame;
+            frame.origin.y = component.position.y + 3;
+            encryptStatusImageView.frame = frame;
+            
+            CGPoint center = encryptStatusImageView.center;
+            center.x = containerView.frame.size.width / 2;
+            encryptStatusImageView.center = center;
+            
+            encryptStatusImageView.tag = componentIndex;
+            
+            [containerView addSubview:encryptStatusImageView];
+        }        
     }
 }
 

--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
@@ -128,8 +128,6 @@
     
     if (_isEncryptionEnabled)
     {
-        self.encryptedRoomIcon.image = [UIImage imageNamed:@"e2e_verified"];
-        
         // Check the device screen size before using large placeholder
         if ([GBDeviceInfo deviceInfo].family == GBDeviceFamilyiPad || [GBDeviceInfo deviceInfo].displayInfo.display >= GBDeviceDisplay4p7Inch)
         {
@@ -138,8 +136,6 @@
     }
     else
     {
-        self.encryptedRoomIcon.image = [UIImage imageNamed:@"e2e_unencrypted"];
-        
         // Check the device screen size before using large placeholder
         if ([GBDeviceInfo deviceInfo].family == GBDeviceFamilyiPad || [GBDeviceInfo deviceInfo].displayInfo.display >= GBDeviceDisplay4p7Inch)
         {

--- a/Riot/Modules/Room/Views/Title/Expanded/ExpandedRoomTitleView.h
+++ b/Riot/Modules/Room/Views/Title/Expanded/ExpandedRoomTitleView.h
@@ -19,6 +19,7 @@
 @interface ExpandedRoomTitleView : RoomTitleView
 
 @property (weak, nonatomic) IBOutlet MXKImageView *roomAvatar;
+@property (weak, nonatomic) IBOutlet UIImageView *roomAvatarBadgeImageView;
 @property (weak, nonatomic) IBOutlet UIView *roomAvatarHeaderBackground;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *roomAvatarHeaderBackgroundHeightConstraint;
 

--- a/Riot/Modules/Room/Views/Title/Expanded/ExpandedRoomTitleView.xib
+++ b/Riot/Modules/Room/Views/Title/Expanded/ExpandedRoomTitleView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,11 +27,20 @@
                                 <constraint firstAttribute="width" constant="84" id="Yye-G1-hCH"/>
                             </constraints>
                         </view>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="14n-e5-ix3">
+                            <rect key="frame" x="318" y="71" width="24" height="24"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="14n-e5-ix3" secondAttribute="height" multiplier="1:1" id="g2h-P2-8gQ"/>
+                                <constraint firstAttribute="width" constant="24" id="oSg-O6-MRx"/>
+                            </constraints>
+                        </imageView>
                     </subviews>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <accessibility key="accessibilityConfiguration" identifier="RoomAvatarHeaderBackground"/>
                     <constraints>
+                        <constraint firstItem="14n-e5-ix3" firstAttribute="trailing" secondItem="eEk-n9-4dA" secondAttribute="trailing" id="3fH-JR-GgP"/>
                         <constraint firstAttribute="height" constant="95" id="DzD-aR-3eV"/>
+                        <constraint firstItem="14n-e5-ix3" firstAttribute="bottom" secondItem="eEk-n9-4dA" secondAttribute="bottom" id="Or6-Ka-Yny"/>
                         <constraint firstItem="eEk-n9-4dA" firstAttribute="centerX" secondItem="uSp-YH-L18" secondAttribute="centerX" id="W1w-ZX-f2d"/>
                         <constraint firstAttribute="bottom" secondItem="eEk-n9-4dA" secondAttribute="bottom" id="hXd-bM-Bbb"/>
                     </constraints>
@@ -148,6 +157,7 @@
                 <outlet property="displayNameTextField" destination="6uH-I3-RQg" id="MfX-LQ-C2K"/>
                 <outlet property="membersListIcon" destination="S3Y-wJ-HOe" id="hkf-a4-Ffw"/>
                 <outlet property="roomAvatar" destination="eEk-n9-4dA" id="5jd-Dx-tXE"/>
+                <outlet property="roomAvatarBadgeImageView" destination="14n-e5-ix3" id="ZSS-wz-Oi7"/>
                 <outlet property="roomAvatarHeaderBackground" destination="uSp-YH-L18" id="sfW-ED-5bD"/>
                 <outlet property="roomAvatarHeaderBackgroundHeightConstraint" destination="DzD-aR-3eV" id="SuC-mO-epX"/>
                 <outlet property="roomDetailsMask" destination="MFb-0F-eO8" id="ajK-sr-qf7"/>
@@ -155,10 +165,11 @@
                 <outlet property="roomTopic" destination="qD3-kA-DSI" id="mOj-AU-7LM"/>
                 <outlet property="titleMask" destination="8HH-9b-1yH" id="MFh-3r-I5e"/>
             </connections>
+            <point key="canvasLocation" x="129.59999999999999" y="153.37331334332833"/>
         </view>
     </objects>
     <resources>
-        <image name="add_participant" width="92.800003051757812" height="92.800003051757812"/>
-        <image name="members_list_icon" width="15" height="15"/>
+        <image name="add_participant" width="30" height="30"/>
+        <image name="members_list_icon" width="15" height="12"/>
     </resources>
 </document>


### PR DESCRIPTION
Closes #2934, #2930, #2906.
Requires matrix-org/matrix-ios-sdk/pull/765

![room_e2e_decoration](https://user-images.githubusercontent.com/2205780/72909691-b527c700-3d37-11ea-8caa-f3534ade0169.png)
