### PR TITLE
Settings: Secure backup

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -574,6 +574,9 @@
 "security_settings_crypto_sessions_loading" = "Loading sessions…";
 "security_settings_crypto_sessions_description" = "Trust sessions to grant access to end-to-end encrypted messages. If you don’t recognise a session, change your login password and reset your Message Password used for Message Backup.";
 
+"security_settings_secure_backup" = "SECURE BACKUP";
+"security_settings_secure_backup_description" =  "Safeguard against losing access to encrypted messages & data by backing up encryption keys on your server.";
+
 "security_settings_backup" = "MESSAGE BACKUP";
 
 "security_settings_crosssigning" = "CROSS-SIGNING";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -602,6 +602,7 @@
 "security_settings_complete_security_alert_message" = "You should complete security on your current session first.";
 
 "security_settings_coming_soon" = "Sorry. This action is not available on Riot-iOS yet. Please use another Matrix client to set it up. Riot-iOS will use it.";
+"security_settings_user_password_description" = "Confirm your identity by entering your account password";
 
 // Manage session
 "manage_session_title" = "Manage session";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -576,6 +576,9 @@
 
 "security_settings_secure_backup" = "SECURE BACKUP";
 "security_settings_secure_backup_description" =  "Safeguard against losing access to encrypted messages & data by backing up encryption keys on your server.";
