### PR TITLE
Some polishing when the device is not trusted yet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes in 0.11.2 (2020-xx-xx)
 Improvements:
  * Registration / Email addition: Support email verification link from homeserver (#3167).
  * Verification requests: Hide incoming request modal when it is no more pending (#3033).
+ * Self-verification: Do not display incoming self verification requests at the top of the Complete Security screen.
 
 Bug fix:
  * AuthenticationViewController: Remove fallback to matrix.org when authentication failed (PR #3165).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,8 @@ Changes in 0.11.2 (2020-xx-xx)
 ===============================================
 
 Improvements:
-* Registration / Email addition: Support email verification link from homeserver (#3167).
+ * Registration / Email addition: Support email verification link from homeserver (#3167).
+ * Verification requests: Hide incoming request modal when it is no more pending (#3033).
 
 Bug fix:
  * AuthenticationViewController: Remove fallback to matrix.org when authentication failed (PR #3165).

--- a/Riot/AppDelegate.h
+++ b/Riot/AppDelegate.h
@@ -65,6 +65,13 @@ extern NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey;
 @property (nonatomic) BOOL isAppForeground;
 @property (nonatomic) BOOL isOffline;
 
+
+/**
+ Let the AppDelegate handle and display self verification requests.
+ Default is YES;
+ */
+@property (nonatomic) BOOL handleSelfVerificationRequest;
+
 /**
  The navigation controller of the master view controller of the main split view controller.
  */

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -493,6 +493,7 @@ NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey = @"AppDe
     NSAssert(_masterTabBarController, @"Something wrong in Main.storyboard");
     
     _isAppForeground = NO;
+    _handleSelfVerificationRequest = YES;
     
     // Configure our analytics. It will indeed start if the option is enabled
     [MXSDKOptions sharedInstance].analyticsDelegate = [Analytics sharedInstance];
@@ -4996,6 +4997,12 @@ NSString *const AppDelegateDidValidateEmailNotificationClientSecretKey = @"AppDe
             {
                 // Self verification
                 NSLog(@"[AppDelegate][KeyVerification] keyVerificationNewRequestNotification: Self verification from %@", keyVerificationByToDeviceRequest.otherDevice);
+                
+                if (!self.handleSelfVerificationRequest)
+                {
+                    NSLog(@"[AppDelegate][KeyVerification] keyVerificationNewRequestNotification: Self verification handled elsewhere");
+                    return;
+                }
                       
                 NSString *myUserId = keyVerificationByToDeviceRequest.otherUser;
                 MXKAccount *account = [[MXKAccountManager sharedManager] accountForUserId:myUserId];

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModel.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModel.swift
@@ -46,6 +46,7 @@ final class KeyVerificationSelfVerifyWaitViewModel: KeyVerificationSelfVerifyWai
     }
     
     deinit {
+        self.unregisterKeyVerificationManagerNewRequestNotification()
     }
     
     // MARK: - Public
@@ -101,9 +102,11 @@ final class KeyVerificationSelfVerifyWaitViewModel: KeyVerificationSelfVerifyWai
     
     private func registerKeyVerificationManagerNewRequestNotification(for verificationManager: MXKeyVerificationManager) {
         NotificationCenter.default.addObserver(self, selector: #selector(keyVerificationManagerNewRequestNotification(notification:)), name: .MXKeyVerificationManagerNewRequest, object: verificationManager)
+        AppDelegate.the()?.handleSelfVerificationRequest = false
     }
     
     private func unregisterKeyVerificationManagerNewRequestNotification() {
+        AppDelegate.the()?.handleSelfVerificationRequest = true
         NotificationCenter.default.removeObserver(self, name: .MXKeyVerificationManagerNewRequest, object: nil)
     }
     

--- a/Riot/Modules/Settings/Security/SecurityViewController.m
+++ b/Riot/Modules/Settings/Security/SecurityViewController.m
@@ -675,7 +675,14 @@ UIDocumentInteractionControllerDelegate>
 {
     if (!self.mainSession.crypto.crossSigning.canCrossSign)
     {
-        return [UIImage imageNamed:@"encryption_normal"];
+        if ([deviceId isEqualToString:self.mainSession.myDeviceId])
+        {
+            return [UIImage imageNamed:@"encryption_warning"];
+        }
+        else
+        {
+            return [UIImage imageNamed:@"encryption_normal"];
+        }
     }
     
     UIImage* shieldImageForDevice = [UIImage imageNamed:@"encryption_warning"];


### PR DESCRIPTION
It fixes bugs seen while testing

If the user skips verify on signin:
- this signin is not red in the sessions list (1st commit)
- on the complete security screen, the incoming verification popup is displayed (3rd commit)

2nd commit fixes #3033.
Commits are independent.
