### PR TITLE
Share extension & Siri intent: Do not fail when sending to locally un…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes in 0.11.5 (2020-xx-xx)
 
 Bug fix:
  * AuthenticationViewController: Adapt UIWebView changes in MatrixKit (PR #3242).
+ * Share extension & Siri intent: Do not fail when sending to locally unverified devices (#3252).
 
 Changes in 0.11.4 (2020-05-08)
 ===============================================

--- a/RiotShareExtension/Modules/Share/Listing/RoomsListViewController.m
+++ b/RiotShareExtension/Modules/Share/Listing/RoomsListViewController.m
@@ -155,6 +155,9 @@
             MXStrongifyAndReturnIfNil(session);
 
             MXRoom *selectedRoom = [MXRoom loadRoomFromStore:[ShareExtensionManager sharedManager].fileStore withRoomId:recentCellData.roomSummary.roomId matrixSession:session];
+            
+            // Do not warn for unknown devices. We have cross-signing now
+            session.crypto.warnOnUnknowDevices = NO;
 
             [ShareExtensionManager sharedManager].delegate = self;
 

--- a/SiriIntents/IntentHandler.m
+++ b/SiriIntents/IntentHandler.m
@@ -226,6 +226,9 @@
                                             MXStrongifyAndReturnIfNil(session);
                                             
                                             MXRoom *room = [MXRoom loadRoomFromStore:fileStore withRoomId:roomID matrixSession:session];
+                                            
+                                            // Do not warn for unknown devices. We have cross-signing now
+                                            session.crypto.warnOnUnknowDevices = NO;
 
                                             [room sendTextMessage:intent.content
                                                           success:^(NSString *eventId) {


### PR DESCRIPTION
…verified devices

Fix #3252

Use cross-signing as the Riot main app.
