### PR TITLE
Enable e2e by default for DM regardless the cross-signing settings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,9 @@ Changes in 0.11.0 (2020-xx-xx)
 ===============================================
 
 Improvements:
- * ON/OFF Cross-signing development in a Lab setting (#2855).
+ * Enable e2e by default for DM (#2943).
  * RoomVC: Update encryption decoration with shields (#2934, #2930, #2906).
+ * Settings: ON/OFF Cross-signing development in a Lab setting (#2855).
  * Settings: Remove "End-to-End Encryption" from the LABS section (#2941).
 
 Changes in 0.10.4 (2019-12-11)

--- a/Riot/Categories/MXSession+Riot.m
+++ b/Riot/Categories/MXSession+Riot.m
@@ -53,33 +53,23 @@
                                                     success:(void (^)(BOOL canEnableE2E))success
                                                     failure:(void (^)(NSError *error))failure
 {
-    MXHTTPOperation *operation;
-    if (RiotSettings.shared.enableCrossSigning)
-    {
-        // Check whether all users have uploaded device keys before.
-        // If so, encryption can be enabled in the new room
-        operation = [self.crypto downloadKeys:userIds forceDownload:NO success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap, NSDictionary<NSString *,MXCrossSigningInfo *> *crossSigningKeysMap) {
-
-            BOOL allUsersHaveDeviceKeys = YES;
-            for (NSString *userId in userIds)
+    // Check whether all users have uploaded device keys before.
+    // If so, encryption can be enabled in the new room
+    return [self.crypto downloadKeys:userIds forceDownload:NO success:^(MXUsersDevicesMap<MXDeviceInfo *> *usersDevicesInfoMap, NSDictionary<NSString *,MXCrossSigningInfo *> *crossSigningKeysMap) {
+        
+        BOOL allUsersHaveDeviceKeys = YES;
+        for (NSString *userId in userIds)
+        {
+            if ([usersDevicesInfoMap deviceIdsForUser:userId].count == 0)
             {
-                if ([usersDevicesInfoMap deviceIdsForUser:userId].count == 0)
-                {
-                    allUsersHaveDeviceKeys = NO;
-                    break;
-                }
+                allUsersHaveDeviceKeys = NO;
+                break;
             }
-
-            success(allUsersHaveDeviceKeys);
-
-        } failure:failure];
-    }
-    else
-    {
-        success(NO);
-    }
-
-    return operation;
+        }
+        
+        success(allUsersHaveDeviceKeys);
+        
+    } failure:failure];
 }
 
 @end


### PR DESCRIPTION
This is to risky. I often forgot to enable this flag