### PR TITLE
Input command should not be auto-corrected (#7424)

### DIFF
--- a/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.swift
+++ b/Riot/Modules/Room/Views/InputToolbar/RoomInputToolbarView.swift
@@ -20,8 +20,9 @@ import GBDeviceInfo
 
 extension RoomInputToolbarView {
     open override func sendCurrentMessage() {
-        // Triggers auto-correct if needed.
-        if self.isFirstResponder {
+        // Triggers auto-correct if needed and if it is not a command.
+        let isCommand = self.textMessage.hasPrefix("/")
+        if self.isFirstResponder && !isCommand {
             let temp = UITextField(frame: .zero)
             temp.isHidden = true
             self.addSubview(temp)

--- a/changelog.d/7424.bugfix
+++ b/changelog.d/7424.bugfix
@@ -1,0 +1,1 @@
+Input command should not be auto-corrected


### PR DESCRIPTION
Fix #7424 

### Pull Request Checklist

- [ x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x ] Pull request is based on the develop branch
- [x ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ x] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [ x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

Signed-off-by: Nicolas Buquet <nicolas.buquet@beta.gouv.fr>
