### PR TITLE
Updated `distanceFiler` to be 10m

### DIFF
--- a/Riot/Modules/LocationSharing/LocationManager.swift
+++ b/Riot/Modules/LocationSharing/LocationManager.swift
@@ -1,5 +1,6 @@
 //
-// Copyright 2022-2024 New Vector Ltd.
+// Copyright 2025 Element Creations Ltd.
+// Copyright 2022-2025 New Vector Ltd.
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 // Please see LICENSE files in the repository root for full details.


### PR DESCRIPTION
Updated `distanceFiler` to use 10m.

The reason for this update, is that it allows precise location to actually work within the 10m range, otherwise the location won't update for movements below 200m.