### PR TITLE
Fix Inviter Display Name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Improvements:
  
 Bug fix:
  * CallVC: Declined calls now properly reset call view controller, thanks to @Legi429 (#2877).
+ * PreviewRoomTitleView: Fix inviter display name (#2520).
 
 Changes in 0.11.5 (2020-05-18)
 ===============================================

--- a/Riot/Modules/Room/Views/Title/Preview/PreviewRoomTitleView.m
+++ b/Riot/Modules/Room/Views/Title/Preview/PreviewRoomTitleView.m
@@ -183,9 +183,20 @@
         {
             MXStrongifyAndReturnIfNil(self);
 
-            MXRoomMember *myMember = [roomMembers memberWithUserId:self.mxRoom.mxSession.myUserId];
+            MXSession *mxSession = self.mxRoom.mxSession;
+            MXRoomMember *myMember = [roomMembers memberWithUserId:mxSession.myUserId];
             NSString *inviterUserId = myMember.originalEvent.sender;
-            NSString *inviter = [roomMembers memberName:inviterUserId] ?: inviterUserId;
+            NSString *inviter = [roomMembers memberName:inviterUserId];
+            //  if not found, check the user in session
+            if (inviter.length == 0)
+            {
+                inviter = [mxSession userWithUserId:inviterUserId].displayname;
+            }
+            //  if still not found, use the user ID
+            if (inviter.length == 0)
+            {
+                inviter = inviterUserId;
+            }
             
             // FIXME: Display members status when it will be available
             self.roomMembers.text = nil;

--- a/Riot/Modules/Room/Views/Title/Preview/PreviewRoomTitleView.m
+++ b/Riot/Modules/Room/Views/Title/Preview/PreviewRoomTitleView.m
@@ -183,29 +183,10 @@
         {
             MXStrongifyAndReturnIfNil(self);
 
-            NSArray *members = roomMembers.members;
-            NSUInteger activeCount = 0;
-            NSUInteger memberCount = self.mxRoom.summary.membersCount.joined;
-            NSString *inviter = nil;
-
-            for (MXRoomMember *mxMember in members)
-            {
-                if (mxMember.membership == MXMembershipJoin)
-                {
-                    // Get the user that corresponds to this member
-                    MXUser *user = [self.mxRoom.mxSession userWithUserId:mxMember.userId];
-                    // existing user ?
-                    if (user && user.presence == MXPresenceOnline)
-                    {
-                        activeCount ++;
-                    }
-
-                    // Presently only one member is available from invited room data
-                    // This is the inviter
-                    inviter = mxMember.displayname.length ? mxMember.displayname : mxMember.userId;
-                }
-            }
-
+            MXRoomMember *myMember = [roomMembers memberWithUserId:self.mxRoom.mxSession.myUserId];
+            NSString *inviterUserId = myMember.originalEvent.sender;
+            NSString *inviter = [roomMembers memberName:inviterUserId] ?: inviterUserId;
+            
             // FIXME: Display members status when it will be available
             self.roomMembers.text = nil;
             //                    if (memberCount)


### PR DESCRIPTION
Get inviter display name directly from the invite event, rather than looping in room members. Fixes #2520 