### PR TITLE
Declined calls now properly reset call view controller

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Improvements:
  * Verification by DM: Support QR code (#2921).
  * Cross-Signing: Detect and expose new sign-ins (#2918).
  * Cross-signing: Complete security at the end of sign in process( #3003).
+ * CallVC: Declined calls now properly reset call view controller (#2877).
 
 Changes in 0.10.5 (2020-04-01)
 ===============================================

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -3258,6 +3258,7 @@ NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey = @"AppDe
                                                                                  }];
             }
 
+            __weak typeof(self) weakSelf = self;
             if (mxCall.isIncoming && isCallKitEnabled)
             {
                 // Let's CallKit display the system incoming call screen
@@ -3277,6 +3278,16 @@ NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey = @"AppDe
 
                                                                                          NSLog(@"[AppDelegate] presentCallViewController");
                                                                                          [self presentCallViewController:NO completion:nil];
+                                                                                     }
+                                                                                     else if (call.state == MXCallStateEnded)
+                                                                                     {
+                                                                                         // Set call vc to nil to let our app handle new incoming calls even it wasn't killed by the system
+                                                                                         
+                                                                                         if (weakSelf)
+                                                                                         {
+                                                                                             typeof(self) self = weakSelf;
+                                                                                             [self dismissCallViewController:self->currentCallViewController completion:nil];
+                                                                                         }
                                                                                      }
                                                                                  }];
             }
@@ -3990,6 +4001,12 @@ NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey = @"AppDe
                 [self dismissCallViewController:currentCallViewController completion:completion];
                 
             }];
+        }
+        else
+        {
+            // Release properly
+            [currentCallViewController destroy];
+            currentCallViewController = nil;
         }
     }
 }


### PR DESCRIPTION
The issue was the call view controller not being set to nil which caused future checks to be a false positive, when determining if there's already an ongoing call. This commit should fix that issue.
#2877