### PR TITLE
RoomMember scree: Display the verify button even in non e2e rooms

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -260,6 +260,7 @@
 "room_participants_action_security_status_verified" = "Verified";
 "room_participants_action_security_status_verify" = "Verify";
 "room_participants_action_security_status_warning" = "Warning";
+"room_participants_action_security_status_loading" = "Loading…";
 
 "room_participants_security_loading" = "Loading…";
 "room_participants_security_information_room_not_encrypted" = "Messages in this room are not end-to-end encrypted.";

--- a/Riot/Categories/MXRoom+Riot.m
+++ b/Riot/Categories/MXRoom+Riot.m
@@ -328,7 +328,7 @@
 {
     UserEncryptionTrustLevel userEncryptionTrustLevel;
     
-    if (self.summary.isEncrypted && self.mxSession.crypto)
+    if (self.mxSession.crypto)
     {
         MXUsersTrustLevelSummary *usersTrustLevelSummary = [self.mxSession.crypto trustLevelSummaryForUserIds:@[userId]];
         

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -2318,6 +2318,10 @@ internal enum VectorL10n {
   internal static var roomParticipantsActionSectionSecurity: String { 
     return VectorL10n.tr("Vector", "room_participants_action_section_security") 
   }
+  /// Loading…
+  internal static var roomParticipantsActionSecurityStatusLoading: String { 
+    return VectorL10n.tr("Vector", "room_participants_action_security_status_loading") 
+  }
   /// Verified
   internal static var roomParticipantsActionSecurityStatusVerified: String { 
     return VectorL10n.tr("Vector", "room_participants_action_security_status_verified") 

--- a/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
+++ b/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
@@ -720,19 +720,15 @@
     
     if (RiotSettings.shared.enableCrossSigning)
     {
-        switch (self.encryptionTrustLevel) {
-            case UserEncryptionTrustLevelUnknown:
-                securityActionsArray = @[@(MXKRoomMemberDetailsActionSecurityInformation)];
-                break;
-            case UserEncryptionTrustLevelNone:
-            case UserEncryptionTrustLevelNormal:
-            case UserEncryptionTrustLevelTrusted:
-            case UserEncryptionTrustLevelWarning:
-                securityActionsArray = @[@(MXKRoomMemberDetailsActionSecurity),
-                                         @(MXKRoomMemberDetailsActionSecurityInformation)];
-                break;
-            default:
-                break;
+        if (self.mxRoom.summary.isEncrypted)
+        {
+            securityActionsArray = @[@(MXKRoomMemberDetailsActionSecurity),
+                                     @(MXKRoomMemberDetailsActionSecurityInformation)];
+            
+        }
+        else
+        {
+            securityActionsArray = @[@(MXKRoomMemberDetailsActionSecurity)];
         }
     }
     


### PR DESCRIPTION
Fix #3046
Display also the shield on the user to have the same screen for e2e and non e2e rooms

### With this PR in non e2e room
![Simulator Screen Shot - iPhone Xʀ - 2020-03-27 at 09 13 47](https://user-images.githubusercontent.com/8418515/77735792-7221f280-700b-11ea-8de3-e8b2d2615033.png)

### In e2e room (still like before)
![Simulator Screen Shot - iPhone Xʀ - 2020-03-27 at 09 13 37](https://user-images.githubusercontent.com/8418515/77735788-70582f00-700b-11ea-886b-e02e1b2944dd.png)

