### PR TITLE
Update the SDK (with a Crypto SDK update).

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,13 +44,13 @@ PODS:
     - AFNetworking (~> 4.0.0)
     - GZIP (~> 1.3.0)
     - libbase58 (~> 0.1.4)
-    - MatrixSDKCrypto (= 0.11.1)
+    - MatrixSDKCrypto (= 0.17.0)
     - Realm (= 10.27.0)
     - SwiftyBeaver (= 1.9.5)
   - MatrixSDK/JingleCallStack (0.27.18):
     - JitsiMeetSDKLite (= 12.0.0-lite)
     - MatrixSDK/Core
-  - MatrixSDKCrypto (0.11.1)
+  - MatrixSDKCrypto (0.17.0)
   - ReadMoreTextView (3.0.1)
   - Realm (10.27.0):
     - Realm/Headers (= 10.27.0)
@@ -176,8 +176,8 @@ SPEC CHECKSUMS:
   libPhoneNumber-iOS: 0a32a9525cf8744fe02c5206eb30d571e38f7d75
   LoggerAPI: ad9c4a6f1e32f518fdb43a1347ac14d765ab5e3d
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MatrixSDK: c2ee6ae269e0fe57b06d824530481fcb879265f7
-  MatrixSDKCrypto: e44608012cae9befc52f13cd8e56c6f51ac83702
+  MatrixSDK: fdccd88405ec9e9f8e9978091bc0ac67cf396542
+  MatrixSDKCrypto: aa38e272e573c7798aa3cd761b2b61ec5c7731b8
   ReadMoreTextView: 19147adf93abce6d7271e14031a00303fe28720d
   Realm: 9ca328bd7e700cc19703799785e37f77d1a130f2
   Reusable: 6bae6a5e8aa793c9c441db0213c863a64bce9136

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -9367,7 +9367,7 @@ public class VectorL10n: NSObject {
   public static func userVerificationStartWaitingPartner(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "user_verification_start_waiting_partner", p1)
   }
-  /// As of April 2026 unverified devices will not be able to send and receive messages
+  /// As of October 2026 unverified devices will not be able to send and receive messages
   public static var verificationRequiredBannerDescription: String { 
     return VectorL10n.tr("Vector", "verification_required_banner_description") 
   }


### PR DESCRIPTION
Updates the SDK to include https://github.com/matrix-org/matrix-ios-sdk/pull/1928 which bumps the Crypto SDK to 0.17.0.