### PR TITLE
Hook up the Reset flow to Verification when there is no recovery or other devices.

### DIFF
--- a/Riot/Modules/CrossSigning/Setup/CrossSigningSetupCoordinator.swift
+++ b/Riot/Modules/CrossSigning/Setup/CrossSigningSetupCoordinator.swift
@@ -54,7 +54,7 @@ final class CrossSigningSetupCoordinator: CrossSigningSetupCoordinatorType {
     
     // MARK: - Private methods
     
-    private func setupCrossSigning(with authenticationParameters: [String: Any] = [:]) {
+    private func setupCrossSigning(with authenticationParameters: [String: Any] = [:], hasAuthenticated: Bool = false) {
         guard let crossSigning = parameters.session.crypto?.crossSigning else { return }
         
         crossSigning.setup(withAuthParams: authenticationParameters) { [weak self] in
@@ -64,7 +64,8 @@ final class CrossSigningSetupCoordinator: CrossSigningSetupCoordinatorType {
             guard let self else { return }
             
             if let responseData = (error as NSError).userInfo[MXHTTPClientErrorResponseDataKey] as? [AnyHashable: Any],
-               let authenticationSession = MXAuthenticationSession(fromJSON: responseData) {
+               let authenticationSession = MXAuthenticationSession(fromJSON: responseData),
+               !hasAuthenticated { // Don't re-presenting authentication if the user closes the web view without finishing.
                 showReauthentication(authenticationSession: authenticationSession)
             } else {
                 delegate?.crossSigningSetupCoordinator(self, didFailWithError: error)
@@ -93,7 +94,7 @@ final class CrossSigningSetupCoordinator: CrossSigningSetupCoordinatorType {
 extension CrossSigningSetupCoordinator: ReauthenticationCoordinatorDelegate {
         
     func reauthenticationCoordinatorDidComplete(_ coordinator: ReauthenticationCoordinatorType, withAuthenticationParameters authenticationParameters: [String: Any]?) {
-        self.setupCrossSigning(with: authenticationParameters ?? [:])
+        self.setupCrossSigning(with: authenticationParameters ?? [:], hasAuthenticated: true)
     }
     
     func reauthenticationCoordinatorDidCancel(_ coordinator: ReauthenticationCoordinatorType) {

--- a/Riot/Modules/KeyVerification/Common/KeyVerificationCoordinator.swift
+++ b/Riot/Modules/KeyVerification/Common/KeyVerificationCoordinator.swift
@@ -189,6 +189,17 @@ final class KeyVerificationCoordinator: KeyVerificationCoordinatorType {
         return coordinator
     }
     
+    private func showSecretsReset() {
+        let coordinator = SecretsResetCoordinator(session: self.session, isCancellable: false)
+        coordinator.delegate = self
+        coordinator.start()
+
+        self.add(childCoordinator: coordinator)
+        self.navigationRouter.push(coordinator.toPresentable(), animated: true, popCompletion: { [weak self] in
+            self?.remove(childCoordinator: coordinator)
+        })
+    }
+
     private func showSecretsRecovery(with recoveryMode: SecretsRecoveryMode) {
         let coordinator = SecretsRecoveryCoordinator(session: self.session, recoveryMode: recoveryMode, recoveryGoal: .verifyDevice, navigationRouter: self.navigationRouter, cancellable: self.cancellable)
         coordinator.delegate = self
@@ -436,8 +447,12 @@ extension KeyVerificationCoordinator: KeyVerificationSelfVerifyWaitCoordinatorDe
         self.didCancel()
     }
     
-    func keyVerificationSelfVerifyWaitCoordinator(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType, wantsToRecoverSecretsWith secretsRecoveryMode: SecretsRecoveryMode) {        
+    func keyVerificationSelfVerifyWaitCoordinator(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType, wantsToRecoverSecretsWith secretsRecoveryMode: SecretsRecoveryMode) {
         self.showSecretsRecovery(with: secretsRecoveryMode)
+    }
+
+    func keyVerificationSelfVerifyWaitCoordinatorWantsToResetSecrets(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType) {
+        self.showSecretsReset()
     }
 }
 
@@ -464,5 +479,17 @@ extension KeyVerificationCoordinator: SecretsRecoveryCoordinatorDelegate {
     func secretsRecoveryCoordinatorDidCancel(_ coordinator: SecretsRecoveryCoordinatorType) {
         self.remove(childCoordinator: coordinator)
         self.didCancel()
+    }
+}
+
+// MARK: - SecretsResetCoordinatorDelegate
+extension KeyVerificationCoordinator: SecretsResetCoordinatorDelegate {
+
+    func secretsResetCoordinatorDidResetSecrets(_ coordinator: SecretsResetCoordinatorType) {
+        self.showVerified(animated: true)
+    }
+
+    func secretsResetCoordinatorDidCancel(_ coordinator: SecretsResetCoordinatorType) {
+        // Not used, the cancel button is hidden.
     }
 }

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitCoordinator.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitCoordinator.swift
@@ -76,4 +76,8 @@ extension KeyVerificationSelfVerifyWaitCoordinator: KeyVerificationSelfVerifyWai
     func keyVerificationSelfVerifyWaitViewModel(_ coordinator: KeyVerificationSelfVerifyWaitViewModelType, wantsToRecoverSecretsWith secretsRecoveryMode: SecretsRecoveryMode) {
         self.delegate?.keyVerificationSelfVerifyWaitCoordinator(self, wantsToRecoverSecretsWith: secretsRecoveryMode)
     }
+
+    func keyVerificationSelfVerifyWaitViewModelWantsToResetSecrets(_ viewModel: KeyVerificationSelfVerifyWaitViewModelType) {
+        self.delegate?.keyVerificationSelfVerifyWaitCoordinatorWantsToResetSecrets(self)
+    }
 }

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitCoordinatorType.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitCoordinatorType.swift
@@ -23,6 +23,7 @@ protocol KeyVerificationSelfVerifyWaitCoordinatorDelegate: AnyObject {
     func keyVerificationSelfVerifyWaitCoordinator(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType, didAcceptIncomingSASTransaction incomingSASTransaction: MXSASTransaction)
     func keyVerificationSelfVerifyWaitCoordinatorDidCancel(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType)
     func keyVerificationSelfVerifyWaitCoordinator(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType, wantsToRecoverSecretsWith secretsRecoveryMode: SecretsRecoveryMode)
+    func keyVerificationSelfVerifyWaitCoordinatorWantsToResetSecrets(_ coordinator: KeyVerificationSelfVerifyWaitCoordinatorType)
 }
 
 /// `KeyVerificationSelfVerifyWaitCoordinatorType` is a protocol describing a Coordinator that handle key backup setup passphrase navigation flow.

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewAction.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewAction.swift
@@ -23,4 +23,5 @@ enum KeyVerificationSelfVerifyWaitViewAction {
     case loadData
     case cancel
     case recoverSecrets
+    case resetSecrets
 }

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewController.storyboard
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="79A-qb-tmk">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="79A-qb-tmk">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,13 +17,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="asO-rj-82y">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tIM-sl-gwE">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="562"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="652"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IlB-Ch-LEo">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="562"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="652"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open Element on your other device" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="aOD-RJ-1qU">
                                                         <rect key="frame" x="20" y="20" width="335" height="67"/>
@@ -73,7 +73,7 @@ Open Element on one of your other devices and follow the instructions.</string>
                                                         </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="8oJ-o6-DLK">
-                                                        <rect key="frame" x="20" y="329" width="335" height="233"/>
+                                                        <rect key="frame" x="20" y="329" width="335" height="323"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dXT-cL-ukJ">
                                                                 <rect key="frame" x="0.0" y="0.0" width="335" height="114.5"/>
@@ -131,6 +131,35 @@ Open Element on one of your other devices and follow the instructions.</string>
                                                                     <constraint firstItem="OEt-k0-vgM" firstAttribute="leading" secondItem="nf8-Ye-b9r" secondAttribute="leading" id="loc-cf-E6p"/>
                                                                     <constraint firstItem="4Ou-cM-K9C" firstAttribute="leading" secondItem="nf8-Ye-b9r" secondAttribute="leading" constant="20" id="o3E-Q9-7h1"/>
                                                                     <constraint firstAttribute="trailing" secondItem="OEt-k0-vgM" secondAttribute="trailing" id="yQK-YS-7Yr"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MZS-LD-c5M">
+                                                                <rect key="frame" x="0.0" y="233" width="335" height="90"/>
+                                                                <subviews>
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dgm-0y-4Zm">
+                                                                        <rect key="frame" x="20" y="20" width="295" height="50"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="50" id="gMu-pN-Qn2"/>
+                                                                        </constraints>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                        <inset key="contentEdgeInsets" minX="20" minY="0.0" maxX="20" maxY="0.0"/>
+                                                                        <state key="normal" title="Forgot or lost all recovery options? Reset everything">
+                                                                            <color key="titleColor" systemColor="darkTextColor"/>
+                                                                        </state>
+                                                                        <state key="disabled">
+                                                                            <color key="titleColor" red="0.47843137250000001" green="0.78823529410000004" blue="0.63137254899999995" alpha="0.5" colorSpace="calibratedRGB"/>
+                                                                        </state>
+                                                                        <connections>
+                                                                            <action selector="resetSecretsButtonAction:" destination="79A-qb-tmk" eventType="touchUpInside" id="z9Y-Vc-Qv6"/>
+                                                                        </connections>
+                                                                    </button>
+                                                                </subviews>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="bottom" secondItem="dgm-0y-4Zm" secondAttribute="bottom" constant="20" symbolic="YES" id="0RW-EA-zD8"/>
+                                                                    <constraint firstItem="dgm-0y-4Zm" firstAttribute="leading" secondItem="MZS-LD-c5M" secondAttribute="leading" constant="20" symbolic="YES" id="IlA-bw-Ge3"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="dgm-0y-4Zm" secondAttribute="trailing" constant="20" symbolic="YES" id="bXE-8Z-xlt"/>
+                                                                    <constraint firstItem="dgm-0y-4Zm" firstAttribute="top" secondItem="MZS-LD-c5M" secondAttribute="top" constant="20" symbolic="YES" id="n0t-Px-2Gw"/>
                                                                 </constraints>
                                                             </view>
                                                         </subviews>
@@ -197,6 +226,8 @@ Open Element on one of your other devices and follow the instructions.</string>
                         <outlet property="recoverSecretsAvailabilityLoadingLabel" destination="A4x-sK-d5C" id="n5k-IO-RkV"/>
                         <outlet property="recoverSecretsButton" destination="OEt-k0-vgM" id="RHU-ps-4m7"/>
                         <outlet property="recoverSecretsContainerView" destination="nf8-Ye-b9r" id="4az-pe-0Uc"/>
+                        <outlet property="resetSecretsButton" destination="dgm-0y-4Zm" id="5di-fv-zHX"/>
+                        <outlet property="resetSecretsContainerView" destination="MZS-LD-c5M" id="V59-pG-iMb"/>
                         <outlet property="titleLabel" destination="aOD-RJ-1qU" id="qvC-fk-TiU"/>
                     </connections>
                 </viewController>
@@ -208,5 +239,8 @@ Open Element on one of your other devices and follow the instructions.</string>
     <resources>
         <image name="monitor" width="48" height="48"/>
         <image name="smartphone" width="48" height="48"/>
+        <systemColor name="darkTextColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewController.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewController.swift
@@ -43,6 +43,9 @@ final class KeyVerificationSelfVerifyWaitViewController: UIViewController {
     @IBOutlet private weak var recoverSecretsButton: RoundedButton!
     @IBOutlet private weak var recoverSecretsAdditionalInformationLabel: UILabel!
     
+    @IBOutlet private weak var resetSecretsContainerView: UIView!
+    @IBOutlet private weak var resetSecretsButton: UIButton!
+    
     // MARK: Private
 
     private var viewModel: KeyVerificationSelfVerifyWaitViewModelType!
@@ -101,6 +104,13 @@ final class KeyVerificationSelfVerifyWaitViewController: UIViewController {
         self.mobileClientImageView.tintColor = theme.tintColor
         self.recoverSecretsAvailabilityLoadingLabel.textColor = theme.textSecondaryColor
         self.recoverSecretsAvailabilityActivityIndicatorView.color = theme.tintColor
+        
+        // Reset secrets button
+        let resetSecretsAttributedString = NSMutableAttributedString(string: VectorL10n.secretsRecoveryResetActionPart1,
+                                                                     attributes: [.foregroundColor: self.theme.textPrimaryColor])
+        resetSecretsAttributedString.append(NSAttributedString(string: VectorL10n.secretsRecoveryResetActionPart2,
+                                                               attributes: [.foregroundColor: self.theme.warningColor]))
+        self.resetSecretsButton.setAttributedTitle(resetSecretsAttributedString, for: .normal)
     }
     
     private func registerThemeServiceDidChangeThemeNotification() {
@@ -121,6 +131,9 @@ final class KeyVerificationSelfVerifyWaitViewController: UIViewController {
 
             self.navigationItem.rightBarButtonItem = cancelBarButtonItem
             self.cancelBarButtonItem = cancelBarButtonItem
+            
+            self.resetSecretsButton.vc_enableMultiLinesTitle()
+            self.resetSecretsButton.isHidden = !RiotSettings.shared.secretsRecoveryAllowReset
         }
         
         self.titleLabel.text = VectorL10n.deviceVerificationSelfVerifyOpenOnOtherDeviceTitle(AppInfo.current.displayName)
@@ -158,22 +171,26 @@ final class KeyVerificationSelfVerifyWaitViewController: UIViewController {
         self.recoverSecretsAvailabilityActivityIndicatorView.startAnimating()
         self.recoverSecretsAvailabilityLoadingContainerView.isHidden = false
         self.recoverSecretsContainerView.isHidden = true
+        self.resetSecretsContainerView.isHidden = true
     }
     
     private func renderLoaded(viewData: KeyVerificationSelfVerifyWaitViewData) {
         self.activityPresenter.removeCurrentActivityIndicator(animated: true)
         
         self.cancelBarButtonItem?.title = viewData.isNewSignIn ? VectorL10n.skip : VectorL10n.cancel
-   
+        
         let hideRecoverSecrets: Bool
+        let hideResetSecrets: Bool
         let recoverSecretsButtonTitle: String?
         
         switch viewData.secretsRecoveryAvailability {
         case .notAvailable:
             hideRecoverSecrets = true
+            hideResetSecrets = false
             recoverSecretsButtonTitle = nil
         case .available(let secretsRecoveryMode):
             hideRecoverSecrets = false
+            hideResetSecrets = true
             
             switch secretsRecoveryMode {
             case .passphraseOrKey:
@@ -187,6 +204,8 @@ final class KeyVerificationSelfVerifyWaitViewController: UIViewController {
         self.recoverSecretsAvailabilityActivityIndicatorView.stopAnimating()
         self.recoverSecretsContainerView.isHidden = hideRecoverSecrets
         self.recoverSecretsButton.setTitle(recoverSecretsButtonTitle, for: .normal)
+        
+        self.resetSecretsContainerView.isHidden = hideResetSecrets
     }
     
     private func renderCancelled(reason: MXTransactionCancelCode) {
@@ -222,6 +241,10 @@ final class KeyVerificationSelfVerifyWaitViewController: UIViewController {
     
     @IBAction private func recoverSecretsButtonAction(_ sender: Any) {
         self.viewModel.process(viewAction: .recoverSecrets)
+    }
+    
+    @IBAction private func resetSecretsButtonAction(_ sender: Any) {
+        self.viewModel.process(viewAction: .resetSecrets)
     }
 }
 

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModel.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModel.swift
@@ -80,6 +80,8 @@ final class KeyVerificationSelfVerifyWaitViewModel: KeyVerificationSelfVerifyWai
             case .available(let secretsRecoveryMode):
                 self.coordinatorDelegate?.keyVerificationSelfVerifyWaitViewModel(self, wantsToRecoverSecretsWith: secretsRecoveryMode)
             }
+        case .resetSecrets:
+            self.coordinatorDelegate?.keyVerificationSelfVerifyWaitViewModelWantsToResetSecrets(self)
         }
     }
     

--- a/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModelType.swift
+++ b/Riot/Modules/KeyVerification/Device/SelfVerifyWait/KeyVerificationSelfVerifyWaitViewModelType.swift
@@ -27,6 +27,7 @@ protocol KeyVerificationSelfVerifyWaitViewModelCoordinatorDelegate: AnyObject {
     func keyVerificationSelfVerifyWaitViewModel(_ viewModel: KeyVerificationSelfVerifyWaitViewModelType, didAcceptIncomingSASTransaction incomingSASTransaction: MXSASTransaction)
     func keyVerificationSelfVerifyWaitViewModelDidCancel(_ viewModel: KeyVerificationSelfVerifyWaitViewModelType)
     func keyVerificationSelfVerifyWaitViewModel(_ viewModel: KeyVerificationSelfVerifyWaitViewModelType, wantsToRecoverSecretsWith secretsRecoveryMode: SecretsRecoveryMode)
+    func keyVerificationSelfVerifyWaitViewModelWantsToResetSecrets(_ viewModel: KeyVerificationSelfVerifyWaitViewModelType)
 }
 
 /// Protocol describing the view model used by `KeyVerificationSelfVerifyWaitViewController`

--- a/Riot/Modules/Reauthentication/ReauthenticationCoordinator.swift
+++ b/Riot/Modules/Reauthentication/ReauthenticationCoordinator.swift
@@ -38,6 +38,8 @@ final class ReauthenticationCoordinator: ReauthenticationCoordinatorType {
     
     private var authenticationSession: SSOAuthentificationSessionProtocol?
     
+    private weak var presentedNavigationController: UINavigationController?
+    
     private var presentingViewController: UIViewController {
         return self.parameters.presenter.toPresentable()
     }
@@ -58,7 +60,7 @@ final class ReauthenticationCoordinator: ReauthenticationCoordinatorType {
         self.userInteractiveAuthenticationService = UserInteractiveAuthenticationService(session: parameters.session)
         self.authenticationParametersBuilder = AuthenticationParametersBuilder()
         self.uiaViewControllerFactory = UserInteractiveAuthenticationViewControllerFactory()
-    }    
+    }
     
     // MARK: - Public methods
     
@@ -143,28 +145,34 @@ final class ReauthenticationCoordinator: ReauthenticationCoordinatorType {
         reauthFallbackViewController.title = self.parameters.title
                 
         reauthFallbackViewController.didCancel = { [weak self] in
-            guard let self = self else {
-                return
-            }
+            guard let self = self else { return }
+            
+            self.dismissFallbackAuthentication()
             self.delegate?.reauthenticationCoordinatorDidCancel(self)
         }
         
         reauthFallbackViewController.didValidate = { [weak self] in
-            guard let self = self else {
-                return
-            }
+            guard let self = self else { return }
             
             guard let sessionId = authenticationSession.session else {
+                self.dismissFallbackAuthentication()
                 self.delegate?.reauthenticationCoordinator(self, didFailWithError: ReauthenticationCoordinatorError.failToBuildPasswordParameters)
                 return
             }
             
             let authenticationParameters = self.authenticationParametersBuilder.buildOAuthParameters(with: sessionId)
+            self.dismissFallbackAuthentication()
             self.delegate?.reauthenticationCoordinatorDidComplete(self, withAuthenticationParameters: authenticationParameters)
         }
         
         let navigationController = RiotNavigationController(rootViewController: reauthFallbackViewController)
+        self.presentedNavigationController = navigationController
         
         self.presentingViewController.present(navigationController, animated: true)
+    }
+    
+    private func dismissFallbackAuthentication() {
+        presentedNavigationController?.dismiss(animated: true)
+        presentedNavigationController = nil
     }
 }

--- a/Riot/Modules/Reauthentication/ReauthenticationCoordinatorBridgePresenter.swift
+++ b/Riot/Modules/Reauthentication/ReauthenticationCoordinatorBridgePresenter.swift
@@ -37,6 +37,9 @@ final class ReauthenticationCoordinatorBridgePresenter: NSObject {
     // MARK: Private
         
     private var coordinator: ReauthenticationCoordinator?
+    /// Re-authentication dismisses itself automatically, so make sure that the dismiss function
+    /// only takes effect when dismissing an ongoing re-authentication rather than a completed one.
+    private var hasDismissed: Bool = false
     
     // MARK: Public
     
@@ -55,6 +58,7 @@ final class ReauthenticationCoordinatorBridgePresenter: NSObject {
         self.didComplete = success
         self.didCancel = cancel
         self.didFail = failure
+        self.hasDismissed = false
         
         let coordinator = ReauthenticationCoordinator(parameters: parameters)
         coordinator.delegate = self
@@ -69,12 +73,16 @@ final class ReauthenticationCoordinatorBridgePresenter: NSObject {
         guard let coordinator = self.coordinator else {
             return
         }
+        
+        guard !hasDismissed else {
+            self.coordinator = nil
+            completion?()
+            return
+        }
+        
         coordinator.toPresentable().dismiss(animated: animated) {
             self.coordinator = nil
-
-            if let completion = completion {
-                completion()
-            }
+            completion?()
         }
     }
     
@@ -90,14 +98,17 @@ final class ReauthenticationCoordinatorBridgePresenter: NSObject {
 // MARK: - ReauthenticationCoordinatorDelegate
 extension ReauthenticationCoordinatorBridgePresenter: ReauthenticationCoordinatorDelegate {
     func reauthenticationCoordinatorDidComplete(_ coordinator: ReauthenticationCoordinatorType, withAuthenticationParameters authenticationParameters: [String: Any]?) {
+        self.hasDismissed = true
         self.didComplete?(authenticationParameters)
     }
     
     func reauthenticationCoordinatorDidCancel(_ coordinator: ReauthenticationCoordinatorType) {
+        self.hasDismissed = true
         self.didCancel?()
     }
     
     func reauthenticationCoordinator(_ coordinator: ReauthenticationCoordinatorType, didFailWithError error: Error) {
+        self.hasDismissed = true
         self.didFail?(error)
     }
 }

--- a/Riot/Modules/Secrets/Reset/SecretsResetCoordinator.swift
+++ b/Riot/Modules/Secrets/Reset/SecretsResetCoordinator.swift
@@ -38,11 +38,11 @@ final class SecretsResetCoordinator: SecretsResetCoordinatorType {
     
     // MARK: - Setup
     
-    init(session: MXSession) {
+    init(session: MXSession, isCancellable: Bool = true) {
         self.session = session
         
         let secretsResetViewModel = SecretsResetViewModel(session: self.session)
-        let secretsResetViewController = SecretsResetViewController.instantiate(with: secretsResetViewModel)
+        let secretsResetViewController = SecretsResetViewController.instantiate(with: secretsResetViewModel, isCancellable: isCancellable)
         self.secretsResetViewModel = secretsResetViewModel
         self.secretsResetViewController = secretsResetViewController
     }
@@ -59,13 +59,13 @@ final class SecretsResetCoordinator: SecretsResetCoordinatorType {
     
     // MARK: - Private
     
-    private func showAuthentication(with request: AuthenticatedEndpointRequest) {
+    private func showReauthentication(for session: MXAuthenticationSession) {
         
         let reauthenticationCoordinatorParameters =  ReauthenticationCoordinatorParameters(session: self.session,
                                                                                            presenter: self.toPresentable(),
                                                                                            title: nil,
                                                                                            message: VectorL10n.secretsResetAuthenticationMessage,
-                                                                                           authenticatedEndpointRequest: request)
+                                                                                           authenticationSession: session)
         
         let coordinator = ReauthenticationCoordinator(parameters: reauthenticationCoordinatorParameters)
         coordinator.delegate = self
@@ -77,8 +77,8 @@ final class SecretsResetCoordinator: SecretsResetCoordinatorType {
 // MARK: - SecretsResetViewModelCoordinatorDelegate
 extension SecretsResetCoordinator: SecretsResetViewModelCoordinatorDelegate {
     
-    func secretsResetViewModel(_ viewModel: SecretsResetViewModelType, needsToAuthenticateWith request: AuthenticatedEndpointRequest) {
-        self.showAuthentication(with: request)
+    func secretsResetViewModel(_ viewModel: SecretsResetViewModelType, needsToAuthenticateFor session: MXAuthenticationSession) {
+        self.showReauthentication(for: session)
     }
     
     func secretsResetViewModelDidResetSecrets(_ viewModel: SecretsResetViewModelType) {

--- a/Riot/Modules/Secrets/Reset/SecretsResetViewController.swift
+++ b/Riot/Modules/Secrets/Reset/SecretsResetViewController.swift
@@ -40,15 +40,17 @@ final class SecretsResetViewController: UIViewController {
     // MARK: Private
 
     private var viewModel: SecretsResetViewModelType!
+    private var isCancellable = true
     private var theme: Theme!
     private var errorPresenter: MXKErrorPresentation!
     private var activityPresenter: ActivityIndicatorPresenter!
     
     // MARK: - Setup
     
-    class func instantiate(with viewModel: SecretsResetViewModelType) -> SecretsResetViewController {
+    class func instantiate(with viewModel: SecretsResetViewModelType, isCancellable: Bool = true) -> SecretsResetViewController {
         let viewController = StoryboardScene.SecretsResetViewController.initialScene.instantiate()
         viewController.viewModel = viewModel
+        viewController.isCancellable = isCancellable
         viewController.theme = ThemeService.shared().theme
         return viewController
     }
@@ -108,11 +110,12 @@ final class SecretsResetViewController: UIViewController {
     }
     
     private func setupViews() {
-        let cancelBarButtonItem = MXKBarButtonItem(title: VectorL10n.cancel, style: .plain) { [weak self] in
-            self?.cancelButtonAction()
+        if isCancellable {
+            let cancelBarButtonItem = MXKBarButtonItem(title: VectorL10n.cancel, style: .plain) { [weak self] in
+                self?.cancelButtonAction()
+            }
+            self.navigationItem.rightBarButtonItem = cancelBarButtonItem
         }
-        
-        self.navigationItem.rightBarButtonItem = cancelBarButtonItem
         
         self.title = VectorL10n.secretsResetTitle
         

--- a/Riot/Modules/Secrets/Reset/SecretsResetViewModel.swift
+++ b/Riot/Modules/Secrets/Reset/SecretsResetViewModel.swift
@@ -48,11 +48,11 @@ final class SecretsResetViewModel: SecretsResetViewModelType {
         case .loadData:
             break
         case .reset:
-            self.askAuthentication()
+            self.resetSecrets()
         case .authenticationCancelled:
             self.authenticationCancelled()
         case .authenticationInfoEntered(let authParameters):
-            self.resetSecrets(with: authParameters)
+            self.resetSecrets(with: authParameters, hasAuthenticated: true)
         case .cancel:
             self.coordinatorDelegate?.secretsResetViewModelDidCancel(self)
         }
@@ -64,43 +64,42 @@ final class SecretsResetViewModel: SecretsResetViewModelType {
         self.viewDelegate?.secretsResetViewModel(self, didUpdateViewState: viewState)
     }
     
-    private func resetSecrets(with authParameters: [String: Any]) {
-        guard let crossSigning = self.session.crypto?.crossSigning else {
-            return
-        }
+    private func resetSecrets(with authParameters: [String: Any] = [:], hasAuthenticated: Bool = false) {
+        guard let crossSigning = self.session.crypto?.crossSigning else { return }
+        
         MXLog.debug("[SecretsResetViewModel] resetSecrets")
+        self.update(viewState: .resetting)
 
-        crossSigning.setup(withAuthParams: authParameters, success: { [weak self] in
-            guard let self = self else {
-                return
-            }
-            self.recoveryService.deleteRecovery(withDeleteServicesBackups: true, success: { [weak self] in
-                guard let self = self else {
-                    return
-                }
+        crossSigning.setup(withAuthParams: authParameters) { [weak self] in
+            guard let self else { return }
+            
+            self.recoveryService.deleteRecovery(withDeleteServicesBackups: true) { [weak self] in
+                guard let self else { return }
+                
                 self.update(viewState: .resetDone)
                 self.coordinatorDelegate?.secretsResetViewModelDidResetSecrets(self)
 
-            }, failure: { [weak self] error in
-                guard let self = self else {
-                    return
-                }
+            } failure: { [weak self] error in
+                guard let self else { return }
                 self.update(viewState: .error(error))
-            })
-
-        }, failure: { [weak self] error in
-            guard let self = self else {
-                return
             }
-            self.update(viewState: .error(error))
-        })
+
+        } failure: { [weak self] error in
+            guard let self else { return }
+            
+            if let responseData = (error as NSError).userInfo[MXHTTPClientErrorResponseDataKey] as? [AnyHashable: Any],
+               let authenticationSession = MXAuthenticationSession(fromJSON: responseData),
+               !hasAuthenticated { // Don't re-presenting authentication if the user closes the web view without finishing.
+                askAuthentication(session: authenticationSession)
+            } else {
+                self.update(viewState: .error(error))
+            }
+        }
     }
     
-    private func askAuthentication() {
-        self.update(viewState: .resetting)
-
+    private func askAuthentication(session: MXAuthenticationSession) {
         let setupCrossSigningRequest = self.crossSigningService.setupCrossSigningRequest()
-        self.coordinatorDelegate?.secretsResetViewModel(self, needsToAuthenticateWith: setupCrossSigningRequest)
+        self.coordinatorDelegate?.secretsResetViewModel(self, needsToAuthenticateFor: session)
     }
     
     private func authenticationCancelled() {

--- a/Riot/Modules/Secrets/Reset/SecretsResetViewModelType.swift
+++ b/Riot/Modules/Secrets/Reset/SecretsResetViewModelType.swift
@@ -23,7 +23,7 @@ protocol SecretsResetViewModelViewDelegate: AnyObject {
 }
 
 protocol SecretsResetViewModelCoordinatorDelegate: AnyObject {
-    func secretsResetViewModel(_ viewModel: SecretsResetViewModelType, needsToAuthenticateWith request: AuthenticatedEndpointRequest)
+    func secretsResetViewModel(_ viewModel: SecretsResetViewModelType, needsToAuthenticateFor session: MXAuthenticationSession)
     func secretsResetViewModelDidResetSecrets(_ viewModel: SecretsResetViewModelType)
     func secretsResetViewModelDidCancel(_ viewModel: SecretsResetViewModelType)
 }

--- a/changelog.d/8024.bugfix
+++ b/changelog.d/8024.bugfix
@@ -1,0 +1,1 @@
+Hook up the Reset flow to Verification when there is no recovery or other devices.


### PR DESCRIPTION
This PR makes the following changes:

- Show a Reset button on `KeyVerificationSelfVerifyWaitViewController` when verifying your own device and there isn't any other devices, nor a recovery set up. This button comes straight from `SecretsRecoveryWithPassphraseViewController` so matches the style used elsewhere in the app. Fixes the [blank view](https://github.com/element-hq/element-meta/issues/3194#issuecomment-4163047829) issue.
- Fix the presentation of re-authentication from `SecretsResetViewModel` in the same way that [#7874](https://github.com/element-hq/element-ios/pull/7874) was implemented. Fixes #7921.
- Fix a bug from [#7874](https://github.com/element-hq/element-ios/pull/7874) where tapping the web view's close button would just re-present authentication over and over.

Additionally I've made a change to re-authentication presentation in a second commit as the user had to swipe the MAS screen away (the close button didn't work).
- Fix ReauthenticationCoordinator not dismissing the fallback view controller automatically: The password's UI alert controller does this automatically, so it makes sense to do the same with the fallback controller. I've added some guards on the bridge presenter to make sure that dismiss only works when something is presented as a safety measure.

Video of this in action when used on top of #8023

https://github.com/user-attachments/assets/379bcc9c-9ebf-467d-80bf-833ff5d434fd
