### PR TITLE
BF: SettingsVC: New phone number is invisible in dark theme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Bug fix:
  * Xcode11: Replace deprecated MPMoviePlayerController with AVPlayerViewController (PR #3092).
  * Xcode11: Show AuthenticationViewController fullscreen (PR #3093).
  * Xcode11: Fix font used for `org.matrix.custom.html`messages in timeline (#3241).
+ * Settings: New phone number is invisible in dark theme (#3218).
  
  Changes in 0.11.6 (2020-xx-xx)
  ===============================================

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -1565,6 +1565,7 @@ SettingsIdentityServerCoordinatorBridgePresenterDelegate>
                 newPhoneCell.countryCodeButton.accessibilityIdentifier = @"SettingsVCPhoneCountryButton";
                 
                 newPhoneCell.mxkLabel.font = newPhoneCell.mxkTextField.font = [UIFont systemFontOfSize:16];
+                newPhoneCell.mxkTextField.textColor = ThemeService.shared.theme.textSecondaryColor;                
                 
                 newPhoneCell.mxkTextField.userInteractionEnabled = YES;
                 newPhoneCell.mxkTextField.keyboardType = UIKeyboardTypePhonePad;


### PR DESCRIPTION
#3218

![settings_new_phone](https://user-images.githubusercontent.com/2205780/83170237-81f5aa00-a114-11ea-9cad-eb7f3df96ecf.png)
