### PR TITLE
Key Verification: Handle incoming self verification request

### DIFF
--- a/Riot/Modules/DeviceVerification/DeviceVerificationCoordinator.swift
+++ b/Riot/Modules/DeviceVerification/DeviceVerificationCoordinator.swift
@@ -83,7 +83,7 @@ final class DeviceVerificationCoordinator: DeviceVerificationCoordinatorType {
     ///   - session: the MXSession
     ///   - incomingKeyVerificationRequest: An existing incoming key verification request to accept
     convenience init(session: MXSession, incomingKeyVerificationRequest: MXKeyVerificationRequest) {
-        let otherDeviceId = incomingKeyVerificationRequest.otherDevice ?? incomingKeyVerificationRequest.request.fromDevice
+        let otherDeviceId = incomingKeyVerificationRequest.otherDevice ?? incomingKeyVerificationRequest.fromDevice
         
         self.init(session: session, otherUserId: incomingKeyVerificationRequest.otherUser, otherDeviceId: otherDeviceId)
         self.incomingKeyVerificationRequest = incomingKeyVerificationRequest


### PR DESCRIPTION
Requires: https://github.com/matrix-org/matrix-ios-sdk/pull/785.
Closes #2871.

We display the same modal as riot-web. It can look minimalist but this is not the main path for verifying a session. The main path being "Complete Security" just after signing in.

<img width="385" alt="Screenshot 2020-02-20 at 16 30 19" src="https://user-images.githubusercontent.com/8418515/74960548-d221e980-540c-11ea-91c4-96ebcd7cf131.png">
