### PR TITLE
Update to Xcode 12.5 and macOS 11.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   tests:
     name: Tests
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
       - uses: actions/checkout@v2

--- a/changelog.d/pr-4998.build
+++ b/changelog.d/pr-4998.build
@@ -1,0 +1,1 @@
+Build: Update to Xcode 12.5 in the Fastfile and macOS 11 in the GitHub actions.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,7 +21,7 @@ platform :ios do
 
   before_all do
     # Ensure used Xcode version
-    xcversion(version: "~> 12.1")
+    xcversion(version: "~> 12.5")
   end
 
   #### Public ####


### PR DESCRIPTION
CI has been failing this morning due to the use of a Swift 5.4 feature. As we're all on Xcode 12.5 now, this updates the Fastfile to use that version and GitHub actions to use macOS 11 (which they still aren't for some reason).