### PR TITLE
Settings: LABS: Keep only one flag for cross-signing

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -458,8 +458,7 @@
 "settings_labs_room_members_lazy_loading_error_message" = "Your homeserver does not support lazy loading of room members yet. Try later.";
 "settings_labs_create_conference_with_jitsi" = "Create conference calls with jitsi";
 "settings_labs_message_reaction" = "React to messages with emoji";
-"settings_labs_dm_key_verification" = "Key verification by direct message";
-"settings_labs_cross_signing" = "Cross-Signing";
+"settings_labs_enable_cross_signing" = "Enable cross-signing to verify per-user instead of per-device (in development)";
 
 "settings_version" = "Version %@";
 "settings_olm_version" = "Olm Version %@";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -3022,14 +3022,6 @@ internal enum VectorL10n {
   internal static var settingsLabsCreateConferenceWithJitsi: String { 
     return VectorL10n.tr("Vector", "settings_labs_create_conference_with_jitsi") 
   }
-  /// Cross-Signing
-  internal static var settingsLabsCrossSigning: String { 
-    return VectorL10n.tr("Vector", "settings_labs_cross_signing") 
-  }
-  /// Key verification by direct message
-  internal static var settingsLabsDmKeyVerification: String { 
-    return VectorL10n.tr("Vector", "settings_labs_dm_key_verification") 
-  }
   /// End-to-End Encryption
   internal static var settingsLabsE2eEncryption: String { 
     return VectorL10n.tr("Vector", "settings_labs_e2e_encryption") 
@@ -3037,6 +3029,10 @@ internal enum VectorL10n {
   /// To finish setting up encryption you must log in again.
   internal static var settingsLabsE2eEncryptionPromptMessage: String { 
     return VectorL10n.tr("Vector", "settings_labs_e2e_encryption_prompt_message") 
+  }
+  /// Enable cross-signing to verify per-user instead of per-device (in development)
+  internal static var settingsLabsEnableCrossSigning: String { 
+    return VectorL10n.tr("Vector", "settings_labs_enable_cross_signing") 
   }
   /// React to messages with emoji
   internal static var settingsLabsMessageReaction: String { 

--- a/Riot/Managers/Settings/RiotSettings.swift
+++ b/Riot/Managers/Settings/RiotSettings.swift
@@ -123,14 +123,6 @@ final class RiotSettings: NSObject {
             UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.createConferenceCallsWithJitsi)
         }
     }
-    
-    var enableDMKeyVerification: Bool {
-        get {
-            return UserDefaults.standard.bool(forKey: UserDefaultsKeys.enableDMKeyVerification)
-        } set {
-            UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.enableDMKeyVerification)
-        }
-    }
 
     var enableCrossSigning: Bool {
         get {

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -136,10 +136,8 @@ enum
 {
     LABS_USE_ROOM_MEMBERS_LAZY_LOADING_INDEX = 0,
     LABS_USE_JITSI_WIDGET_INDEX,
-    LABS_COUNT,     // TODO: Remove it once features exist
-    LABS_DM_KEY_VERIFICATION_INDEX,
     LABS_CROSS_SIGNING_INDEX,
-//    LABS_COUNT
+    LABS_COUNT
 };
 
 enum {
@@ -2429,25 +2427,14 @@ SettingsIdentityServerCoordinatorBridgePresenterDelegate>
 
             cell = labelAndSwitchCell;
         }
-        else if (row == LABS_DM_KEY_VERIFICATION_INDEX)
-        {
-            MXKTableViewCellWithLabelAndSwitch* labelAndSwitchCell = [self getLabelAndSwitchCell:tableView forIndexPath:indexPath];
-            
-            labelAndSwitchCell.mxkLabel.text = NSLocalizedStringFromTable(@"settings_labs_dm_key_verification", @"Vector", nil);
-            labelAndSwitchCell.mxkSwitch.on = RiotSettings.shared.enableDMKeyVerification;
-            labelAndSwitchCell.mxkSwitch.onTintColor = ThemeService.shared.theme.tintColor;
-            
-            [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleLabsDMKeyVerification:) forControlEvents:UIControlEventTouchUpInside];
-            
-            cell = labelAndSwitchCell;
-        }
         else if (row == LABS_CROSS_SIGNING_INDEX)
         {
             MXKTableViewCellWithLabelAndSwitch* labelAndSwitchCell = [self getLabelAndSwitchCell:tableView forIndexPath:indexPath];
             
-            labelAndSwitchCell.mxkLabel.text = NSLocalizedStringFromTable(@"settings_labs_cross_signing", @"Vector", nil);
+            labelAndSwitchCell.mxkLabel.text = NSLocalizedStringFromTable(@"settings_labs_enable_cross_signing", @"Vector", nil);
             labelAndSwitchCell.mxkSwitch.on = RiotSettings.shared.enableCrossSigning;
             labelAndSwitchCell.mxkSwitch.onTintColor = ThemeService.shared.theme.tintColor;
+            labelAndSwitchCell.mxkSwitch.enabled = YES;
             
             [labelAndSwitchCell.mxkSwitch addTarget:self action:@selector(toggleLabsCrossSigning:) forControlEvents:UIControlEventTouchUpInside];
             
@@ -3398,13 +3385,6 @@ SettingsIdentityServerCoordinatorBridgePresenterDelegate>
 
         [self.tableView reloadData];
     }
-}
-    
-- (void)toggleLabsDMKeyVerification:(id)sender
-{
-    UISwitch *switchButton = (UISwitch*)sender;
-    
-    RiotSettings.shared.enableDMKeyVerification = switchButton.isOn;
 }
     
 - (void)toggleLabsCrossSigning:(id)sender


### PR DESCRIPTION
Use the same copy as riot-web:

<img width="320" alt="Screenshot 2020-01-28 at 16 52 41" src="https://user-images.githubusercontent.com/8418515/73280324-9ff6e080-41ee-11ea-95af-cd8a3318125d.png">
