### PR TITLE
Security screen: Add a dedicated cross-signing section

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -497,7 +497,7 @@
 
 "settings_crypto_device_name" = "Session name: ";
 "settings_crypto_device_id" = "\nSession ID: ";
-"settings_crypto_device_key" = "\Session key:\n";
+"settings_crypto_device_key" = "\nSession key:\n";
 "settings_crypto_export" = "Export keys";
 "settings_crypto_blacklist_unverified_devices" = "Encrypt to verified sessions only";
 
@@ -560,10 +560,14 @@
 
 "security_settings_backup" = "MESSAGE BACKUP";
 
+"security_settings_crosssigning" = "CROSS-SIGNING";
+
+"security_settings_cryptography" = "CRYPTOGRAPHY";
+"security_settings_export_keys_manually" = "Export keys manually";
+
 "security_settings_advanced" = "ADVANCED";
 "security_settings_blacklist_unverified_devices" = "Never send messages to untrusted sessions";
 "security_settings_blacklist_unverified_devices_description" = "Verify all of a users sessions to mark them as trusted and send messages to them.";
-"security_settings_export_keys_manually" = "Export keys manually";
 
 
 // Manage session

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -2694,6 +2694,10 @@ internal enum VectorL10n {
   internal static var securitySettingsBlacklistUnverifiedDevicesDescription: String { 
     return VectorL10n.tr("Vector", "security_settings_blacklist_unverified_devices_description") 
   }
+  /// CROSS-SIGNING
+  internal static var securitySettingsCrosssigning: String { 
+    return VectorL10n.tr("Vector", "security_settings_crosssigning") 
+  }
   /// MY SESSIONS
   internal static var securitySettingsCryptoSessions: String { 
     return VectorL10n.tr("Vector", "security_settings_crypto_sessions") 
@@ -2705,6 +2709,10 @@ internal enum VectorL10n {
   /// Loading sessions…
   internal static var securitySettingsCryptoSessionsLoading: String { 
     return VectorL10n.tr("Vector", "security_settings_crypto_sessions_loading") 
+  }
+  /// CRYPTOGRAPHY
+  internal static var securitySettingsCryptography: String { 
+    return VectorL10n.tr("Vector", "security_settings_cryptography") 
   }
   /// Export keys manually
   internal static var securitySettingsExportKeysManually: String { 
@@ -2862,7 +2870,7 @@ internal enum VectorL10n {
   internal static var settingsCryptoDeviceId: String { 
     return VectorL10n.tr("Vector", "settings_crypto_device_id") 
   }
-  /// Session key:\n
+  /// \nSession key:\n
   internal static var settingsCryptoDeviceKey: String { 
     return VectorL10n.tr("Vector", "settings_crypto_device_key") 
   }


### PR DESCRIPTION
Cross-signing information is based on the new `MXCrossSigning.state` (https://github.com/matrix-org/matrix-ios-sdk/pull/797).

This section has not been designed. It will probably be removed (or merged) soon as we are discussing to put all keys (backup and cross-signing) behind a main key. 
Its goal is help to debug and to better understand cross-signing states.
We need to work again on it before release cross-signing. 

Strings are not i18ned because it is a temporary thing.


Screen according to `MXCrossSigning.state`:

- MXCrossSigningStateNotBootstrapped
<img width="377" alt="Screenshot 2020-03-18 at 12 16 08" src="https://user-images.githubusercontent.com/8418515/76962137-edeeb180-691e-11ea-9b9c-b2d4bba1dc23.png">
<img width="277" alt="Screenshot 2020-03-18 at 13 49 02" src="https://user-images.githubusercontent.com/8418515/76962281-40c86900-691f-11ea-8349-7eed3f6b7aed.png">


- MXCrossSigningStateCrossSigningExists
<img width="376" alt="Screenshot 2020-03-18 at 12 16 52" src="https://user-images.githubusercontent.com/8418515/76962174-02cb4500-691f-11ea-97b8-bc776c8410be.png">
<img width="278" alt="Screenshot 2020-03-18 at 12 17 04" src="https://user-images.githubusercontent.com/8418515/76962227-22626d80-691f-11ea-8e02-9c287c986fbc.png">


- MXCrossSigningStateTrustCrossSigning
<img width="373" alt="Screenshot 2020-03-18 at 12 11 52" src="https://user-images.githubusercontent.com/8418515/76962410-78cfac00-691f-11ea-8f88-e61e3e3e1130.png">
<img width="286" alt="Screenshot 2020-03-18 at 13 52 06" src="https://user-images.githubusercontent.com/8418515/76962535-af0d2b80-691f-11ea-9149-a029d1f96027.png">


- MXCrossSigningStateCanCrossSign / MXCrossSigningStateCanCrossSignAsynchronously
<img width="375" alt="Screenshot 2020-03-18 at 12 18 16" src="https://user-images.githubusercontent.com/8418515/76962561-bcc2b100-691f-11ea-9484-8fff7e45f6b9.png">


