### PR TITLE
Fix some warnings.

### DIFF
--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.h
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomDataSource.h
@@ -622,7 +622,7 @@ extern NSString *const kMXKRoomDataSourceTimelineErrorErrorKey;
  @param latitude the location's latitude
  @param longitude the location's longitude
  @param description an optional description
- @param assetType the location's type
+ @param coordinateType the location's type
  @param success A block object called when the operation succeeds. It returns
                 the event id of the event generated on the homeserver
  @param failure A block object called when the operation fails.

--- a/Riot/Modules/Spaces/SpaceMembers/MemberDetail/SpaceMemberDetailCoordinator.swift
+++ b/Riot/Modules/Spaces/SpaceMembers/MemberDetail/SpaceMemberDetailCoordinator.swift
@@ -50,7 +50,11 @@ final class SpaceMemberDetailCoordinator: NSObject, SpaceMemberDetailCoordinator
     init(parameters: SpaceMemberDetailCoordinatorParameters) {
         self.parameters = parameters
         
-        let spaceMemberDetailViewModel = SpaceMemberDetailViewModel(userSessionsService: parameters.userSessionsService, session: parameters.session, member: parameters.member, spaceId: parameters.spaceId, showCancelMenuItem: parameters.showCancelMenuItem)
+        let spaceMemberDetailViewModel = SpaceMemberDetailViewModel(userSessionsService: parameters.userSessionsService,
+                                                                    session: parameters.session,
+                                                                    member: parameters.member,
+                                                                    spaceId: parameters.spaceId,
+                                                                    showCancelMenuItem: parameters.showCancelMenuItem)
         let spaceMemberDetailViewController = SpaceMemberDetailViewController.instantiate(with: spaceMemberDetailViewModel)
         spaceMemberDetailViewController.enableMention = true
         spaceMemberDetailViewController.enableVoipCall = false

--- a/Riot/Modules/Threads/Beta/ThreadsBetaCoordinatorBridgePresenter.swift
+++ b/Riot/Modules/Threads/Beta/ThreadsBetaCoordinatorBridgePresenter.swift
@@ -26,7 +26,8 @@ import MatrixSDK
 
 /// ThreadsBetaCoordinatorBridgePresenter enables to start ThreadsBetaCoordinator from a view controller.
 /// This bridge is used while waiting for global usage of coordinator pattern.
-/// **WARNING**: This class breaks the Coordinator abstraction and it has been introduced for **Objective-C compatibility only** (mainly for integration in legacy view controllers). Each bridge should be removed once the underlying Coordinator has been integrated by another Coordinator.
+/// **WARNING**: This class breaks the Coordinator abstraction and it has been introduced for **Objective-C compatibility only** (mainly for integration in legacy view controllers).
+/// Each bridge should be removed once the underlying Coordinator has been integrated by another Coordinator.
 @objcMembers
 final class ThreadsBetaCoordinatorBridgePresenter: NSObject {
     

--- a/changelog.d/pr-6032.misc
+++ b/changelog.d/pr-6032.misc
@@ -1,0 +1,1 @@
+Fix some warnings.


### PR DESCRIPTION
The parameter warnings were being repeated. This PR (along with one in the SDK) takes the warning count from ~750 down to ~275.