+"security_settings_secure_backup_setup" = "Set up";
+"security_settings_secure_backup_synchronise" = "Synchronise";
+"security_settings_secure_backup_delete" = "Delete";
 
 "security_settings_backup" = "MESSAGE BACKUP";
 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -3206,6 +3206,10 @@ internal enum VectorL10n {
   internal static var securitySettingsTitle: String { 
     return VectorL10n.tr("Vector", "security_settings_title") 
   }
+  /// Confirm your identity by entering your account password
+  internal static var securitySettingsUserPasswordDescription: String { 
+    return VectorL10n.tr("Vector", "security_settings_user_password_description") 
+  }
   /// Send to %@
   internal static func sendTo(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "send_to", p1)

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -3182,6 +3182,14 @@ internal enum VectorL10n {
   internal static var securitySettingsExportKeysManually: String { 
     return VectorL10n.tr("Vector", "security_settings_export_keys_manually") 
   }
+  /// SECURE BACKUP
+  internal static var securitySettingsSecureBackup: String { 
+    return VectorL10n.tr("Vector", "security_settings_secure_backup") 
+  }
+  /// Safeguard against losing access to encrypted messages & data by backing up encryption keys on your server.
+  internal static var securitySettingsSecureBackupDescription: String { 
+    return VectorL10n.tr("Vector", "security_settings_secure_backup_description") 
+  }
   /// Security
   internal static var securitySettingsTitle: String { 
     return VectorL10n.tr("Vector", "security_settings_title") 

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -3186,9 +3186,21 @@ internal enum VectorL10n {
   internal static var securitySettingsSecureBackup: String { 
     return VectorL10n.tr("Vector", "security_settings_secure_backup") 
   }
+  /// Delete
+  internal static var securitySettingsSecureBackupDelete: String { 
+    return VectorL10n.tr("Vector", "security_settings_secure_backup_delete") 
+  }
   /// Safeguard against losing access to encrypted messages & data by backing up encryption keys on your server.
   internal static var securitySettingsSecureBackupDescription: String { 
     return VectorL10n.tr("Vector", "security_settings_secure_backup_description") 
+  }
+  /// Set up
+  internal static var securitySettingsSecureBackupSetup: String { 
+    return VectorL10n.tr("Vector", "security_settings_secure_backup_setup") 
+  }
+  /// Synchronise
+  internal static var securitySettingsSecureBackupSynchronise: String { 
+    return VectorL10n.tr("Vector", "security_settings_secure_backup_synchronise") 
   }
   /// Security
   internal static var securitySettingsTitle: String { 

--- a/Riot/Modules/Settings/Security/SecurityViewController.m
+++ b/Riot/Modules/Settings/Security/SecurityViewController.m
@@ -680,7 +680,6 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
 
 - (void)refreshSecureBackupSectionData
 {
-    // TODO
     MXRecoveryService *recoveryService =  self.mainSession.crypto.recoveryService;
     if (recoveryService.hasRecovery)
     {
@@ -1149,7 +1148,7 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
 #endif
             case SECURE_BACKUP_SETUP:
             {
-                MXKTableViewCellWithButton *buttonCell = [self buttonCellWithTitle:@"Set up"    // TODO
+                MXKTableViewCellWithButton *buttonCell = [self buttonCellWithTitle:NSLocalizedStringFromTable(@"security_settings_secure_backup_setup", @"Vector", nil)
                                                                             action:@selector(setupSecureBackup)
                                                                       forTableView:tableView
                                                                        atIndexPath:indexPath];
@@ -1159,17 +1158,17 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
             }
             case SECURE_BACKUP_RESTORE:
             {
-                MXKTableViewCellWithButton *buttonCell = [self buttonCellWithTitle:@"Synchronise"    // TODO
-                                                                                   action:@selector(restoreFromSecureBackup)
-                                                                             forTableView:tableView
-                                                                              atIndexPath:indexPath];
+                MXKTableViewCellWithButton *buttonCell = [self buttonCellWithTitle:NSLocalizedStringFromTable(@"security_settings_secure_backup_synchronise", @"Vector", nil)
+                                                                            action:@selector(restoreFromSecureBackup)
+                                                                      forTableView:tableView
+                                                                       atIndexPath:indexPath];
                 
                 cell = buttonCell;
                 break;
             }
             case SECURE_BACKUP_DELETE:
             {
-                MXKTableViewCellWithButton *buttonCell = [self buttonCellWithTitle:@"Delete"  // TODO
+                MXKTableViewCellWithButton *buttonCell = [self buttonCellWithTitle:NSLocalizedStringFromTable(@"security_settings_secure_backup_delete", @"Vector", nil)
                                                                             action:@selector(deleteSecureBackup)
                                                                       forTableView:tableView
                                                                        atIndexPath:indexPath];

--- a/Riot/Modules/Settings/Security/SecurityViewController.m
+++ b/Riot/Modules/Settings/Security/SecurityViewController.m
@@ -35,10 +35,10 @@
 enum
 {
     SECTION_CRYPTO_SESSIONS,
-    SECTION_CROSSSIGNING,
     SECTION_SECURE_BACKUP,
     SECTION_CRYPTOGRAPHY,
 #ifdef CROSS_SIGNING_AND_BACKUP_DEV
+    SECTION_CROSSSIGNING,
     SECTION_KEYBACKUP,
 #endif
     SECTION_ADVANCED,
@@ -59,7 +59,9 @@ enum {
     // - Advice them to do a recovery if local keys are obsolete -> We cannot know now
     // - Advice them to fix a secure backup if there is 4S but no key backup
     // - Warm them if there is no 4S and they do not have all 3 signing keys locally. They will set up a not complete secure backup
+#ifdef CROSS_SIGNING_AND_BACKUP_DEV
     SECURE_BACKUP_INFO,
+#endif
     SECURE_BACKUP_SETUP,
     SECURE_BACKUP_RESTORE,
     SECURE_BACKUP_DELETE,
@@ -683,7 +685,6 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
     if (recoveryService.hasRecovery)
     {
         secureBackupSectionState = @[
-                                     @(SECURE_BACKUP_INFO),
                                      @(SECURE_BACKUP_RESTORE),
                                      @(SECURE_BACKUP_DELETE),
                                      @(SECURE_BACKUP_DESCRIPTION),
@@ -695,7 +696,6 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
         if (self.canSetupSecureBackup)
         {
             secureBackupSectionState = @[
-                                         @(SECURE_BACKUP_INFO),
                                          @(SECURE_BACKUP_SETUP),    // TODO: Check we have all keys locally (at least MSK, SSK & SSK)
                                          @(SECURE_BACKUP_DESCRIPTION),
                                          //@(SECURE_BACKUP_MANAGE_MANUALLY),
@@ -704,12 +704,16 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
         else
         {
             secureBackupSectionState = @[
-                                         @(SECURE_BACKUP_INFO),
                                          @(SECURE_BACKUP_DESCRIPTION),
                                          //@(SECURE_BACKUP_MANAGE_MANUALLY),
                                          ];
         }
     }
+    
+#ifdef CROSS_SIGNING_AND_BACKUP_DEV
+    secureBackupSectionState = [@[@(SECURE_BACKUP_INFO)] arrayByAddingObjectsFromArray:secureBackupSectionState];
+#endif
+    
 }
 
 - (NSUInteger)secureBackupSectionEnumForRow:(NSUInteger)row
@@ -922,10 +926,10 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
         case SECTION_KEYBACKUP:
             count = keyBackupSection.numberOfRows;
             break;
-#endif
         case SECTION_CROSSSIGNING:
             count = [self numberOfRowsInCrossSigningSection];
             break;
+#endif
         case SECTION_CRYPTOGRAPHY:
             count = CRYPTOGRAPHY_COUNT;
             break;
@@ -1135,23 +1139,17 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
                                                 withText:NSLocalizedStringFromTable(@"security_settings_secure_backup_description", @"Vector", nil)];
                 break;
             }
+#ifdef CROSS_SIGNING_AND_BACKUP_DEV
             case SECURE_BACKUP_INFO:
             {
-                // TODO
                 cell = [self descriptionCellForTableView:tableView
                                                 withText:self.secureBackupInformation];
                 break;
             }
+#endif
             case SECURE_BACKUP_SETUP:
             {
-                // TODO: Button or cell?
-//                MXKTableViewCellWithTextView *textCell = [self textViewCellForTableView:tableView atIndexPath:indexPath];
-//                textCell.mxkTextView.text = @"Set up Secure Backup";    // TODO
-//                textCell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-//
-//                cell = textCell;
-                
-                MXKTableViewCellWithButton *buttonCell = [self buttonCellWithTitle:@"Set up Secure Backup"    // TODO
+                MXKTableViewCellWithButton *buttonCell = [self buttonCellWithTitle:@"Set up"    // TODO
                                                                             action:@selector(setupSecureBackup)
                                                                       forTableView:tableView
                                                                        atIndexPath:indexPath];
@@ -1161,7 +1159,7 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
             }
             case SECURE_BACKUP_RESTORE:
             {
-                MXKTableViewCellWithButton *buttonCell = [self buttonCellWithTitle:@"Synchronise (Restore and/or Back up)"    // TODO
+                MXKTableViewCellWithButton *buttonCell = [self buttonCellWithTitle:@"Synchronise"    // TODO
                                                                                    action:@selector(restoreFromSecureBackup)
                                                                              forTableView:tableView
                                                                               atIndexPath:indexPath];
@@ -1171,7 +1169,7 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
             }
             case SECURE_BACKUP_DELETE:
             {
-                MXKTableViewCellWithButton *buttonCell = [self buttonCellWithTitle:@"Delete Secure Backup"  // TODO
+                MXKTableViewCellWithButton *buttonCell = [self buttonCellWithTitle:@"Delete"  // TODO
                                                                             action:@selector(deleteSecureBackup)
                                                                       forTableView:tableView
                                                                        atIndexPath:indexPath];
@@ -1198,7 +1196,6 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
     {
         cell = [keyBackupSection cellForRowAtRow:row];
     }
-#endif
     else if (section == SECTION_CROSSSIGNING)
     {
         switch (row)
@@ -1218,6 +1215,7 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
                 break;
         }
     }
+#endif
     else if (section == SECTION_CRYPTOGRAPHY)
     {
         switch (row)
@@ -1281,9 +1279,9 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
 #ifdef CROSS_SIGNING_AND_BACKUP_DEV
         case SECTION_KEYBACKUP:
             return NSLocalizedStringFromTable(@"security_settings_backup", @"Vector", nil);
-#endif
         case SECTION_CROSSSIGNING:
             return NSLocalizedStringFromTable(@"security_settings_crosssigning", @"Vector", nil);
+#endif
         case SECTION_CRYPTOGRAPHY:
             return NSLocalizedStringFromTable(@"security_settings_cryptography", @"Vector", nil);
         case SECTION_ADVANCED:


### PR DESCRIPTION
Fixes #3296 

The key backup section is removed. This is now handle by the secure backup. The creation of the secure backup will re-use existing key backup.
The cross-signing section is gone. Cross-signing should be enabled by default now (on login or on registration). We will have a banner to migrate existing users (#3299). If the user taps on "set up secure backup", the cross-signing will be set up.

<img width="387" alt="Screenshot 2020-06-30 at 16 45 05" src="https://user-images.githubusercontent.com/8418515/86143160-648d7480-baf4-11ea-8171-82cc8f106032.png">

<img width="416" alt="Screenshot 2020-06-30 at 17 10 22" src="https://user-images.githubusercontent.com/8418515/86143355-9b638a80-baf4-11ea-93ef-2783784aa0f7.png">

User migration:
<img width="401" alt="Screenshot 2020-06-30 at 16 44 51" src="https://user-images.githubusercontent.com/8418515/86143159-61928400-baf4-11ea-8773-d55a18d48fd5.png">

