### PR TITLE
Table view headers and footers

### DIFF
--- a/Riot/Modules/Room/Settings/RoomSettingsViewController.m
+++ b/Riot/Modules/Room/Settings/RoomSettingsViewController.m
@@ -2084,8 +2084,7 @@ NSString *const kRoomSettingsAdvancedE2eEnabledCellViewIdentifier = @"kRoomSetti
     {
         // Customize label style
         UITableViewHeaderFooterView *tableViewHeaderFooterView = (UITableViewHeaderFooterView*)view;
-        tableViewHeaderFooterView.textLabel.textColor = ThemeService.shared.theme.textPrimaryColor;
-        tableViewHeaderFooterView.textLabel.font = [UIFont systemFontOfSize:15];
+        tableViewHeaderFooterView.textLabel.textColor = ThemeService.shared.theme.headerTextPrimaryColor;
     }
 }
 

--- a/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
+++ b/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
@@ -490,8 +490,7 @@ enum {
     {
         // Customize label style
         UITableViewHeaderFooterView *tableViewHeaderFooterView = (UITableViewHeaderFooterView*)view;
-        tableViewHeaderFooterView.textLabel.textColor = ThemeService.shared.theme.textPrimaryColor;
-        tableViewHeaderFooterView.textLabel.font = [UIFont systemFontOfSize:15];
+        tableViewHeaderFooterView.textLabel.textColor = ThemeService.shared.theme.headerTextPrimaryColor;
     }
 }
 

--- a/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
+++ b/Riot/Modules/Settings/Security/ManageSession/ManageSessionViewController.m
@@ -377,7 +377,8 @@ enum {
 {
     MXKTableViewCell *cell = [self getDefaultTableViewCell:tableView];
     cell.textLabel.text = text;
-    cell.textLabel.textColor = ThemeService.shared.theme.textPrimaryColor;
+    cell.textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote];
+    cell.textLabel.textColor = ThemeService.shared.theme.headerTextPrimaryColor;
     cell.textLabel.numberOfLines = 0;
     cell.contentView.backgroundColor = ThemeService.shared.theme.headerBackgroundColor;
     cell.selectionStyle = UITableViewCellSelectionStyleNone;

--- a/Riot/Modules/Settings/Security/SecurityViewController.m
+++ b/Riot/Modules/Settings/Security/SecurityViewController.m
@@ -1051,7 +1051,8 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
 {
     MXKTableViewCell *cell = [self getDefaultTableViewCell:tableView];
     cell.textLabel.text = text;
-    cell.textLabel.textColor = ThemeService.shared.theme.textPrimaryColor;
+    cell.textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote];
+    cell.textLabel.textColor = ThemeService.shared.theme.headerTextPrimaryColor;
     cell.textLabel.numberOfLines = 0;
     cell.contentView.backgroundColor = ThemeService.shared.theme.headerBackgroundColor;
     cell.selectionStyle = UITableViewCellSelectionStyleNone;

--- a/Riot/Modules/Settings/Security/SecurityViewController.m
+++ b/Riot/Modules/Settings/Security/SecurityViewController.m
@@ -1320,8 +1320,7 @@ SecureBackupSetupCoordinatorBridgePresenterDelegate>
     {
         // Customize label style
         UITableViewHeaderFooterView *tableViewHeaderFooterView = (UITableViewHeaderFooterView*)view;
-        tableViewHeaderFooterView.textLabel.textColor = ThemeService.shared.theme.textPrimaryColor;
-        tableViewHeaderFooterView.textLabel.font = [UIFont systemFontOfSize:15];
+        tableViewHeaderFooterView.textLabel.textColor = ThemeService.shared.theme.headerTextPrimaryColor;
     }
 }
 

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -2313,8 +2313,7 @@ SettingsIdentityServerCoordinatorBridgePresenterDelegate>
     {
         // Customize label style
         UITableViewHeaderFooterView *tableViewHeaderFooterView = (UITableViewHeaderFooterView*)view;
-        tableViewHeaderFooterView.textLabel.textColor = ThemeService.shared.theme.textPrimaryColor;
-        tableViewHeaderFooterView.textLabel.font = [UIFont systemFontOfSize:15];
+        tableViewHeaderFooterView.textLabel.textColor = ThemeService.shared.theme.headerTextPrimaryColor;
     }
 }
 

--- a/Riot/Modules/Settings/SettingsViewController.m
+++ b/Riot/Modules/Settings/SettingsViewController.m
@@ -1319,6 +1319,18 @@ SettingsIdentityServerCoordinatorBridgePresenterDelegate>
     return cell;
 }
 
