### PR TITLE
AuthenticationVC: Fix crash due to update to WKWebView

### DIFF
--- a/Riot/Modules/Authentication/AuthenticationViewController.xib
+++ b/Riot/Modules/Authentication/AuthenticationViewController.xib
@@ -466,7 +466,7 @@ Clear it if you're finished using this device, or want to sign in to another acc
                                 <action selector="onButtonPressed:" destination="-1" eventType="touchUpInside" id="Pxo-2q-AdE"/>
                             </connections>
                         </button>
-                        <webView contentMode="scaleToFill" scalesPageToFit="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vhh-m0-nXN" userLabel="fallback WebView" customClass="MXKAuthenticationFallbackWebView">
+                        <webView contentMode="scaleToFill" scalesPageToFit="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vhh-m0-nXN" userLabel="fallback WebView" customClass="MXKAuthenticationFallbackWebView" customModule="Riot" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="40" width="375" height="694"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <userDefinedRuntimeAttributes>


### PR DESCRIPTION
The crash was:

```
2020-05-11 17:53:44.125128+0200 Riot[60416:899392] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'Configuration cannot be nil'
*** First throw call stack:
(
	0   CoreFoundation                      0x000000010b0e98db __exceptionPreprocess + 331
	1   libobjc.A.dylib                     0x0000000109d3dac5 objc_exception_throw + 48
	2   CoreFoundation                      0x000000010b0e9735 +[NSException raise:format:] + 197
	3   WebKit                              0x00000001080f112e -[WKWebView _initializeWithConfiguration:] + 88
	4   WebKit                              0x00000001080f35ab -[WKWebView initWithCoder:] + 131
```

I checked this checkbox:
<img width="658" alt="Screenshot 2020-05-11 at 17 50 46" src="https://user-images.githubusercontent.com/8418515/81582886-da0c7c80-93b0-11ea-8a5e-d02b35d1893c.png">


