### PR TITLE
Verification: Do not talk about QR code if only emoji is possible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in 0.11.2 (2020-xx-xx)
 
 Improvements:
 * Registration / Email addition: Support email verification link from homeserver (#3167).
+* Verification: Do not talk about QR code if only emoji is possible (#3035).
 
 Bug fix:
  * AuthenticationViewController: Remove fallback to matrix.org when authentication failed (PR #3165).

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1223,8 +1223,10 @@
 
 "key_verification_verify_qr_code_title" = "Verify by scanning";
 "key_verification_verify_qr_code_information" = "Scan the code to securely verify each other.";
+"key_verification_verify_qr_code_emoji_information" = "Compare unique emoji.";
 "key_verification_verify_qr_code_scan_code_action" = "Scan their code";
 "key_verification_verify_qr_code_cannot_scan_action" = "Can't scan?";
+"key_verification_verify_qr_code_start_emoji_action" = "Start";
 
 "key_verification_verify_qr_code_other_scan_my_code_title" = "Did the other user successfully scan the QR code?";
 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -1634,6 +1634,10 @@ internal enum VectorL10n {
   internal static var keyVerificationVerifyQrCodeCannotScanAction: String { 
     return VectorL10n.tr("Vector", "key_verification_verify_qr_code_cannot_scan_action") 
   }
+  /// Compare unique emoji.
+  internal static var keyVerificationVerifyQrCodeEmojiInformation: String { 
+    return VectorL10n.tr("Vector", "key_verification_verify_qr_code_emoji_information") 
+  }
   /// Scan the code to securely verify each other.
   internal static var keyVerificationVerifyQrCodeInformation: String { 
     return VectorL10n.tr("Vector", "key_verification_verify_qr_code_information") 
@@ -1653,6 +1657,10 @@ internal enum VectorL10n {
   /// Code validated!
   internal static var keyVerificationVerifyQrCodeScanOtherCodeSuccessTitle: String { 
     return VectorL10n.tr("Vector", "key_verification_verify_qr_code_scan_other_code_success_title") 
+  }
+  /// Start
+  internal static var keyVerificationVerifyQrCodeStartEmojiAction: String { 
+    return VectorL10n.tr("Vector", "key_verification_verify_qr_code_start_emoji_action") 
   }
   /// Verify by scanning
   internal static var keyVerificationVerifyQrCodeTitle: String { 

--- a/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.swift
+++ b/Riot/Modules/KeyVerification/Common/Verify/Scanning/KeyVerificationVerifyByScanningViewController.swift
@@ -184,6 +184,12 @@ final class KeyVerificationVerifyByScanningViewController: UIViewController {
         self.titleLabel.text = viewData.verificationKind.verificationTitle
         self.qrCodeContainerView.isHidden = hideQRCodeImage
         self.scanButtonContainerView.isHidden = !viewData.showScanAction
+        
+        if viewData.qrCodeData == nil && viewData.showScanAction == false {
+            // Update the copy if QR code scanning is not possible at all
+            self.informationLabel.text = VectorL10n.keyVerificationVerifyQrCodeEmojiInformation
+            self.cannotScanButton.setTitle(VectorL10n.keyVerificationVerifyQrCodeStartEmojiAction, for: .normal)
+        }
     }
     
     private func render(error: Error) {


### PR DESCRIPTION
Fix #3035

Copy took from riot-web. The screen looks empty but it should go a bottom sheet.
![image](https://user-images.githubusercontent.com/8418515/80511586-96f7e580-897c-11ea-88ef-e13ccf1944df.png)
