### PR TITLE
Poor fix for missing "Riot is now element" modal

### DIFF
--- a/Riot/AppDelegate.m
+++ b/Riot/AppDelegate.m
@@ -4582,7 +4582,10 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
 {
     if (self.majorUpdateManager.shouldShowMajorUpdate)
     {
-        [self showMajorUpdate];
+        // When you do not understand why the UI does not work as expected...
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self showMajorUpdate];
+        });
     }
 }
 

--- a/Riot/Managers/AppVersion/AppVersion.swift
+++ b/Riot/Managers/AppVersion/AppVersion.swift
@@ -94,6 +94,10 @@ final class AppVersion: NSObject {
         UserDefaults.standard.set(currentVersion.bundleShortVersion, forKey: Constants.lastBundleShortVersion)
         UserDefaults.standard.set(currentVersion.bundleVersion, forKey: Constants.lastBundleVersion)
     }
+    
+    override var description: String {
+        return "\(bundleShortVersion)(\(bundleVersion))"
+    }
 
     // MARK: - Private
 

--- a/Riot/Modules/MajorUpdate/MajorUpdateManager.swift
+++ b/Riot/Modules/MajorUpdate/MajorUpdateManager.swift
@@ -31,9 +31,14 @@ final public class MajorUpdateManager: NSObject {
     
     var shouldShowMajorUpdate: Bool {
         guard let lastUsedAppVersion = AppVersion.lastUsed else {
+            NSLog("[MajorUpdateManager] shouldShowMajorUpdate: Unknown previous version")
             return true
         }
-        return lastUsedAppVersion.compare(Constants.lastMajorAppVersion) == .orderedAscending
+        
+        let shouldShowMajorUpdate = (lastUsedAppVersion.compare(Constants.lastMajorAppVersion) == .orderedAscending)
+        NSLog("[MajorUpdateManager] shouldShowMajorUpdate: \(shouldShowMajorUpdate). AppVersion.lastUsed: \(lastUsedAppVersion). lastMajorAppVersion: \(Constants.lastMajorAppVersion)")
+        
+        return shouldShowMajorUpdate
     }
     
     var learnMoreURL: URL {

--- a/Riot/Modules/SlidingModal/SlidingModalPresenter.swift
+++ b/Riot/Modules/SlidingModal/SlidingModalPresenter.swift
@@ -38,6 +38,8 @@ final class SlidingModalPresenter: NSObject {
     
     @objc func present(_ viewController: SlidingModalPresentable.ViewControllerType, from presentingViewController: UIViewController, animated: Bool, completion: (() -> Void)?) {
         
+        NSLog("[SlidingModalPresenter] present \(type(of: viewController))")
+        
         if UIDevice.current.userInterfaceIdiom == .pad {
             viewController.modalPresentationStyle = .formSheet
             
@@ -62,6 +64,9 @@ final class SlidingModalPresenter: NSObject {
     }
     
     @objc func presentView(_ view: SlidingModalPresentable.ViewType, from viewControllerPresenter: UIViewController, animated: Bool, completion: (() -> Void)?) {
+        
+        NSLog("[SlidingModalPresenter] presentView \(type(of: view))")
+        
         let viewController = SlidingModalEmptyViewController.instantiate(with: view)
         self.present(viewController, from: viewControllerPresenter, animated: animated, completion: completion)
     }


### PR DESCRIPTION
Eventually a fix for #3451 .
At least we have more logs for it.