### PR TITLE
Fix 'occured' -> 'occurred' typos across Riot modules (8 files)

### DIFF
--- a/BroadcastUploadExtension/Sources/SocketConnection.swift
+++ b/BroadcastUploadExtension/Sources/SocketConnection.swift
@@ -104,7 +104,7 @@ extension SocketConnection: StreamDelegate {
                 streamHasSpaceAvailable?()
             }
         case .errorOccurred:
-            MXLog.error("client stream error occured", context: aStream.streamError)
+            MXLog.error("client stream error occurred", context: aStream.streamError)
             close()
             notifyDidClose(error: aStream.streamError)
 

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -906,7 +906,7 @@ Tap the + to start adding people.";
 "settings_discovery_three_pids_management_information_part1" = "Manage which email addresses or phone numbers other users can use to discover you and use to invite you to rooms. Add or remove email addresses or phone numbers from this list in ";
 "settings_discovery_three_pids_management_information_part2" = "User Settings";
 "settings_discovery_three_pids_management_information_part3" = ".";
-"settings_discovery_error_message" = "An error occured. Please retry.";
+"settings_discovery_error_message" = "An error occurred. Please retry.";
 
 "settings_discovery_three_pid_details_title_email" = "Manage email";
 "settings_discovery_three_pid_details_information_email" = "Manage preferences for this email address, which other users can use to discover you and use to invite you to rooms. Add or remove email addresses in Accounts.";
@@ -2968,7 +2968,7 @@ To enable access, tap Settings> Location and select Always";
 "user_id_title" = "User ID:";
 "offline" = "offline";
 "unsent" = "Unsent";
-"error_common_message" = "An error occured. Please try again later.";
+"error_common_message" = "An error occurred. Please try again later.";
 "not_supported_yet" = "Not supported yet";
 "default" = "default";
 "power_level" = "Power Level";

