### PR TITLE
Allow images to be pasted from Safari rather than their URL.

### DIFF
--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.m
@@ -38,7 +38,7 @@ const NSTimeInterval kActionMenuContentAlphaAnimationDuration = .2;
 const NSTimeInterval kActionMenuComposerHeightAnimationDuration = .3;
 const CGFloat kComposerContainerTrailingPadding = 12;
 
-@interface RoomInputToolbarView() <GrowingTextViewDelegate>
+@interface RoomInputToolbarView() <GrowingTextViewDelegate, RoomInputToolbarTextViewDelegate>
 {
     // The intermediate action sheet
     UIAlertController *actionSheet;
@@ -83,6 +83,8 @@ const CGFloat kComposerContainerTrailingPadding = 12;
     self.isEncryptionEnabled = _isEncryptionEnabled;
     
     [self updateUIWithTextMessage:nil animated:NO];
+    
+    self.textView.toolbarDelegate = self;
 }
 
 - (void)setVoiceMessageToolbarView:(UIView *)voiceMessageToolbarView
@@ -382,6 +384,16 @@ const CGFloat kComposerContainerTrailingPadding = 12;
     [super onTouchUpInside:button];
 }
 
+- (BOOL)becomeFirstResponder
+{
+    return [self.textView becomeFirstResponder];
+}
+
+- (void)dismissKeyboard
+{
+    [self.textView resignFirstResponder];
+}
+
 - (void)destroy
 {
     if (actionSheet)
@@ -453,6 +465,11 @@ const CGFloat kComposerContainerTrailingPadding = 12;
     // TODO Custom here the validation screen for each available item
     
     [super paste:sender];
+}
+
+- (void)textView:(GrowingTextView *)textView didReceivePasteForMediaFromSender:(id)sender
+{
+    [self paste:sender];
 }
 
 #pragma mark - Private

--- a/changelog.d/2076.bugfix
+++ b/changelog.d/2076.bugfix
@@ -1,0 +1,1 @@
+Message Composer: Pasting images from Safari now pastes the image and not its URL.


### PR DESCRIPTION
Fixes #2076, depends on https://github.com/matrix-org/matrix-ios-kit/pull/934. Two points to note:
- GIFs aren't animated as Safari copies them as `UIImage` objects and so only contain the first frame ☹️
In theory it would be possible to download them via the URL, but when copying a GIF that links to something else, the copied URL is for that link and not the GIF's source.
- I've added a couple of methods to `RoomInputToolbarView` that were previously inherited before switching to `GrowingTextView`. This fixes pasting an image having the keyboard overlaid on top of the confirmation view and editing a message not showing the keyboard automatically.