### PR TITLE
Correctly select reactions and URL previews when selecting a message.

### DIFF
--- a/Riot/Modules/Room/DataSources/RoomDataSource.m
+++ b/Riot/Modules/Room/DataSources/RoomDataSource.m
@@ -377,6 +377,7 @@ const CGFloat kTypingCellHeight = 24;
                         urlPreviewView = [URLPreviewView instantiate];
                         urlPreviewView.preview = component.urlPreviewData;
                         urlPreviewView.delegate = self;
+                        urlPreviewView.tag = index;
                         
                         [temporaryViews addObject:urlPreviewView];
                         
@@ -416,6 +417,7 @@ const CGFloat kTypingCellHeight = 24;
                         
                         reactionsView = [BubbleReactionsView new];
                         reactionsView.viewModel = bubbleReactionsViewModel;
+                        reactionsView.tag = index;
                         [reactionsView updateWithTheme:ThemeService.shared.theme];
                         
                         bubbleReactionsViewModel.viewModelDelegate = self;

--- a/Riot/Utils/Tools.m
+++ b/Riot/Utils/Tools.m
@@ -126,7 +126,7 @@
          if (attrs[NSForegroundColorAttributeName])
          {
              UIColor *color = attrs[NSForegroundColorAttributeName];
-             color = [color colorWithAlphaComponent:0.2];
+             color = [color colorWithAlphaComponent:alpha];
 
              NSMutableDictionary *newAttrs = [NSMutableDictionary dictionaryWithDictionary:attrs];
              newAttrs[NSForegroundColorAttributeName] = color;

--- a/changelog.d/4992.bugfix
+++ b/changelog.d/4992.bugfix
@@ -1,0 +1,1 @@
+Timeline: Selecting a message now correctly selects any reactions and URL previews too.


### PR DESCRIPTION
Fixes #4992. The view tags weren't being set meaning selecting the first message in a cell didn't dim any previews or reactions, whereas selecting any other message in a cell dimmed them all.
![Frame 1](https://user-images.githubusercontent.com/6060466/137102112-206cca4b-28cb-4c0d-9fe8-a2b53a3f04ba.png)