### PR TITLE
Increase max. length of voice message recordings to 5m

### DIFF
--- a/Riot/Modules/Room/VoiceMessages/VoiceMessageController.swift
+++ b/Riot/Modules/Room/VoiceMessages/VoiceMessageController.swift
@@ -27,7 +27,7 @@ import DSWaveformImage
 public class VoiceMessageController: NSObject, VoiceMessageToolbarViewDelegate, VoiceMessageAudioRecorderDelegate, VoiceMessageAudioPlayerDelegate {
     
     private enum Constants {
-        static let maximumAudioRecordingDuration: TimeInterval = 120.0
+        static let maximumAudioRecordingDuration: TimeInterval = 300.0
         static let maximumAudioRecordingLengthReachedThreshold: TimeInterval = 10.0
         static let elapsedTimeFormat = "m:ss"
         static let fileNameDateFormat = "MM.dd.yyyy HH.mm.ss"

--- a/changelog.d/pr-7582.feature
+++ b/changelog.d/pr-7582.feature
@@ -1,0 +1,1 @@
+ Increase max. length of voice message recordings to 5m


### PR DESCRIPTION
I tested this on an iPhone X and the experience felt acceptable. When recording a 5m voice message, it took two or three seconds for it to display in the timeline after pressing the send button. This isn't particularly great UX but struck me as acceptable given that the current limit appears to be quite limiting for parts of our user base (see the discussion in #5415). @jakewb-b curious if you'd be ok with this.