### PR TITLE
Send full user agent header to server during OIDC authentication and when viewing Account and Device management screens

### DIFF
--- a/Riot/Modules/Authentication/SSO/SSOAuthentificationSession.swift
+++ b/Riot/Modules/Authentication/SSO/SSOAuthentificationSession.swift
@@ -63,14 +63,12 @@ final class SSOAuthentificationSession: SSOAuthentificationSessionProtocol {
             authentificationSession.presentationContextProvider = asWebContextProvider
         }
         
-        if #available(iOS 17.4, *) {
-            if let httpAdditionalHeaders = MXSDKOptions.sharedInstance().httpAdditionalHeaders {
-                if let userAgent = httpAdditionalHeaders["User-Agent"] {
-                    authentificationSession.additionalHeaderFields = [
-                        "X-Element-User-Agent": userAgent
-                    ]
-                }
-            }
+        if #available(iOS 17.4, *),
+           let httpAdditionalHeaders = MXSDKOptions.sharedInstance().httpAdditionalHeaders,
+           let userAgent = httpAdditionalHeaders["User-Agent"] {
+            authentificationSession.additionalHeaderFields = [
+                "X-Element-User-Agent": userAgent
+            ]
         }
         
         authentificationSession.start()


### PR DESCRIPTION
This is the equivalent of https://github.com/element-hq/element-x-ios/pull/4106 but in Element Classic.

It allows the home server account management screens to see the full Element User-Agent even when running inside an ASWebAuthenticationSession.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ ] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
