### PR TITLE
Negotiate E2E by default for DMs

### DIFF
--- a/Riot/Categories/MXSession+Riot.h
+++ b/Riot/Categories/MXSession+Riot.h
@@ -25,4 +25,18 @@
  */
 - (NSUInteger)riot_missedDiscussionsCount;
 
+/**
+ Decide if E2E must be enabled in a new room with a list users
+
+ @param userIds the list of users;
+
+ @param success A block object called when the operation succeeds.
+ @param failure A block object called when the operation fails.
+
+ @return a MXHTTPOperation instance.
+ */
+- (MXHTTPOperation*)canEnableE2EByDefaultInNewRoomWithUsers:(NSArray<NSString*>*)userIds
+                                                    success:(void (^)(BOOL canEnableE2E))success
+                                                    failure:(void (^)(NSError *error))failure;
+
 @end

--- a/Riot/Categories/MXSession+Riot.m
+++ b/Riot/Categories/MXSession+Riot.m
@@ -17,6 +17,7 @@
 #import "MXSession+Riot.h"
 
 #import "MXRoom+Riot.h"
+#import "Riot-Swift.h"
 
 @implementation MXSession (Riot)
 
@@ -46,6 +47,39 @@
     missedDiscussionsCount += [self invitedRooms].count;
     
     return missedDiscussionsCount;
+}
+
+- (MXHTTPOperation*)canEnableE2EByDefaultInNewRoomWithUsers:(NSArray<NSString*>*)userIds
+                                                    success:(void (^)(BOOL canEnableE2E))success
+                                                    failure:(void (^)(NSError *error))failure
+{
+    MXHTTPOperation *operation;
+    if (RiotSettings.shared.enableCrossSigning)
+    {
+        // Check whether all users have uploaded device keys before.
+        // If so, encryption can be enabled in the new room
+        operation = [self.crypto downloadKeys:userIds forceDownload:NO success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap, NSDictionary<NSString *,MXCrossSigningInfo *> *crossSigningKeysMap) {
+
+            BOOL allUsersHaveDeviceKeys = YES;
+            for (NSString *userId in userIds)
+            {
+                if ([usersDevicesInfoMap deviceIdsForUser:userId].count == 0)
+                {
+                    allUsersHaveDeviceKeys = NO;
+                    break;
+                }
+            }
+
+            success(allUsersHaveDeviceKeys);
+
+        } failure:failure];
+    }
+    else
+    {
+        success(NO);
+    }
+
+    return operation;
 }
 
 @end

--- a/Riot/Modules/StartChat/StartChatViewController.m
+++ b/Riot/Modules/StartChat/StartChatViewController.m
@@ -19,6 +19,7 @@
 
 #import "AppDelegate.h"
 #import "Riot-Swift.h"
+#import "MXSession+Riot.h"
 
 @interface StartChatViewController () <UITableViewDataSource, UISearchBarDelegate, ContactsTableViewControllerDelegate>
 {
@@ -571,36 +572,51 @@
         {
             // Ensure direct chat are created with equal ops on both sides (the trusted_private_chat preset)
             MXRoomPreset preset = (isDirect ? kMXRoomPresetTrustedPrivateChat : nil);
-            
-            // Create new room
-            MXRoomCreationParameters *roomCreationParameters = [MXRoomCreationParameters new];
-            roomCreationParameters.visibility = kMXRoomDirectoryVisibilityPrivate;
-            roomCreationParameters.inviteArray = inviteArray.count ? inviteArray : nil;
-            roomCreationParameters.invite3PIDArray = invite3PIDArray.count ? invite3PIDArray : nil;
-            roomCreationParameters.isDirect = isDirect;
-            roomCreationParameters.preset = preset;
 
-            roomCreationRequest = [self.mainSession createRoomWithParameters:roomCreationParameters success:^(MXRoom *room) {
+            MXWeakify(self);
+            void (^onFailure)(NSError *) = ^(NSError *error){
+                MXStrongifyAndReturnIfNil(self);
 
-                roomCreationRequest = nil;
+                self->createBarButtonItem.enabled = YES;
 
-                [self stopActivityIndicator];
-
-                [[AppDelegate theDelegate] showRoom:room.roomId andEventId:nil withMatrixSession:self.mainSession];
-
-            } failure:^(NSError *error) {
-
-                createBarButtonItem.enabled = YES;
-
-                roomCreationRequest = nil;
+                self->roomCreationRequest = nil;
                 [self stopActivityIndicator];
 
                 NSLog(@"[StartChatViewController] Create room failed");
 
                 // Alert user
                 [[AppDelegate theDelegate] showErrorAsAlert:error];
+            };
 
-            }];
+            [self.mainSession canEnableE2EByDefaultInNewRoomWithUsers:inviteArray success:^(BOOL canEnableE2E) {
+                MXStrongifyAndReturnIfNil(self);
+
+                // Create new room
+                MXRoomCreationParameters *roomCreationParameters = [MXRoomCreationParameters new];
+                roomCreationParameters.visibility = kMXRoomDirectoryVisibilityPrivate;
+                roomCreationParameters.inviteArray = inviteArray.count ? inviteArray : nil;
+                roomCreationParameters.invite3PIDArray = invite3PIDArray.count ? invite3PIDArray : nil;
+                roomCreationParameters.isDirect = isDirect;
+                roomCreationParameters.preset = preset;
+
+                if (canEnableE2E && roomCreationParameters.invite3PIDArray == nil)
+                {
+                    roomCreationParameters.initialStateEvents = @[
+                                                                  [MXRoomCreationParameters initialStateEventForEncryptionWithAlgorithm:kMXCryptoMegolmAlgorithm
+                                                                   ]];
+                }
+
+                self->roomCreationRequest = [self.mainSession createRoomWithParameters:roomCreationParameters success:^(MXRoom *room) {
+
+                    self->roomCreationRequest = nil;
+
+                    [self stopActivityIndicator];
+
+                    [[AppDelegate theDelegate] showRoom:room.roomId andEventId:nil withMatrixSession:self.mainSession];
+
+                } failure:onFailure];
+
+            } failure:onFailure];
         }
     }
     else if (sender == self.navigationItem.leftBarButtonItem)


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-ios-sdk/pull/769
Closes #2943

This screenshot shows that e2e was enabled during the room creation (shields look wrong but this is another issue):
![image](https://user-images.githubusercontent.com/8418515/73271297-9b2b3000-41e0-11ea-8eba-63457feefeb1.png)
