### PR TITLE
Add Xcode file header template

### DIFF
--- a/Riot.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/Riot.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string> 
+// Copyright 2020 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//</string>
+</dict>
+</plist>


### PR DESCRIPTION
Add Xcode file header template `IDETemplateMacros.plist` shared for all users.