### PR TITLE
Fix crash when using the built in camera.

### DIFF
--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -7154,7 +7154,7 @@ static CGSize kThreadListBarButtonItemImageSize;
     self.cameraPresenter = nil;
 }
 
-- (void)cameraPresenter:(CameraPresenter *)cameraPresenter didSelectImageData:(NSData *)imageData withUTI:(MXKUTI *)uti
+- (void)cameraPresenter:(CameraPresenter *)cameraPresenter didSelectImage:(UIImage *)image
 {
     [cameraPresenter dismissWithAnimated:YES completion:nil];
     self.cameraPresenter = nil;
@@ -7162,8 +7162,9 @@ static CGSize kThreadListBarButtonItemImageSize;
     RoomInputToolbarView *roomInputToolbarView = [self inputToolbarViewAsRoomInputToolbarView];
     if (roomInputToolbarView)
     {
+        NSData *imageData = UIImageJPEGRepresentation(image, 1.0);
         [roomInputToolbarView sendSelectedImage:imageData
-                                   withMimeType:uti.mimeType
+                                   withMimeType:MXKUTI.jpeg.mimeType
                              andCompressionMode:MediaCompressionHelper.defaultCompressionMode
                             isPhotoLibraryAsset:NO];
     }

--- a/changelog.d/5951.bugfix
+++ b/changelog.d/5951.bugfix
@@ -1,0 +1,1 @@
+Message Composer: Fix a crash when sending a photo using the camera.


### PR DESCRIPTION
As part of #5861 the `CameraPresenterDelegate` changed, however `RoomViewController` wasn't updated to take this into account (I miss Swift's errors in this case!) This PR updates it and fixes the crash.