### PR TITLE
AuthFallback: Stay in Riot App

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Bug fix:
  * Fix error when joining some public rooms, thanks to @chrismoos (PR #2888).
  * Fix crash due to malformed widget (#2997).
  * Push notifications: Avoid any automatic deactivation (vector-im/riot-ios#3017).
+ * Fix links breaking user out of SSO flow.
 
 Changes in 0.10.4 (2019-12-11)
 ===============================================

--- a/Riot/Modules/Home/Fallback/AuthFallBackViewController.m
+++ b/Riot/Modules/Home/Fallback/AuthFallBackViewController.m
@@ -203,14 +203,6 @@ NSString *FallBackViewControllerJavascriptOnLogin = @"window.matrixLogin.onLogin
         return;
     }
 
-    if (navigationAction.navigationType == WKNavigationTypeLinkActivated)
-    {
-        // Open links outside the app
-        [[UIApplication sharedApplication] openURL:navigationAction.request.URL options:@{} completionHandler:nil];
-        decisionHandler(WKNavigationActionPolicyCancel);
-        return;
-    }
-
     decisionHandler(WKNavigationActionPolicyAllow);
 }
 


### PR DESCRIPTION
When doing a SAML based SSO via Gsuite, I must click a link specifying that I trust this app. That link will break me out of the SSO sign-in process, and open up safari.

To fix address this, I've removed the feature that opens links in safari.



Signed-off-by: Mark Schulte <schultetwin@gmail.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [ ] UI change has been tested on both light and dark themes
* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [ ] Pull request includes screenshots or videos of UI changes
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
