### PR TITLE
Remove Riot from App Name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Improvements:
  * BuildSettings: A new class that entralises build settings and exposes xcconfig variable.
  * AuthenticationVC: Make custom server options and register button configurable.
 
+Bug fix:
+ * Rebranding: Remove Riot from app name (#3497).
+
 Changes in 1.0.2 (2020-07-28)
 ===============================================
 

--- a/Config/Common.xcconfig
+++ b/Config/Common.xcconfig
@@ -17,6 +17,6 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-BUNDLE_DISPLAY_NAME = Element (Riot.im)
+BUNDLE_DISPLAY_NAME = Element
 
 APPLICATION_GROUP_IDENTIFIER = group.im.vector

--- a/Riot/Modules/MajorUpdate/MajorUpdateManager.swift
+++ b/Riot/Modules/MajorUpdate/MajorUpdateManager.swift
@@ -32,7 +32,7 @@ final public class MajorUpdateManager: NSObject {
     var shouldShowMajorUpdate: Bool {
         guard let lastUsedAppVersion = AppVersion.lastUsed else {
             NSLog("[MajorUpdateManager] shouldShowMajorUpdate: Unknown previous version")
-            return true
+            return false
         }
         
         let shouldShowMajorUpdate = (lastUsedAppVersion.compare(Constants.lastMajorAppVersion) == .orderedAscending)


### PR DESCRIPTION
Fixes #3497. No need to do anything on major update popup. It will only be visible for the users coming from < 1.0.0 versions.