### PR TITLE
Fix avatars and hide spaces in Share Extension.

### DIFF
--- a/RiotShareExtension/Shared/ShareDataSource.m
+++ b/RiotShareExtension/Shared/ShareDataSource.m
@@ -86,7 +86,7 @@
         
         for (MXRoomSummary *roomSummary in roomsSummaries)
         {
-            if (!roomSummary.hiddenFromUser)
+            if (!roomSummary.hiddenFromUser && roomSummary.roomType == MXRoomTypeRoom)
             {
                 [roomSummary setMatrixSession:session];
                 

--- a/RiotShareExtension/Shared/View/RecentRoomTableViewCell.m
+++ b/RiotShareExtension/Shared/View/RecentRoomTableViewCell.m
@@ -86,7 +86,7 @@
         [self.avatarImageView vc_setRoomAvatarImageWith:roomCellData.avatarUrl
                                                  roomId:roomCellData.roomIdentifier
                                             displayName:roomCellData.roomDisplayname
-                                           mediaManager:roomCellData.mxSession.mediaManager];
+                                           mediaManager:roomCellData.roomSummary.mxSession.mediaManager];
         
         self.roomTitleLabel.text = roomCellData.roomDisplayname;
         if (!self.roomTitleLabel.text.length)

--- a/changelog.d/5057.bugfix
+++ b/changelog.d/5057.bugfix
@@ -1,0 +1,1 @@
+Share Extension: Fix missing avatars and don't list spaces as rooms.


### PR DESCRIPTION
Fixes #5057.
- Avatars were missing as the room cell data doesn't have an associated MXSession in the share extension, but it summary does (side effect of #4980 only visible on fresh installs).
- Rooms are now filtered to only show room types so that spaces are now hidden.