+- (MXKTableViewCell*)descriptionCellForTableView:(UITableView*)tableView
+{
+    MXKTableViewCell *cell = [self getDefaultTableViewCell:tableView];
+    cell.textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote];
+    cell.textLabel.textColor = ThemeService.shared.theme.headerTextPrimaryColor;
+    cell.textLabel.numberOfLines = 0;
+    cell.contentView.backgroundColor = ThemeService.shared.theme.headerBackgroundColor;
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+
+    return cell;
+}
+
 - (MXKTableViewCellWithTextView*)textViewCellForTableView:(UITableView*)tableView atIndexPath:(NSIndexPath *)indexPath
 {
     MXKTableViewCellWithTextView *textViewCell = [tableView dequeueReusableCellWithIdentifier:[MXKTableViewCellWithTextView defaultReuseIdentifier] forIndexPath:indexPath];
@@ -1621,7 +1633,7 @@ SettingsIdentityServerCoordinatorBridgePresenterDelegate>
         }
         else if (row == userSettingsThreePidsInformation)
         {
-            MXKTableViewCell *threePidsInformationCell = [self getDefaultTableViewCell:self.tableView];
+            MXKTableViewCell *threePidsInformationCell = [self descriptionCellForTableView:self.tableView];
             
             NSMutableAttributedString *attributedString =  [[NSMutableAttributedString alloc] initWithString:NSLocalizedStringFromTable(@"settings_three_pids_management_information_part1", @"Vector", nil) attributes:@{NSForegroundColorAttributeName: ThemeService.shared.theme.textPrimaryColor}];
             [attributedString appendAttributedString:[[NSAttributedString alloc] initWithString:NSLocalizedStringFromTable(@"settings_three_pids_management_information_part2", @"Vector", nil) attributes:@{NSForegroundColorAttributeName: ThemeService.shared.theme.tintColor}]];
@@ -1692,7 +1704,7 @@ SettingsIdentityServerCoordinatorBridgePresenterDelegate>
         }
         else if (row == NOTIFICATION_SETTINGS_GLOBAL_SETTINGS_INDEX)
         {
-            MXKTableViewCell *globalInfoCell = [self getDefaultTableViewCell:tableView];
+            MXKTableViewCell *globalInfoCell = [self descriptionCellForTableView:tableView];
 
             NSString *appDisplayName = [[NSBundle mainBundle] infoDictionary][@"CFBundleDisplayName"];
 
@@ -1747,7 +1759,7 @@ SettingsIdentityServerCoordinatorBridgePresenterDelegate>
             // Remove "stun:"
             stunFallbackHost = [stunFallbackHost componentsSeparatedByString:@":"].lastObject;
 
-            MXKTableViewCell *globalInfoCell = [self getDefaultTableViewCell:tableView];
+            MXKTableViewCell *globalInfoCell = [self descriptionCellForTableView:tableView];
             globalInfoCell.textLabel.text = [NSString stringWithFormat:NSLocalizedStringFromTable(@"settings_calls_stun_server_fallback_description", @"Vector", nil), stunFallbackHost];
             globalInfoCell.textLabel.numberOfLines = 0;
             globalInfoCell.selectionStyle = UITableViewCellSelectionStyleNone;
@@ -1782,7 +1794,7 @@ SettingsIdentityServerCoordinatorBridgePresenterDelegate>
 
             case IDENTITY_SERVER_DESCRIPTION_INDEX:
             {
-                MXKTableViewCell *descriptionCell = [self getDefaultTableViewCell:tableView];
+                MXKTableViewCell *descriptionCell = [self descriptionCellForTableView:tableView];
 
                 if (account.mxSession.identityService.identityServer)
                 {
@@ -1823,7 +1835,7 @@ SettingsIdentityServerCoordinatorBridgePresenterDelegate>
 
             case INTEGRATIONS_DESCRIPTION_INDEX:
             {
-                MXKTableViewCell *descriptionCell = [self getDefaultTableViewCell:tableView];
+                MXKTableViewCell *descriptionCell = [self descriptionCellForTableView:tableView];
 
                 NSString *integrationManager = [WidgetManager.sharedManager configForUser:session.myUser.userId].apiUrl;
                 NSString *integrationManagerDomain = [NSURL URLWithString:integrationManager].host;


### PR DESCRIPTION
Not sure if you'd like this PR or not, however it helps make the settings view feel more inline with iOS's design by updating the table view header font sizes and by showing descriptions in the footnote text style as if they were section footers.

![Simulator Screen Shot - iPhone SE - 2020-07-15 at 18 37 04](https://user-images.githubusercontent.com/6060466/87581982-af50e400-c6d1-11ea-9250-23546fac6519.png)

![Simulator Screen Shot - iPhone SE - 2020-07-15 at 18 37 10](https://user-images.githubusercontent.com/6060466/87582086-cd1e4900-c6d1-11ea-9d4f-be89c310dac5.png)

It may look better to use a secondary text colour for these as this is more in line with normal iOS settings, and I'd be happy to update if you wish:

![lighter](https://user-images.githubusercontent.com/6060466/87582571-782f0280-c6d2-11ea-923b-4565ecc09363.png)

If you are happy with this PR I will update CHANGES.rst and sign off on it.

### Pull Request Checklist

* [x] UI change has been tested on both light and dark themes
* [x] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [x] Pull request includes screenshots or videos of UI changes
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
