### PR TITLE
Authentication: Redirect webview (SSO) javascript logs to native logs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes in 0.11.6 (2020-xx-xx)
 Improvements:
  * PushNotificationService: Move all notification related code to a new class (PR #3100).
  * Cross-signing: Bootstrap cross-sign on registration (and login if applicable). This action is now invisible to the user (#3292).
+ * Authentication: Redirect the webview (SSO) javascript logs to iOS native logs.
  
 Bug fix:
  * CallVC: Declined calls now properly reset call view controller, thanks to @Legi429 (#2877).

--- a/Riot/Modules/Home/Fallback/AuthFallBackViewController.m
+++ b/Riot/Modules/Home/Fallback/AuthFallBackViewController.m
@@ -56,6 +56,9 @@ NSString *FallBackViewControllerJavascriptOnLogin = @"window.matrixLogin.onLogin
 {
     [super viewDidLoad];
 
+    // Catch js logs
+    [self enableDebug];
+    
     // Due to https://developers.googleblog.com/2016/08/modernizing-oauth-interactions-in-native-apps.html, we hack
     // the user agent to bypass the limitation of Google, as a quick fix (a proper solution will be to use the SSO SDK)
     webView.customUserAgent = @"Mozilla/5.0";


### PR DESCRIPTION
This will help to debug our SSO support into a webview.

The HS with SSO I have gives me this logs:
```

2020-06-03 13:56:38.320748+0200 Riot[31562:1222934] -- JavaScript: Server accepts SSO 
```