### PR TITLE
Log sentry events as debug instead of error

### DIFF
--- a/Riot/Modules/Analytics/SentryMonitoringClient.swift
+++ b/Riot/Modules/Analytics/SentryMonitoringClient.swift
@@ -35,7 +35,7 @@ struct SentryMonitoringClient {
             options.tracesSampleRate = 1.0
             
             options.beforeSend = { event in
-                MXLog.error("[SentryMonitoringClient] Issue detected: \(event)")
+                MXLog.debug("[SentryMonitoringClient] Issue detected: \(event)")
                 return event
             }
 


### PR DESCRIPTION
This is a minor change, related to [error tracking change](https://github.com/matrix-org/matrix-ios-sdk/pull/1517) which also includes the changelog. This hook just informs that an event has been sent to Sentry, not tracking the event itself