### PR TITLE
Fix broken UI tests.

### DIFF
--- a/RiotSwiftUI/Modules/Settings/ChangePassword/MockChangePasswordScreenState.swift
+++ b/RiotSwiftUI/Modules/Settings/ChangePassword/MockChangePasswordScreenState.swift
@@ -29,18 +29,21 @@ enum MockChangePasswordScreenState: MockScreenState, CaseIterable {
         let viewModel: ChangePasswordViewModel
         switch self {
         case .allEmpty:
-            viewModel = ChangePasswordViewModel()
+            viewModel = ChangePasswordViewModel(passwordRequirements: "The password must contain a 🎪 emoji.")
         case .cannotSubmit:
             viewModel = ChangePasswordViewModel(oldPassword: "12345678",
-                                                newPassword1: "87654321")
+                                                newPassword1: "87654321",
+                                                passwordRequirements: "The password must contain a 🎪 emoji.")
         case .canSubmit:
             viewModel = ChangePasswordViewModel(oldPassword: "12345678",
                                                 newPassword1: "87654321",
-                                                newPassword2: "87654321")
+                                                newPassword2: "87654321",
+                                                passwordRequirements: "The password must contain a 🎪 emoji.")
         case .canSubmitAndSignoutAllDevicesChecked:
             viewModel = ChangePasswordViewModel(oldPassword: "12345678",
                                                 newPassword1: "87654321",
                                                 newPassword2: "87654321",
+                                                passwordRequirements: "The password must contain a 🎪 emoji.",
                                                 signoutAllDevices: true)
         }
         

--- a/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/MockUserOtherSessionsScreenState.swift
+++ b/RiotSwiftUI/Modules/UserSessions/UserOtherSessions/MockUserOtherSessionsScreenState.swift
@@ -44,7 +44,7 @@ enum MockUserOtherSessionsScreenState: MockScreenState, CaseIterable {
                                                    settingsService: MockUserSessionSettings())
         case .none:
             viewModel = UserOtherSessionsViewModel(sessionInfos: [],
-                                                   filter: .all,
+                                                   filter: .verified,
                                                    title: VectorL10n.userSessionsOverviewOtherSessionsSectionTitle,
                                                    showDeviceLogout: true,
                                                    settingsService: MockUserSessionSettings())


### PR DESCRIPTION
The tests have been failing as Xcode now removes `Text("").accessibilityIdentifier(someID)` from the hierarchy but we are asserting `app.staticTexts[someID].exists`. This PR simply makes sure there's some non-empty values.