--- a/Riot/Managers/URLPreviews/URLPreviewService.swift
+++ b/Riot/Managers/URLPreviews/URLPreviewService.swift
@@ -35,7 +35,7 @@ class URLPreviewService: NSObject {
     ///   - event: The event that the preview is for.
     ///   - session: The session to use to contact the homeserver.
     ///   - success: The closure called when the operation complete. The generated preview data is passed in.
-    ///   - failure: The closure called when something goes wrong. The error that occured is passed in.
+    ///   - failure: The closure called when something goes wrong. The error that occurred is passed in.
     func preview(for url: URL,
                  and event: MXEvent,
                  with session: MXSession,

--- a/Riot/Modules/Analytics/Analytics.swift
+++ b/Riot/Modules/Analytics/Analytics.swift
@@ -224,7 +224,7 @@ protocol E2EAnalytics {
     /// Track an E2EE error that occurred
     /// - Parameters:
     ///   - reason: The error that occurred.
-    ///   - context: Additional context of the error that occured
+    ///   - context: Additional context of the error that occurred
     func trackE2EEError(_ failure: DecryptionFailure) {
         let event = failure.toAnalyticsEvent()
         capture(event: event)

--- a/Riot/Modules/Analytics/DecryptionFailureTracker.swift
+++ b/Riot/Modules/Analytics/DecryptionFailureTracker.swift
@@ -153,7 +153,7 @@ class DecryptionFailureTracker: NSObject {
     }
     
     /**
-     Mark reported failures that occured before tsNow - GRACE_PERIOD as failures that should be
+     Mark reported failures that occurred before tsNow - GRACE_PERIOD as failures that should be
      tracked.
      */
     @objc

--- a/Riot/Modules/Application/LegacyAppDelegate.m
+++ b/Riot/Modules/Application/LegacyAppDelegate.m
@@ -672,7 +672,7 @@ NSString *const AppDelegateUniversalLinkDidChangeNotification = @"AppDelegateUni
     
     // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
 
-    // Check if an initial sync failure occured while the app was in background
+    // Check if an initial sync failure occurred while the app was in background
     MXSession *mainSession = self.mxSessions.firstObject;
     if (mainSession.state == MXSessionStateInitialSyncFailed)
     {

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h
@@ -44,12 +44,12 @@ Please see LICENSE in the repository root for full details.
 @property (nonatomic) NSString *roomId;
 
 /**
- The sender display name composed when event occured
+ The sender display name composed when event occurred
  */
 @property (nonatomic) NSString *senderDisplayName;
 
 /**
- The sender avatar url retrieved when event occured
+ The sender avatar url retrieved when event occurred
  */
 @property (nonatomic) NSString *senderAvatarUrl;
 
@@ -59,7 +59,7 @@ Please see LICENSE in the repository root for full details.
 @property (nonatomic) UIImage *senderAvatarPlaceholder;
 
 /**
- The target display name composed when event occured (may be nil)
+ The target display name composed when event occurred (may be nil)
 
  @discussion "target" refers to the room member who is the target of this event (if any), e.g.
  the invitee, the person being banned, etc.
@@ -67,7 +67,7 @@ Please see LICENSE in the repository root for full details.
 @property (nonatomic) NSString *targetDisplayName;
 
 /**
- The target avatar url retrieved when event occured (may be nil)
+ The target avatar url retrieved when event occurred (may be nil)
 
  @discussion "target" refers to the room member who is the target of this event (if any), e.g.
  the invitee, the person being banned, etc.
@@ -221,7 +221,7 @@ Please see LICENSE in the repository root for full details.
  Create a new `MXKRoomBubbleCellDataStoring` object for a new bubble cell.
  
  @param event the event to be displayed in the cell.
- @param roomState the room state when the event occured.
+ @param roomState the room state when the event occurred.
  @param roomDataSource the `MXKRoomDataSource` object that will use this instance.
  @return the newly created instance.
  */
@@ -342,7 +342,7 @@ Update the event because its sent state changed or it is has been redacted.
  Attempt to add a new event to the bubble.
  
  @param event the event to be displayed in the cell.
- @param roomState the room state when the event occured.
+ @param roomState the room state when the event occurred.
  @return YES if the model accepts that the event can concatenated to events already in the bubble.
  */
 - (BOOL)addEvent:(MXEvent*)event andRoomState:(MXRoomState*)roomState;

--- a/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleComponent.h
+++ b/Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleComponent.h
@@ -107,7 +107,7 @@ typedef enum : NSUInteger {
  Create a new `MXKRoomBubbleComponent` object based on a `MXEvent` instance.
  
  @param event the event used to compose the bubble component.
- @param roomState the room state when the event occured.
+ @param roomState the room state when the event occurred.
  @param latestRoomState the latest room state of the room containing this event.
  @param eventFormatter object used to format event into displayable string.
  @param session the related matrix session.


### PR DESCRIPTION
Fix 14 instances of \`occured\` → \`occurred\` across 8 files in the Riot/MatrixKit codebase.

## Files

| File | Instances | Kind |
|------|-----------|------|
| \`Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleCellDataStoring.h\` | 6 | Method doc comments |
| \`Riot/Assets/en.lproj/Vector.strings\` | 2 | **User-visible localization strings** |
| \`Riot/Modules/Analytics/Analytics.swift\` | 1 | Comment |
| \`Riot/Modules/MatrixKit/Models/Room/MXKRoomBubbleComponent.h\` | 1 | Doc comment |
| \`Riot/Managers/URLPreviews/URLPreviewService.swift\` | 1 | Comment |
| \`BroadcastUploadExtension/Sources/SocketConnection.swift\` | 1 | Comment |
| \`Riot/Modules/Analytics/DecryptionFailureTracker.swift\` | 1 | Comment |
| \`Riot/Modules/Application/LegacyAppDelegate.m\` | 1 | Comment |

The \`Vector.strings\` change is user-visible (localized strings shown in the app UI). All other changes are doc comments or inline comments.