### PR TITLE
CountryPickerVC: Search field is invisible in dark theme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Improvements:
 Bug fix:
  * AuthenticationViewController: Adapt UIWebView changes in MatrixKit (PR #3242).
  * Share extension & Siri intent: Do not fail when sending to locally unverified devices (#3252).
+ * CountryPickerVC: Search field is invisible in dark theme (#3219).
 
 Changes in 0.11.4 (2020-05-08)
 ===============================================

--- a/Riot/Categories/UILabel.swift
+++ b/Riot/Categories/UILabel.swift
@@ -29,7 +29,8 @@ extension UILabel {
         self.attributedText = attributeString
     }
     
-    // Fix multiline label height with auto layout. After performing orientation multiline label text appears on one line. For more information see https://www.objc.io/issues/3-views/advanced-auto-layout-toolbox/#intrinsic-content-size-of-multi-line-text
+    // Fix multiline label height with auto layout. After performing orientation multiline label text appears on one line.
+    // For more information see https://www.objc.io/issues/3-views/advanced-auto-layout-toolbox/#intrinsic-content-size-of-multi-line-text
     @objc func vc_fixMultilineHeight() {
         let width = self.frame.size.width
         

--- a/Riot/Modules/KeyVerification/User/SessionsStatus/UserVerificationSessionsStatusViewModel.swift
+++ b/Riot/Modules/KeyVerification/User/SessionsStatus/UserVerificationSessionsStatusViewModel.swift
@@ -114,7 +114,7 @@ final class UserVerificationSessionsStatusViewModel: UserVerificationSessionsSta
         
         let httpOperation: MXHTTPOperation?
         
-        httpOperation = self.session.crypto.downloadKeys([self.userId], forceDownload: false, success: { ( usersDeviceMap: MXUsersDevicesMap<MXDeviceInfo>?, usersCrossSigningMap: [String : MXCrossSigningInfo]?) in
+        httpOperation = self.session.crypto.downloadKeys([self.userId], forceDownload: false, success: { ( usersDeviceMap: MXUsersDevicesMap<MXDeviceInfo>?, usersCrossSigningMap: [String: MXCrossSigningInfo]?) in
             
             let sessionsViewData: [UserVerificationSessionStatusViewData]
             

--- a/Riot/Modules/Settings/PhoneCountry/CountryPickerViewController.m
+++ b/Riot/Modules/Settings/PhoneCountry/CountryPickerViewController.m
@@ -51,9 +51,6 @@
 
     // Hide line separators of empty cells
     self.tableView.tableFooterView = [[UIView alloc] init];
-    // Note: UISearchDisplayController is deprecated in iOS 8.
-    // MXKCountryPickerViewController should use UISearchController to manage the presentation of a search bar and display search results.
-    self.searchDisplayController.searchResultsTableView.tableFooterView = [[UIView alloc] init];
     
     // Add a top view which will be displayed in case of vertical bounce.
     CGFloat height = self.tableView.frame.size.height;
@@ -76,13 +73,15 @@
 
     self.activityIndicator.backgroundColor = ThemeService.shared.theme.overlayBackgroundColor;
     
-    [ThemeService.shared.theme applyStyleOnSearchBar:self.searchBar];
-    
     // Use the primary bg color for the table view in plain style.
     self.tableView.backgroundColor = ThemeService.shared.theme.backgroundColor;
     self.tableView.separatorColor = ThemeService.shared.theme.lineBreakColor;
     topview.backgroundColor = ThemeService.shared.theme.backgroundColor;
-    self.searchDisplayController.searchResultsTableView.backgroundColor = self.tableView.backgroundColor;
+    
+    if (self.searchController.searchBar)
+    {
+        [ThemeService.shared.theme applyStyleOnSearchBar:self.searchController.searchBar];
+    }
     
     if (self.tableView.dataSource)
     {


### PR DESCRIPTION
Fix #3219
Requires matrix-org/matrix-ios-kit/pull/673

![country_search](https://user-images.githubusercontent.com/2205780/83234386-72b44200-a190-11ea-838e-e391b879ab00.png)
