### PR TITLE
Cross-signing: Allow to verify each device of users with no cross-signing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in 0.11.1 (2020-xx-xx)
 
 Improvements:
  * Cross-signing: Allow incoming device verification request from other user (#3139).
+ * Cross-signing: Allow to verify each device of users with no cross-signing (#3138).
 
 Bug fix:
 

--- a/Riot/Categories/MXRoom+Riot.m
+++ b/Riot/Categories/MXRoom+Riot.m
@@ -326,7 +326,7 @@
 
 - (void)encryptionTrustLevelForUserId:(NSString*)userId onComplete:(void (^)(UserEncryptionTrustLevel userEncryptionTrustLevel))onComplete
 {
-        if (self.mxSession.crypto)
+    if (self.mxSession.crypto)
     {
         [self.mxSession.crypto trustLevelSummaryForUserIds:@[userId] onComplete:^(MXUsersTrustLevelSummary *usersTrustLevelSummary) {
             
@@ -339,7 +339,15 @@
             }
             else if (trustedDevicesPercentage == 0.0)
             {
-                userEncryptionTrustLevel = UserEncryptionTrustLevelNormal;
+                // Verify if the user has the user has cross-signing enabled
+                if ([self.mxSession.crypto crossSigningKeysForUser:userId])
+                {
+                    userEncryptionTrustLevel = UserEncryptionTrustLevelNormal;
+                }
+                else
+                {
+                    userEncryptionTrustLevel = UserEncryptionTrustLevelNoCrossSigning;
+                }
             }
             else
             {

--- a/Riot/Categories/MXRoom+Riot.m
+++ b/Riot/Categories/MXRoom+Riot.m
@@ -342,7 +342,7 @@
                 // Verify if the user has the user has cross-signing enabled
                 if ([self.mxSession.crypto crossSigningKeysForUser:userId])
                 {
-                    userEncryptionTrustLevel = UserEncryptionTrustLevelNormal;
+                    userEncryptionTrustLevel = UserEncryptionTrustLevelNotVerified;
                 }
                 else
                 {

--- a/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
+++ b/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
@@ -841,7 +841,7 @@
                 case UserEncryptionTrustLevelTrusted:
                     statusText = NSLocalizedStringFromTable(@"room_participants_action_security_status_verified", @"Vector", nil);
                     break;
-                case UserEncryptionTrustLevelNormal:
+                case UserEncryptionTrustLevelNotVerified:
                 case UserEncryptionTrustLevelNoCrossSigning:
                     statusText = NSLocalizedStringFromTable(@"room_participants_action_security_status_verify", @"Vector", nil);
                     break;
@@ -875,7 +875,7 @@
             
             switch (self.encryptionTrustLevel) {
                 case UserEncryptionTrustLevelWarning:
-                case UserEncryptionTrustLevelNormal:
+                case UserEncryptionTrustLevelNotVerified:
                 case UserEncryptionTrustLevelNoCrossSigning:
                 case UserEncryptionTrustLevelTrusted:
                     [encryptionInformation appendString:NSLocalizedStringFromTable(@"room_participants_security_information_room_encrypted", @"Vector", nil)];
@@ -1029,7 +1029,7 @@
 {
     if (indexPath.section == securityIndex)
     {
-        if (self.encryptionTrustLevel == UserEncryptionTrustLevelNormal)
+        if (self.encryptionTrustLevel == UserEncryptionTrustLevelNotVerified)
         {
             [self startUserVerification];
         }

--- a/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
+++ b/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
@@ -842,6 +842,7 @@
                     statusText = NSLocalizedStringFromTable(@"room_participants_action_security_status_verified", @"Vector", nil);
                     break;
                 case UserEncryptionTrustLevelNormal:
+                case UserEncryptionTrustLevelNoCrossSigning:
                     statusText = NSLocalizedStringFromTable(@"room_participants_action_security_status_verify", @"Vector", nil);
                     break;
                 case UserEncryptionTrustLevelWarning:
@@ -875,6 +876,7 @@
             switch (self.encryptionTrustLevel) {
                 case UserEncryptionTrustLevelWarning:
                 case UserEncryptionTrustLevelNormal:
+                case UserEncryptionTrustLevelNoCrossSigning:
                 case UserEncryptionTrustLevelTrusted:
                     [encryptionInformation appendString:NSLocalizedStringFromTable(@"room_participants_security_information_room_encrypted", @"Vector", nil)];
                     break;

--- a/Riot/Modules/Room/Members/Detail/UserEncryptionTrustLevel.h
+++ b/Riot/Modules/Room/Members/Detail/UserEncryptionTrustLevel.h
@@ -20,10 +20,10 @@
  UserEncryptionTrustLevel represents the user trust level in an encrypted room.
  */
 typedef NS_ENUM(NSUInteger, UserEncryptionTrustLevel) {
-    UserEncryptionTrustLevelTrusted,
-    UserEncryptionTrustLevelWarning,
-    UserEncryptionTrustLevelNormal,
+    UserEncryptionTrustLevelTrusted,            // The user is verified and they have trusted all their devices
+    UserEncryptionTrustLevelWarning,            // The user is verified but they have not trusted all their devices
+    UserEncryptionTrustLevelNotVerified,        // The user is not verified yet
     UserEncryptionTrustLevelNoCrossSigning,     // The user has not bootstrapped cross-signing yet
-    UserEncryptionTrustLevelNone,
-    UserEncryptionTrustLevelUnknown
+    UserEncryptionTrustLevelNone,               // Crypto is not enabled. Should not happen
+    UserEncryptionTrustLevelUnknown             // Computation in progress
 };

--- a/Riot/Modules/Room/Members/Detail/UserEncryptionTrustLevel.h
+++ b/Riot/Modules/Room/Members/Detail/UserEncryptionTrustLevel.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(NSUInteger, UserEncryptionTrustLevel) {
     UserEncryptionTrustLevelTrusted,
     UserEncryptionTrustLevelWarning,
     UserEncryptionTrustLevelNormal,
+    UserEncryptionTrustLevelNoCrossSigning,     // The user has not bootstrapped cross-signing yet
     UserEncryptionTrustLevelNone,
     UserEncryptionTrustLevelUnknown
 };

--- a/Riot/Utils/EncryptionTrustLevelBadgeImageHelper.swift
+++ b/Riot/Utils/EncryptionTrustLevelBadgeImageHelper.swift
@@ -46,7 +46,7 @@ final class EncryptionTrustLevelBadgeImageHelper: NSObject {
         switch trustLevel {
         case .warning:
             badgeImage = Asset.Images.encryptionWarning.image
-        case .normal, .noCrossSigning:
+        case .notVerified, .noCrossSigning:
             badgeImage = Asset.Images.encryptionNormal.image
         case .trusted:
             badgeImage = Asset.Images.encryptionTrusted.image

--- a/Riot/Utils/EncryptionTrustLevelBadgeImageHelper.swift
+++ b/Riot/Utils/EncryptionTrustLevelBadgeImageHelper.swift
@@ -46,7 +46,7 @@ final class EncryptionTrustLevelBadgeImageHelper: NSObject {
         switch trustLevel {
         case .warning:
             badgeImage = Asset.Images.encryptionWarning.image
-        case .normal:
+        case .normal, .noCrossSigning:
             badgeImage = Asset.Images.encryptionNormal.image
         case .trusted:
             badgeImage = Asset.Images.encryptionTrusted.image


### PR DESCRIPTION
Fix #3138.

We offer that by displaying the list of devices of the other user. Our user can verify them one by one:

![Simulator Screen Shot - iPhone Xs - 2020-04-23 at 15 35 43](https://user-images.githubusercontent.com/8418515/80105335-c2dc2b00-8578-11ea-811d-792018a1457e.png)
