### PR TITLE
MXCrypto: Rename MXDeviceVerificationManager to MXKeyVerificationManager

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -699,7 +699,7 @@ NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey = @"AppDe
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyBackupStateDidChangeNotification:) name:kMXKeyBackupDidStateChangeNotification object:nil];
     
     // Observe key verification request
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyVerificationRequestDidChangeNotification:) name:MXDeviceVerificationManagerNewRequestNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyVerificationRequestDidChangeNotification:) name:MXKeyVerificationManagerNewRequestNotification object:nil];
 
     // Resume all existing matrix sessions
     NSArray *mxAccounts = [MXKAccountManager sharedManager].activeAccounts;
@@ -728,7 +728,7 @@ NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey = @"AppDe
     
     NSDictionary *userInfo = notification.userInfo;
     
-    MXKeyVerificationRequest *keyVerificationRequest = userInfo[MXDeviceVerificationManagerNotificationRequestKey];
+    MXKeyVerificationRequest *keyVerificationRequest = userInfo[MXKeyVerificationManagerNotificationRequestKey];
     
     if ([keyVerificationRequest isKindOfClass:MXKeyVerificationByDMRequest.class])
     {
@@ -1779,7 +1779,7 @@ NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey = @"AppDe
                 }
                 else if (room.isDirect && isIncomingEvent && [msgType isEqualToString:kMXMessageTypeKeyVerificationRequest])
                 {
-                    [account.mxSession.crypto.deviceVerificationManager keyVerificationFromKeyVerificationEvent:event
+                    [account.mxSession.crypto.keyVerificationManager keyVerificationFromKeyVerificationEvent:event
                                                                                                         success:^(MXKeyVerification * _Nonnull keyVerification)
                      {
                          if (keyVerification && keyVerification.state == MXKeyVerificationRequestStatePending)
@@ -4785,12 +4785,12 @@ NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey = @"AppDe
 - (void)enableIncomingDeviceVerificationObserver:(MXSession*)mxSession
 {
     incomingDeviceVerificationObserver =
-    [[NSNotificationCenter defaultCenter] addObserverForName:MXDeviceVerificationManagerNewTransactionNotification
-                                                      object:mxSession.crypto.deviceVerificationManager
+    [[NSNotificationCenter defaultCenter] addObserverForName:MXKeyVerificationManagerNewTransactionNotification
+                                                      object:mxSession.crypto.keyVerificationManager
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(NSNotification *notif)
      {
-         NSObject *object = notif.userInfo[MXDeviceVerificationManagerNotificationTransactionKey];
+         NSObject *object = notif.userInfo[MXKeyVerificationManagerNotificationTransactionKey];
          if ([object isKindOfClass:MXIncomingSASTransaction.class])
          {
              [self checkPendingIncomingDeviceVerificationsInSession:mxSession];
@@ -4816,11 +4816,11 @@ NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey = @"AppDe
         return;
     }
 
-    [mxSession.crypto.deviceVerificationManager transactions:^(NSArray<MXDeviceVerificationTransaction *> * _Nonnull transactions) {
+    [mxSession.crypto.keyVerificationManager transactions:^(NSArray<MXKeyVerificationTransaction *> * _Nonnull transactions) {
 
         NSLog(@"[AppDelegate][MXKeyVerification] checkPendingIncomingDeviceVerificationsInSession: transactions: %@", transactions);
 
-        for (MXDeviceVerificationTransaction *transaction in transactions)
+        for (MXKeyVerificationTransaction *transaction in transactions)
         {
             if (transaction.isIncoming)
             {

--- a/Riot/Modules/DeviceVerification/DeviceVerificationCoordinator.swift
+++ b/Riot/Modules/DeviceVerification/DeviceVerificationCoordinator.swift
@@ -209,7 +209,7 @@ extension DeviceVerificationCoordinator: DeviceVerificationDataLoadingCoordinato
         }
     }
     
-    func deviceVerificationDataLoadingCoordinator(_ coordinator: DeviceVerificationDataLoadingCoordinatorType, didAcceptKeyVerificationRequestWithTransaction transaction: MXDeviceVerificationTransaction) {
+    func deviceVerificationDataLoadingCoordinator(_ coordinator: DeviceVerificationDataLoadingCoordinatorType, didAcceptKeyVerificationRequestWithTransaction transaction: MXKeyVerificationTransaction) {
         
         if let sasTransaction = transaction as? MXSASTransaction {
             self.showVerify(transaction: sasTransaction, animated: true)

--- a/Riot/Modules/DeviceVerification/Incoming/DeviceVerificationIncomingViewModel.swift
+++ b/Riot/Modules/DeviceVerification/Incoming/DeviceVerificationIncomingViewModel.swift
@@ -84,14 +84,14 @@ final class DeviceVerificationIncomingViewModel: DeviceVerificationIncomingViewM
         self.viewDelegate?.deviceVerificationIncomingViewModel(self, didUpdateViewState: viewState)
     }
 
-    // MARK: - MXDeviceVerificationTransactionDidChange
+    // MARK: - MXKeyVerificationTransactionDidChange
 
     private func registerTransactionDidStateChangeNotification(transaction: MXIncomingSASTransaction) {
-        NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: NSNotification.Name.MXDeviceVerificationTransactionDidChange, object: transaction)
+        NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: NSNotification.Name.MXKeyVerificationTransactionDidChange, object: transaction)
     }
     
     private func unregisterTransactionDidStateChangeNotification() {
-        NotificationCenter.default.removeObserver(self, name: .MXDeviceVerificationTransactionDidChange, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .MXKeyVerificationTransactionDidChange, object: nil)
     }
 
     @objc private func transactionDidStateChange(notification: Notification) {

--- a/Riot/Modules/DeviceVerification/Loading/DeviceVerificationDataLoadingCoordinator.swift
+++ b/Riot/Modules/DeviceVerification/Loading/DeviceVerificationDataLoadingCoordinator.swift
@@ -65,7 +65,7 @@ final class DeviceVerificationDataLoadingCoordinator: DeviceVerificationDataLoad
 // MARK: - DeviceVerificationDataLoadingViewModelCoordinatorDelegate
 extension DeviceVerificationDataLoadingCoordinator: DeviceVerificationDataLoadingViewModelCoordinatorDelegate {
     
-    func deviceVerificationDataLoadingViewModel(_ viewModel: DeviceVerificationDataLoadingViewModelType, didAcceptKeyVerificationWithTransaction transaction: MXDeviceVerificationTransaction) {
+    func deviceVerificationDataLoadingViewModel(_ viewModel: DeviceVerificationDataLoadingViewModelType, didAcceptKeyVerificationWithTransaction transaction: MXKeyVerificationTransaction) {
         self.delegate?.deviceVerificationDataLoadingCoordinator(self, didAcceptKeyVerificationRequestWithTransaction: transaction)
     }
     

--- a/Riot/Modules/DeviceVerification/Loading/DeviceVerificationDataLoadingCoordinatorType.swift
+++ b/Riot/Modules/DeviceVerification/Loading/DeviceVerificationDataLoadingCoordinatorType.swift
@@ -20,7 +20,7 @@ import Foundation
 
 protocol DeviceVerificationDataLoadingCoordinatorDelegate: class {
     func deviceVerificationDataLoadingCoordinator(_ coordinator: DeviceVerificationDataLoadingCoordinatorType, didLoadUser user: MXUser, device: MXDeviceInfo)
-    func deviceVerificationDataLoadingCoordinator(_ coordinator: DeviceVerificationDataLoadingCoordinatorType, didAcceptKeyVerificationRequestWithTransaction transaction: MXDeviceVerificationTransaction)
+    func deviceVerificationDataLoadingCoordinator(_ coordinator: DeviceVerificationDataLoadingCoordinatorType, didAcceptKeyVerificationRequestWithTransaction transaction: MXKeyVerificationTransaction)
     func deviceVerificationDataLoadingCoordinatorDidCancel(_ coordinator: DeviceVerificationDataLoadingCoordinatorType)
 }
 

--- a/Riot/Modules/DeviceVerification/Loading/DeviceVerificationDataLoadingViewModel.swift
+++ b/Riot/Modules/DeviceVerification/Loading/DeviceVerificationDataLoadingViewModel.swift
@@ -152,14 +152,14 @@ final class DeviceVerificationDataLoadingViewModel: DeviceVerificationDataLoadin
         self.viewDelegate?.deviceVerificationDataLoadingViewModel(self, didUpdateViewState: viewState)
     }
     
-    // MARK: MXDeviceVerificationTransactionDidChange
+    // MARK: MXKeyVerificationTransactionDidChange
     
     private func registerTransactionDidStateChangeNotification(transaction: MXOutgoingSASTransaction) {
-        NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: NSNotification.Name.MXDeviceVerificationTransactionDidChange, object: transaction)
+        NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: NSNotification.Name.MXKeyVerificationTransactionDidChange, object: transaction)
     }
     
     private func unregisterTransactionDidStateChangeNotification() {
-        NotificationCenter.default.removeObserver(self, name: .MXDeviceVerificationTransactionDidChange, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .MXKeyVerificationTransactionDidChange, object: nil)
     }
     
     @objc private func transactionDidStateChange(notification: Notification) {

--- a/Riot/Modules/DeviceVerification/Loading/DeviceVerificationDataLoadingViewModelType.swift
+++ b/Riot/Modules/DeviceVerification/Loading/DeviceVerificationDataLoadingViewModelType.swift
@@ -24,7 +24,7 @@ protocol DeviceVerificationDataLoadingViewModelViewDelegate: class {
 
 protocol DeviceVerificationDataLoadingViewModelCoordinatorDelegate: class {
     func deviceVerificationDataLoadingViewModel(_ viewModel: DeviceVerificationDataLoadingViewModelType, didLoadUser user: MXUser, device: MXDeviceInfo)
-    func deviceVerificationDataLoadingViewModel(_ viewModel: DeviceVerificationDataLoadingViewModelType, didAcceptKeyVerificationWithTransaction transaction: MXDeviceVerificationTransaction)
+    func deviceVerificationDataLoadingViewModel(_ viewModel: DeviceVerificationDataLoadingViewModelType, didAcceptKeyVerificationWithTransaction transaction: MXKeyVerificationTransaction)
     func deviceVerificationDataLoadingViewModelDidCancel(_ viewModel: DeviceVerificationDataLoadingViewModelType)
 }
 

--- a/Riot/Modules/DeviceVerification/Start/DeviceVerificationStartViewModel.swift
+++ b/Riot/Modules/DeviceVerification/Start/DeviceVerificationStartViewModel.swift
@@ -25,7 +25,7 @@ final class DeviceVerificationStartViewModel: DeviceVerificationStartViewModelTy
     // MARK: Private
 
     private let session: MXSession
-    private let verificationManager: MXDeviceVerificationManager
+    private let verificationManager: MXKeyVerificationManager
     private let otherUser: MXUser
     private let otherDevice: MXDeviceInfo
 
@@ -40,7 +40,7 @@ final class DeviceVerificationStartViewModel: DeviceVerificationStartViewModelTy
     
     init(session: MXSession, otherUser: MXUser, otherDevice: MXDeviceInfo) {
         self.session = session
-        self.verificationManager = session.crypto.deviceVerificationManager
+        self.verificationManager = session.crypto.keyVerificationManager
         self.otherUser = otherUser
         self.otherDevice = otherDevice
     }
@@ -101,14 +101,14 @@ final class DeviceVerificationStartViewModel: DeviceVerificationStartViewModelTy
     }
 
 
-    // MARK: - MXDeviceVerificationTransactionDidChange
+    // MARK: - MXKeyVerificationTransactionDidChange
 
     private func registerTransactionDidStateChangeNotification(transaction: MXOutgoingSASTransaction) {
-        NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: NSNotification.Name.MXDeviceVerificationTransactionDidChange, object: transaction)
+        NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: NSNotification.Name.MXKeyVerificationTransactionDidChange, object: transaction)
     }
     
     private func unregisterTransactionDidStateChangeNotification() {
-        NotificationCenter.default.removeObserver(self, name: .MXDeviceVerificationTransactionDidChange, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .MXKeyVerificationTransactionDidChange, object: nil)
     }
 
     @objc private func transactionDidStateChange(notification: Notification) {

--- a/Riot/Modules/DeviceVerification/Verify/DeviceVerificationVerifyViewModel.swift
+++ b/Riot/Modules/DeviceVerification/Verify/DeviceVerificationVerifyViewModel.swift
@@ -81,14 +81,14 @@ final class DeviceVerificationVerifyViewModel: DeviceVerificationVerifyViewModel
         self.viewDelegate?.deviceVerificationVerifyViewModel(self, didUpdateViewState: viewState)
     }
 
-    // MARK: - MXDeviceVerificationTransactionDidChange
+    // MARK: - MXKeyVerificationTransactionDidChange
 
     private func registerTransactionDidStateChangeNotification(transaction: MXSASTransaction) {
-        NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: NSNotification.Name.MXDeviceVerificationTransactionDidChange, object: transaction)
+        NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: NSNotification.Name.MXKeyVerificationTransactionDidChange, object: transaction)
     }
     
     private func unregisterTransactionDidStateChangeNotification() {
-        NotificationCenter.default.removeObserver(self, name: .MXDeviceVerificationTransactionDidChange, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .MXKeyVerificationTransactionDidChange, object: nil)
     }
 
     @objc private func transactionDidStateChange(notification: Notification) {

--- a/Riot/Modules/Room/DataSources/RoomDataSource.m
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.m
@@ -672,12 +672,12 @@
 
 - (void)registerDeviceVerificationTransactionNotification
 {
-    self.deviceVerificationTransactionDidChangeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:MXDeviceVerificationTransactionDidChangeNotification
+    self.deviceVerificationTransactionDidChangeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:MXKeyVerificationTransactionDidChangeNotification
                                                                                                                         object:nil
                                                                                                                          queue:[NSOperationQueue mainQueue]
                                                                                                                     usingBlock:^(NSNotification *notification)
                                                                        {
-                                                                           MXDeviceVerificationTransaction *deviceVerificationTransaction = (MXDeviceVerificationTransaction*)notification.object;
+                                                                           MXKeyVerificationTransaction *deviceVerificationTransaction = (MXKeyVerificationTransaction*)notification.object;
                                                                            
                                                                            if ([deviceVerificationTransaction.dmRoomId isEqualToString:self.roomId])
                                                                            {
@@ -741,7 +741,7 @@
         return;
     }
     
-    __block MXHTTPOperation *operation = [self.mxSession.crypto.deviceVerificationManager keyVerificationFromKeyVerificationEvent:event
+    __block MXHTTPOperation *operation = [self.mxSession.crypto.keyVerificationManager keyVerificationFromKeyVerificationEvent:event
                                                                                                                           success:^(MXKeyVerification * _Nonnull keyVerification)
                                           {
                                               BOOL shouldRefreshCells = bubbleCellData.isKeyVerificationOperationPending || bubbleCellData.keyVerification == nil;

--- a/Riot/Modules/UserVerification/Start/UserVerificationStartViewModel.swift
+++ b/Riot/Modules/UserVerification/Start/UserVerificationStartViewModel.swift
@@ -36,7 +36,7 @@ final class UserVerificationStartViewModel: UserVerificationStartViewModelType {
 
     private let session: MXSession
     private let roomMember: MXRoomMember
-    private let verificationManager: MXDeviceVerificationManager
+    private let verificationManager: MXKeyVerificationManager
     
     private var keyVerificationRequest: MXKeyVerificationRequest?
     
@@ -53,7 +53,7 @@ final class UserVerificationStartViewModel: UserVerificationStartViewModelType {
     
     init(session: MXSession, roomMember: MXRoomMember) {
         self.session = session
-        self.verificationManager = session.crypto.deviceVerificationManager
+        self.verificationManager = session.crypto.keyVerificationManager
         self.roomMember = roomMember
     }
     
@@ -114,14 +114,14 @@ final class UserVerificationStartViewModel: UserVerificationStartViewModelType {
         keyVerificationRequest.cancel(with: MXTransactionCancelCode.user(), success: nil, failure: nil)
     }
     
-    // MARK: - MXDeviceVerificationTransactionDidChange
+    // MARK: - MXKeyVerificationTransactionDidChange
     
     private func registerTransactionDidStateChangeNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: .MXDeviceVerificationTransactionDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(transactionDidStateChange(notification:)), name: .MXKeyVerificationTransactionDidChange, object: nil)
     }
     
     private func unregisterTransactionDidStateChangeNotification() {
-        NotificationCenter.default.removeObserver(self, name: .MXDeviceVerificationTransactionDidChange, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .MXKeyVerificationTransactionDidChange, object: nil)
     }
     
     @objc private func transactionDidStateChange(notification: Notification) {
@@ -156,7 +156,7 @@ final class UserVerificationStartViewModel: UserVerificationStartViewModelType {
         }
     }
     
-    // MARK: - MXDeviceVerificationTransactionDidChange
+    // MARK: - MXKeyVerificationTransactionDidChange
     
     private func registerKeyVerificationDidChangeNotification(keyVerificationRequest: MXKeyVerificationRequest) {
         NotificationCenter.default.addObserver(self, selector: #selector(keyVerificationRequestDidChange(notification:)), name: .MXKeyVerificationRequestDidChange, object: keyVerificationRequest)


### PR DESCRIPTION
Because it makes more sense now

Follows changes made by https://github.com/matrix-org/matrix-ios-sdk/pull/780