### PR TITLE
Secrets: On startup, request again private keys we are missing locally

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes in 0.11.3 (2020-05-xx)
 Improvements:
  * Cross-signing: Display "Verify your other sessions" modal at every startup if needed (#3180).
  * Cross-signing: The "Complete Security" button now triggers a verification request to all user devices.
+ * Secrets: On startup, request again private keys we are missing locally.
 
 Bug fix:
  * KeyVerificationSelfVerifyStartViewController has no navigation (#3195).

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -3542,7 +3542,8 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
         keysCount++;
     }
     
-    if (keysCount > 0 && keysCount < 3)
+    if ((keysCount > 0 && keysCount < 3)
+        || (mxSession.crypto.crossSigning.canTrustCrossSigning && !mxSession.crypto.crossSigning.canCrossSign))
     {
         // We should have 3 of them. If not, request them again as mitigation
         NSLog(@"[AppDelegate] checkLocalPrivateKeysInSession: request keys because keysCount = %@", @(keysCount));

--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -2769,6 +2769,8 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
             
             // Register to new key verification request
             [self registerNewRequestNotificationForSession:mxSession];
+            
+            [self checkLocalPrivateKeysInSession:mxSession];
         }
         else if (mxSession.state == MXSessionStateClosed)
         {
@@ -3522,6 +3524,32 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     [notificationListenerBlocks removeObjectForKey:@(mxSession.hash)];
     [eventsToNotify removeObjectForKey:@(mxSession.hash)];
 }
+
+- (void)checkLocalPrivateKeysInSession:(MXSession*)mxSession
+{
+    id<MXCryptoStore> cryptoStore = mxSession.crypto.store;
+    NSUInteger keysCount = 0;
+    if ([cryptoStore secretWithSecretId:MXSecretId.keyBackup])
+    {
+        keysCount++;
+    }
+    if ([cryptoStore secretWithSecretId:MXSecretId.crossSigningUserSigning])
+    {
+        keysCount++;
+    }
+    if ([cryptoStore secretWithSecretId:MXSecretId.crossSigningSelfSigning])
+    {
+        keysCount++;
+    }
+    
+    if (keysCount > 0 && keysCount < 3)
+    {
+        // We should have 3 of them. If not, request them again as mitigation
+        NSLog(@"[AppDelegate] checkLocalPrivateKeysInSession: request keys because keysCount = %@", @(keysCount));
+        [mxSession.crypto requestAllPrivateKeys];
+    }
+}
+
 
 #pragma mark -
 


### PR DESCRIPTION
This will mitigate unexpected state of cross-signing and backup.